### PR TITLE
docs: add agent-facing documentation system

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,80 @@
+# Claude Instructions — weaver-spec
+
+Read `AGENTS.md` at the repo root for the full shared instruction set.
+This file adds Claude-specific operating behavior only.
+
+---
+
+## Critical rules (projected from AGENTS.md)
+
+- This repo is **docs + contracts only**. Never add runtime logic, CLI tools, or helper utilities.
+- **Authority hierarchy:** `docs/INVARIANTS.md` → `docs/BOUNDARIES.md` → `docs/ARCHITECTURE.md` → everything else.
+- **Every Core contract change must update all six artifacts in the same PR:** JSON schema, Python dataclass, sample payload, roundtrip test, CHANGELOG, version bump.
+- **Core contract changes affect sibling repos** (contextweaver, agent-kernel, ChainWeaver). Flag cross-repo impact in the PR description.
+
+---
+
+## Before acting
+
+1. Read `AGENTS.md` for rules, repo map, and authority hierarchy.
+2. Read the relevant supporting doc under `docs/agent-context/` for the area of your change (workflows, invariants, lessons learned, review checklist). For architecture and boundary context, consult `docs/ARCHITECTURE.md` and `docs/BOUNDARIES.md` directly.
+3. Inspect the files you will modify — verify current structure before assuming patterns.
+4. If working in `contracts/json/`, `contracts/python/`, or `docs/`, check the corresponding `.github/instructions/*.instructions.md` file for path-specific rules.
+5. Do not infer repo-wide conventions from a single file. Verify against canonical docs.
+
+---
+
+## Safe implementation
+
+- Preserve invariants I-01 through I-07 (`docs/INVARIANTS.md`). These override cleanup, simplification, or refactoring goals.
+- Do not invent conventions. Use workflows, commands, and commit prefixes from `AGENTS.md` and `CONTRIBUTING.md`.
+- Do not merge or collapse contract types without understanding the architectural reason for their separation. Consult `docs/ARCHITECTURE.md` and `docs/BOUNDARIES.md`, and check the "Design decisions not to reopen" section in `AGENTS.md`.
+- Treat scoped rules (`.github/instructions/*.instructions.md`) as mandatory within their declared scope.
+
+---
+
+## Validation before completion
+
+Before proposing that work is done:
+
+1. Verify all required artifacts are updated (see definition of done in `AGENTS.md`).
+2. Run the local validation commands from `AGENTS.md`: pytest, JSON schema validation, markdownlint.
+3. Check whether the change triggers doc updates — consult the governance table in `docs/agent-context/workflows.md`.
+4. Check cross-file consistency: Python fields match JSON schema, sample payloads validate, tests cover changed fields.
+5. For Core contract changes, draft the cross-repo impact section for the PR description.
+
+---
+
+## Handling contradictions
+
+- If canonical docs contradict each other, follow the authority hierarchy: `INVARIANTS.md` → `BOUNDARIES.md` → `ARCHITECTURE.md` → rest.
+- If code contradicts canonical docs, flag the discrepancy. Do not silently follow the code.
+- If a Claude-specific rule contradicts canonical shared docs, canonical docs win. Flag the inconsistency for cleanup.
+- If you encounter stale, ambiguous, or conflicting guidance, surface it explicitly — do not silently choose one interpretation.
+- When genuinely uncertain after checking all sources, prefer the safer, more conservative option and note the ambiguity.
+
+---
+
+## Lessons learned — capture and promotion
+
+When you encounter a failure pattern or discover a non-obvious constraint during work:
+
+1. **Assess reusability.** Could this pattern recur across different files or contexts? If not, it is a one-off fix — do not promote it.
+2. **Generalize.** Extract the underlying pattern, not the specific instance.
+3. **Decide placement:**
+   - If the lesson is shared and durable → it belongs in canonical docs (`docs/agent-context/lessons-learned.md` or `invariants.md`). Update canonical docs first.
+   - If the lesson is Claude-specific operating behavior → it could belong in this file. But verify it is truly Claude-specific.
+   - If the lesson is too fresh or narrow → note it in your working context but do not promote it into durable guidance yet.
+4. **Promotion order:** Canonical docs first, Claude-specific files second. Never add durable shared knowledge only to Claude files.
+5. **Do not promote prematurely.** A single occurrence is an observation. A recurring pattern with reusable prevention guidance is a lesson.
+
+See `docs/agent-context/lessons-learned.md` for the full failure-capture workflow and promotion chain.
+
+---
+
+## Update order
+
+1. Shared durable knowledge → update canonical docs (`AGENTS.md`, `docs/agent-context/*`) first.
+2. Claude-specific behavior → update this file second.
+3. If a rule in this file becomes shared and durable, promote it to canonical docs and reduce or remove it here.
+4. Do not let Claude-specific files become a shadow copy of canonical docs.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,31 @@
+# Copilot Instructions — weaver-spec
+
+## Review priorities (in order)
+
+1. **All required artifacts present in same PR.** Core contract changes must update: JSON schema, Python dataclass, sample payload, roundtrip test, CHANGELOG, version bump (`version.py` + `pyproject.toml`). Missing any artifact fails review.
+2. **Invariants hold.** Verify I-01 through I-07 in `docs/INVARIANTS.md` are not violated.
+3. **Boundaries respected.** Check the artifact ownership table in `docs/BOUNDARIES.md` for changes affecting data flow between layers.
+
+## Critical rules
+
+- This repo is **docs + contracts only**. Never add runtime logic, CLI tools, or helper utilities.
+- JSON schemas are the source of truth. Python types must mirror them exactly — same fields, types, required/optional status.
+- Core contract changes affect sibling repos (contextweaver, agent-kernel, ChainWeaver). The PR description must flag cross-repo impact.
+- Breaking Core changes require the ADR process (`CONTRIBUTING.md`), not a direct PR.
+
+## Authority hierarchy
+
+When documents conflict: `docs/INVARIANTS.md` → `docs/BOUNDARIES.md` → `docs/ARCHITECTURE.md` → everything else.
+
+## Review expectations
+
+- Review code changes and agent-facing docs together when one affects the other.
+- PRs that change workflows, invariants, architecture intent, review conventions, or path-specific rules must trigger doc review.
+- Do not invent conventions not grounded in canonical docs or repository evidence.
+- Use the validation commands from `AGENTS.md` and `CONTRIBUTING.md` — do not substitute alternatives.
+- Surface contradictions or stale docs explicitly. Do not silently work around authority conflicts.
+- Invariants take priority over cleanup, simplification, or local refactors.
+
+## Deeper context
+
+See `AGENTS.md` for the full shared instruction set, repo map, definition of done, validation commands, and documentation map. Path-specific rules are in `.github/instructions/`.

--- a/.github/instructions/contracts-json.instructions.md
+++ b/.github/instructions/contracts-json.instructions.md
@@ -1,0 +1,23 @@
+---
+applyTo: "contracts/json/**"
+---
+
+# JSON Schema Instructions
+
+## Conventions
+
+- Use JSON Schema Draft 2020-12.
+- Every schema must include `$id`, `title`, `description`, and set `additionalProperties: true`.
+- `$id` URIs follow the pattern `https://weaver-spec.dev/contracts/v{MAJOR}/name.schema.json` — this is a namespace, not a live URL.
+- Cross-schema references (`$ref`) use full `$id` URIs, not relative paths.
+- `contracts/json/README.md` is the authoritative source for schema design conventions.
+
+## Review cautions
+
+- **Description must not contradict structural constraints.** Do not say a field is "required" in a `description` if it is not in the `required` array. Do not claim extensibility ("additional values may be used") for a field with an `enum` constraint.
+- **Never weaken a constraint** (remove `minLength`, loosen an `enum`, drop a `required` entry) without an ADR. Weakening is always a breaking change.
+- Every new schema must have a corresponding sample payload in `examples/sample_payloads/`.
+
+## Change scope
+
+A schema change is never standalone. The same PR must also update the Python dataclass, sample payload, roundtrip test, CHANGELOG, and version. See `AGENTS.md` for the full six-artifact rule.

--- a/.github/instructions/contracts-json.instructions.md
+++ b/.github/instructions/contracts-json.instructions.md
@@ -15,7 +15,7 @@ applyTo: "contracts/json/**"
 ## Review cautions
 
 - **Description must not contradict structural constraints.** Do not say a field is "required" in a `description` if it is not in the `required` array. Do not claim extensibility ("additional values may be used") for a field with an `enum` constraint.
-- **Never weaken a constraint** (remove `minLength`, loosen an `enum`, drop a `required` entry) without an ADR. Weakening is always a breaking change.
+- **Never weaken a constraint** (remove `minLength`, loosen an `enum`, drop a `required` entry) without an ADR. Constraint loosening affects consumers even when existing payloads remain valid.
 - Every new schema must have a corresponding sample payload in `examples/sample_payloads/`.
 
 ## Change scope

--- a/.github/instructions/contracts-python.instructions.md
+++ b/.github/instructions/contracts-python.instructions.md
@@ -1,0 +1,16 @@
+---
+applyTo: "contracts/python/**"
+---
+
+# Python Contract Instructions
+
+## Constraints
+
+- Use stdlib only (`dataclasses`, `typing`). No third-party runtime dependencies in `core.py` or `extended.py`.
+- Validation is construction-time only (dataclass `__post_init__`). Never add runtime validation, conversion helpers, or business logic.
+- Field names, types, and required/optional status in `core.py` must match the corresponding JSON schema exactly. Zero divergence.
+
+## Required artifacts
+
+- Every new or changed Python type must have a roundtrip test in `tests/test_roundtrip_examples.py`.
+- Python changes to contract types are never standalone — the same PR must include the corresponding schema change and all other required artifacts. See `AGENTS.md` for the full six-artifact rule.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,14 @@
+---
+applyTo: "docs/**"
+---
+
+# Documentation Instructions
+
+## Verification rules
+
+- When editing docs that describe layer responsibilities or data flow, verify claims against the artifact ownership table in `docs/BOUNDARIES.md` and invariants in `docs/INVARIANTS.md`.
+- Never modify a Mermaid diagram without checking it against the `BOUNDARIES.md` artifact ownership table. The table is canonical; diagrams are derived.
+
+## Authority
+
+When docs conflict, the authority hierarchy applies: `INVARIANTS.md` → `BOUNDARIES.md` → `ARCHITECTURE.md` → everything else. See `AGENTS.md` for details.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,196 @@
+# Agent Instructions — weaver-spec
+
+This file is the shared source of truth for any coding agent working in this repository.
+Read this file first. Consult the linked supporting docs when you need deeper context.
+
+---
+
+## Purpose and scope
+
+This repository is **documentation + contracts only**.
+
+- It defines the shared interfaces for three sibling repositories: **contextweaver** (routing), **agent-kernel** (execution), and **ChainWeaver** (orchestration).
+- It contains JSON Schemas (language-agnostic source of truth), a Python `weaver_contracts` package (stdlib dataclasses mirroring the schemas), specification docs, and examples.
+- **Never add runtime logic, CLI tools, helper utilities, or business logic to this repository.** Validation is limited to construction-time checks in dataclass `__post_init__`.
+
+---
+
+## Repo map
+
+| Path | Contains | When to consult |
+|------|----------|-----------------|
+| `contracts/json/` | JSON Schemas (Draft 2020-12) | Adding or modifying contract definitions |
+| `contracts/python/src/weaver_contracts/core.py` | Core contract dataclasses (9 types) | When schemas change — must update in same PR |
+| `contracts/python/src/weaver_contracts/extended.py` | Extended metadata types (6 types) | Adding optional metadata contracts |
+| `contracts/python/src/weaver_contracts/version.py` | `CONTRACT_VERSION` constant | Every version bump |
+| `contracts/python/pyproject.toml` | Package build config | Every version bump |
+| `contracts/python/tests/` | Roundtrip + schema alignment tests | Every contract change |
+| `examples/sample_payloads/` | Example JSON payloads | Every new or changed schema |
+| `docs/` | Specification documents | When changing behavior, boundaries, or invariants |
+| `docs/agent-context/` | Agent-oriented supporting docs | When you need workflow detail, invariant context, lessons learned, or a review checklist |
+
+---
+
+## Authority hierarchy
+
+When documents conflict, higher-ranked sources win:
+
+1. **`docs/INVARIANTS.md`** — non-negotiable rules (I-01 through I-07)
+2. **`docs/BOUNDARIES.md`** — responsibility boundaries and artifact ownership
+3. **`docs/ARCHITECTURE.md`** — structural model and data flow
+4. Everything else (FAQ, Glossary, README, etc.) is supporting
+
+For JSON schema conventions specifically, `contracts/json/README.md` is authoritative.
+
+---
+
+## Source of truth: schemas lead
+
+JSON Schemas are the language-agnostic source of truth for all contract definitions. Python types must mirror them exactly — same field names, same types, same required/optional status. Zero divergence.
+
+---
+
+## Core contract change scope
+
+Every Core contract change must update **all six artifacts in the same PR**:
+
+1. JSON Schema (`contracts/json/`)
+2. Python dataclass (`contracts/python/src/weaver_contracts/core.py`)
+3. Sample payload (`examples/sample_payloads/`)
+4. Roundtrip test (`contracts/python/tests/test_roundtrip_examples.py`)
+5. CHANGELOG entry (`CHANGELOG.md`)
+6. Version bump (`version.py` + `pyproject.toml`)
+
+**Cross-repo impact:** Core contract changes affect contextweaver, agent-kernel, and ChainWeaver. Always flag the cross-repo impact in the PR description and consider whether sibling repos need coordinated updates.
+
+See [docs/agent-context/workflows.md](docs/agent-context/workflows.md) for detailed sequences.
+
+---
+
+## Versioning rules
+
+- **Breaking changes** to Core contracts require the ADR process: issue → 3-day discussion → PR with version bump + CHANGELOG + compatibility matrix update. See `CONTRIBUTING.md`.
+- **Extended contracts** may have breaking changes in a MINOR version — this is an intentional exception to standard semver. See `docs/VERSIONING.md`.
+
+---
+
+## Invariants and boundaries
+
+Before any Core contract change:
+
+1. **Check invariants I-01 through I-07** in `docs/INVARIANTS.md`. These are non-negotiable. *(Review priority #2)*
+2. **Check the artifact ownership table** in `docs/BOUNDARIES.md` for any change affecting data flow between layers. *(Review priority #3)*
+
+Do not restate invariants in new docs or code comments — point to `docs/INVARIANTS.md` instead.
+
+See [docs/agent-context/invariants.md](docs/agent-context/invariants.md) for forbidden shortcuts and constraint-safety rules.
+
+---
+
+## Forbidden behaviors
+
+- **Never add a field to a Core contract** without confirming it is universally needed by all adopters. Proactively move non-universal fields to Extended contracts instead.
+- **Never weaken a schema constraint** (remove `minLength`, loosen an enum, drop a `required` entry) without an ADR — weakening constraints is always a breaking change.
+- **Never write a schema `description` that contradicts structural constraints** — do not say "required" for a field not in the `required` array, and do not claim extensibility for a field with an `enum` constraint.
+- **Never modify a Mermaid diagram without verifying it against the `BOUNDARIES.md` artifact ownership table** — the table is canonical; diagrams are derived.
+- **Never describe aspirational features as current** — if a capability (e.g., token signing) is not enforced by a schema constraint or code mechanism, do not assert it as fact.
+
+See [docs/agent-context/invariants.md](docs/agent-context/invariants.md) for the full forbidden-shortcuts list and safe-vs-unsafe simplification table.
+
+---
+
+## Design decisions not to reopen
+
+These separations look like simplification targets but exist for deliberate architectural reasons:
+
+| Separation | Why it exists |
+|------------|---------------|
+| **ChoiceCard vs RoutingDecision** | ChoiceCards carry only what the LLM needs for selection (no full tool schemas). RoutingDecisions wrap ChoiceCards with state. Merging them would re-introduce context bloat. |
+| **Frame vs Handle** | Frames are safe to display. Handles are opaque references to raw artifacts requiring authorization to resolve. Merging them would collapse the safety boundary. |
+| **CapabilityToken vs Capability** | Tokens are scoped, time-limited authorization credentials. Capabilities are stable definitions. Merging them would conflate identity with authorization. |
+
+Do not merge, collapse, or "simplify" these types without a spec-level ADR.
+
+---
+
+## Domain clarifications
+
+**CapabilityToken:** Currently a plain data structure. The word "signed" in the Glossary and schema descriptions is aspirational. Signing is an agent-kernel implementation concern, not enforced in this spec. Do not add signature fields or cryptographic logic here.
+
+**ID format:** IDs are any non-empty string (`minLength: 1`). UUIDs are not required. Sample payloads use readable slug-style IDs (e.g., `rd-20260308-001`). Ignore the FAQ's imprecise "UUIDs or stable strings" claim — the JSON schemas are the authority.
+
+---
+
+## Code review expectations
+
+- Review code changes and agent-facing docs together when one affects the other.
+- Do not invent conventions not grounded in canonical docs or repository evidence.
+- Surface contradictions or stale docs explicitly — do not silently work around authority conflicts.
+- Invariants take priority over cleanup, simplification, or local refactors.
+- PRs that change workflows, invariants, architecture intent, review conventions, or path-specific rules must trigger doc review.
+- Use the validation commands listed below and in `CONTRIBUTING.md` — do not substitute alternatives.
+
+---
+
+## Definition of done
+
+A change is ready for review when:
+
+- [ ] All affected artifacts are updated in the same PR (see six-artifact list above)
+- [ ] Invariants I-01 through I-07 are not violated
+- [ ] No boundary from `docs/BOUNDARIES.md` is crossed without an ADR
+- [ ] All local validation checks pass (see below)
+- [ ] Cross-repo impact is flagged in the PR description (for Core contract changes)
+- [ ] CHANGELOG is updated for any non-patch change
+
+See [docs/agent-context/review-checklist.md](docs/agent-context/review-checklist.md) for the full review checklist.
+
+---
+
+## Local validation
+
+Run all three checks before submitting a PR:
+
+```bash
+# 1. Python tests
+cd contracts/python
+pip install -e ".[dev]"
+pytest
+
+# 2. JSON schema validation
+cd ../..
+python -c "import json; [json.load(open(f)) for f in __import__('glob').glob('contracts/json/*.schema.json')]"
+
+# 3. Markdown lint
+# Run markdownlint on all .md files
+```
+
+---
+
+## Commit conventions
+
+Prefixes: `docs:`, `contracts:`, `ci:`, `fix:`.
+
+For mixed changes, use the prefix for the most impactful change. Mention the secondary scope in the commit body.
+
+---
+
+## Documentation map
+
+| File | Scope |
+|------|-------|
+| `AGENTS.md` *(this file)* | Primary agent entrypoint — rules, navigation, authority |
+| [docs/agent-context/architecture.md](docs/agent-context/architecture.md) | Pointers to canonical architecture and boundary docs |
+| [docs/agent-context/workflows.md](docs/agent-context/workflows.md) | Authoritative commands, change sequences, documentation governance |
+| [docs/agent-context/invariants.md](docs/agent-context/invariants.md) | Hard constraints, forbidden shortcuts, safe-vs-unsafe changes |
+| [docs/agent-context/lessons-learned.md](docs/agent-context/lessons-learned.md) | Failure-capture workflow and pattern index |
+| [docs/agent-context/review-checklist.md](docs/agent-context/review-checklist.md) | Definition-of-done and review gates |
+
+---
+
+## Update policy
+
+- **When to update this file:** When a new shared rule is added, an existing rule changes, or a new agent-context doc is created.
+- **When to update supporting docs:** When the topic they own changes. Each supporting doc states its own update triggers.
+- **How contradictions are resolved:** The authority hierarchy above governs existing spec docs. Within the agent-facing layer, `AGENTS.md` is canonical; supporting docs elaborate but must not contradict it.
+- **Duplication rule:** Each rule has one canonical home. If a rule appears in multiple files, one must be the canonical source and others must be explicit projections or cross-references.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,9 @@ For JSON schema conventions specifically, `contracts/json/README.md` is authorit
 
 ## Source of truth: schemas lead
 
-JSON Schemas are the language-agnostic source of truth for all contract definitions. Python types must mirror them exactly — same field names, same types, same required/optional status. Zero divergence.
+JSON Schemas are the language-agnostic source of truth for all **Core** contract definitions. Python Core types must mirror them exactly — same field names, same types, same required/optional status. Zero divergence.
+
+Extended contracts currently have no JSON Schemas — the Python dataclasses in `extended.py` are the source of truth for Extended types.
 
 ---
 
@@ -90,7 +92,7 @@ See [docs/agent-context/invariants.md](docs/agent-context/invariants.md) for for
 ## Forbidden behaviors
 
 - **Never add a field to a Core contract** without confirming it is universally needed by all adopters. Proactively move non-universal fields to Extended contracts instead.
-- **Never weaken a schema constraint** (remove `minLength`, loosen an enum, drop a `required` entry) without an ADR — weakening constraints is always a breaking change.
+- **Never weaken a schema constraint** (remove `minLength`, loosen an enum, drop a `required` entry) without an ADR — constraint loosening affects consumers even when existing payloads remain valid.
 - **Never write a schema `description` that contradicts structural constraints** — do not say "required" for a field not in the `required` array, and do not claim extensibility for a field with an `enum` constraint.
 - **Never modify a Mermaid diagram without verifying it against the `BOUNDARIES.md` artifact ownership table** — the table is canonical; diagrams are derived.
 - **Never describe aspirational features as current** — if a capability (e.g., token signing) is not enforced by a schema constraint or code mechanism, do not assert it as fact.
@@ -117,7 +119,7 @@ Do not merge, collapse, or "simplify" these types without a spec-level ADR.
 
 **CapabilityToken:** Currently a plain data structure. The word "signed" in the Glossary and schema descriptions is aspirational. Signing is an agent-kernel implementation concern, not enforced in this spec. Do not add signature fields or cryptographic logic here.
 
-**ID format:** IDs are any non-empty string (`minLength: 1`). UUIDs are not required. Sample payloads use readable slug-style IDs (e.g., `rd-20260308-001`). Ignore the FAQ's imprecise "UUIDs or stable strings" claim — the JSON schemas are the authority.
+**ID format:** IDs are any non-empty string (`minLength: 1`). UUIDs are not required. Sample payloads use readable slug-style IDs (e.g., `rd-20260308-001`). If any other docs or examples ever conflict with this, treat the JSON Schemas as the authority.
 
 ---
 
@@ -162,7 +164,7 @@ cd ../..
 python -c "import json; [json.load(open(f)) for f in __import__('glob').glob('contracts/json/*.schema.json')]"
 
 # 3. Markdown lint
-# Run markdownlint on all .md files
+# See CONTRIBUTING.md "Markdown Lint" section for the canonical command.
 ```
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ This repository is **documentation + contracts only**.
 |------|----------|-----------------|
 | `contracts/json/` | JSON Schemas (Draft 2020-12) | Adding or modifying contract definitions |
 | `contracts/python/src/weaver_contracts/core.py` | Core contract dataclasses (9 types) | When schemas change — must update in same PR |
-| `contracts/python/src/weaver_contracts/extended.py` | Extended metadata types (6 types) | Adding optional metadata contracts |
+| `contracts/python/src/weaver_contracts/extended.py` | Extended metadata types | Adding optional metadata contracts |
 | `contracts/python/src/weaver_contracts/version.py` | `CONTRACT_VERSION` constant | Every version bump |
 | `contracts/python/pyproject.toml` | Package build config | Every version bump |
 | `contracts/python/tests/` | Roundtrip + schema alignment tests | Every contract change |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
 
 ## [Unreleased]
 
+### Added
+
+- Agent-facing documentation system:
+  - `AGENTS.md` — shared entrypoint for all coding agents (rules, repo map, authority hierarchy, forbidden behaviors, design decisions not to reopen).
+  - `docs/agent-context/architecture.md` — thin pointer to canonical architecture and boundary docs.
+  - `docs/agent-context/workflows.md` — contract change workflows, validation commands, commit conventions, documentation governance.
+  - `docs/agent-context/invariants.md` — forbidden shortcuts, must-preserve constraints, safe-vs-unsafe simplification table.
+  - `docs/agent-context/lessons-learned.md` — failure-capture workflow and known pattern index.
+  - `docs/agent-context/review-checklist.md` — self-review and maintainer-review checklist with checkbox items.
+- GitHub Copilot instructions:
+  - `.github/copilot-instructions.md` — compact review-priority entrypoint for GitHub code review.
+  - `.github/instructions/contracts-json.instructions.md` — path-scoped rules for `contracts/json/**`.
+  - `.github/instructions/contracts-python.instructions.md` — path-scoped rules for `contracts/python/**`.
+  - `.github/instructions/docs.instructions.md` — path-scoped rules for `docs/**`.
+- Claude Code instructions:
+  - `.claude/CLAUDE.md` — Claude-specific operating behavior, contradiction handling, lesson promotion workflow.
+
+### Fixed
+
+- `docs/FAQ.md` — corrected ID format claim from "UUIDs or stable strings" to "non-empty strings (`minLength: 1`)" to match JSON schema authority.
+- `CONTRIBUTING.md` — added missing Markdown Lint section with exact `markdownlint-cli` command matching CI configuration.
+
 ---
 
 ## [0.1.0] — 2026-03-08

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,15 @@ python -c "import json; [json.load(open(f)) for f in __import__('glob').glob('co
 echo "All schemas are valid JSON"
 ```
 
+### Markdown Lint
+
+```bash
+npm install -g markdownlint-cli
+markdownlint --disable MD013 MD033 MD041 \
+  README.md CONTRIBUTING.md CHANGELOG.md \
+  docs/*.md contracts/**/*.md examples/*.md
+```
+
 ---
 
 ## Commit Messages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,7 @@ echo "All schemas are valid JSON"
 
 ```bash
 npm install -g markdownlint-cli
+cd ../..
 markdownlint --disable MD013 MD033 MD041 \
   README.md CONTRIBUTING.md CHANGELOG.md \
   docs/*.md contracts/**/*.md examples/*.md

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -27,7 +27,7 @@ Three overlaps are explicitly prohibited by the boundary decisions in [BOUNDARIE
 
 ## How strict are the contracts?
 
-**Core contracts are strict.** Every required field is required; types are precise; IDs must be non-empty UUIDs or stable strings.
+**Core contracts are strict.** Every required field is required; types are precise; IDs must be non-empty strings (`minLength: 1`).
 
 **Extended contracts are lenient.** Optional fields may be absent. New fields may be added in a minor version. Extended contracts are not required for spec compliance.
 

--- a/docs/agent-context/architecture.md
+++ b/docs/agent-context/architecture.md
@@ -1,0 +1,22 @@
+# Architecture Context for Agents
+
+> This file routes you to the canonical architecture and boundary documents.
+> For the rules themselves, see [AGENTS.md](../../AGENTS.md).
+
+---
+
+## Where to find architecture context
+
+- **System structure and data flow:** [docs/ARCHITECTURE.md](../ARCHITECTURE.md)
+- **Responsibility boundaries and artifact ownership:** [docs/BOUNDARIES.md](../BOUNDARIES.md)
+- **Design decisions not to reopen** (ChoiceCard vs RoutingDecision, Frame vs Handle, CapabilityToken vs Capability): [AGENTS.md](../../AGENTS.md)
+
+Consult these docs when scoping a change that might cross architectural boundaries or when you need to understand why contract types are separated as they are.
+
+---
+
+## Update triggers
+
+Update this file when:
+- A new canonical architecture doc is added
+- The pointers above become stale

--- a/docs/agent-context/invariants.md
+++ b/docs/agent-context/invariants.md
@@ -1,0 +1,82 @@
+# Invariants and Constraints for Agents
+
+> Consult this file when you need to understand what you must not break, what shortcuts are forbidden,
+> and how to distinguish safe simplifications from unsafe ones.
+> For the rules themselves, see [AGENTS.md](../../AGENTS.md).
+> For the canonical invariant definitions, see [docs/INVARIANTS.md](../INVARIANTS.md).
+
+---
+
+## Hard invariants
+
+Invariants I-01 through I-07 in `docs/INVARIANTS.md` are non-negotiable. Violating any of them makes an implementation non-compliant. Before any Core contract change, verify that your change does not weaken, contradict, or circumvent any invariant.
+
+The invariants most often relevant to contract changes:
+
+| Invariant | What it prevents |
+|-----------|-----------------|
+| **I-01 / I-05** — LLM and contextweaver never see raw tool output | Adding fields that expose unfiltered data |
+| **I-04** — Core contracts are minimal and stable | Adding implementation-specific fields to Core |
+| **I-06** — CapabilityTokens are scoped and time-limited | Removing `expires_at`/`single_use` constraints |
+
+Always check the full list. The invariants above are highlighted because they are the ones most frequently relevant to contract editing, not because the others are less binding.
+
+---
+
+## Forbidden shortcuts
+
+These patterns are confirmed traps. Each is a generalized rule — not tied to any single incident.
+
+### Schema descriptions must not contradict structural constraints
+
+Every `description` string in a JSON schema must be consistent with the structural constraints (`required`, `enum`, `minLength`, `type`, etc.) on the same field. Read both before writing either.
+
+- Do not say a field is "required" in a `description` if the field is not in the `required` array.
+- Do not claim extensibility (e.g., "additional values may be used") when an `enum` constraint is present on the same field.
+
+### Diagrams must not contradict boundaries
+
+Any visual representation of data flow must match the artifact ownership table in `docs/BOUNDARIES.md`. The table is canonical; the diagram is derived. Do not modify a Mermaid diagram without verifying it against the table.
+
+### Never weaken schema constraints without an ADR
+
+Removing a `minLength`, loosening an `enum`, dropping a `required` field, or widening a type — these are all breaking changes even when they look like cleanup. They require the ADR process.
+
+### Never add non-universal fields to Core
+
+A field belongs in Core only if every adopter needs it. If a field is useful to one implementation or one use case, it belongs in Extended. When reviewing a Core contract change, ask: "Would an adopter using *only* contextweaver or *only* agent-kernel need this field?" If not, move it to Extended.
+
+---
+
+## Must-preserve constraints
+
+These constraints must not be removed or weakened without an ADR:
+
+- `minLength: 1` on all ID fields
+- `additionalProperties: true` on all schemas
+- `anyOf` constraint on CapabilityToken requiring `expires_at` or `single_use` (enforces I-06)
+- `required` arrays on all schemas — never remove a field from `required` without an ADR
+
+---
+
+## Safe vs unsafe simplifications
+
+| Simplification | Safe? | Why |
+|---------------|-------|-----|
+| Add an optional field to a schema | Yes | `additionalProperties: true` makes additive changes backward-compatible |
+| Add a new enum value | Yes | Existing values remain valid |
+| Remove an optional field from a schema | **No** | Consumers may depend on it; requires ADR |
+| Remove a required field | **No** | Breaking change; requires ADR |
+| Change a field's type | **No** | Breaking change; requires ADR |
+| Refactor Python code without changing fields | Yes | As long as field names, types, and required status still match the schema |
+| Add a new Extended type | Yes | Extended types don't affect Core stability |
+| Merge two separate contract types | **No** | Changes the interface contract; requires ADR |
+
+---
+
+## Update triggers
+
+Update this file when:
+- A new invariant is added to `docs/INVARIANTS.md`
+- A new forbidden pattern is identified (see failure-capture workflow in `lessons-learned.md`)
+- The safe-vs-unsafe classification changes due to a versioning policy change

--- a/docs/agent-context/invariants.md
+++ b/docs/agent-context/invariants.md
@@ -40,7 +40,7 @@ Any visual representation of data flow must match the artifact ownership table i
 
 ### Never weaken schema constraints without an ADR
 
-Removing a `minLength`, loosening an `enum`, dropping a `required` field, or widening a type — these are all breaking changes even when they look like cleanup. They require the ADR process.
+Removing a `minLength`, loosening an `enum`, dropping a `required` field, or widening a type — these are high-risk changes that affect consumers even when existing payloads remain valid. They require the ADR process regardless of whether they meet the formal "breaking change" definition in `CONTRIBUTING.md`.
 
 ### Never add non-universal fields to Core
 
@@ -65,7 +65,7 @@ These constraints must not be removed or weakened without an ADR:
 |---------------|-------|-----|
 | Add an optional field to a schema | Yes | `additionalProperties: true` makes additive changes backward-compatible |
 | Add a new enum value | Yes | Existing values remain valid |
-| Remove an optional field from a schema | **No** | Consumers may depend on it; requires ADR |
+| Remove an optional field from a schema | **No** | Affects Python API consumers and downstream readers; requires ADR even though payloads remain valid |
 | Remove a required field | **No** | Breaking change; requires ADR |
 | Change a field's type | **No** | Breaking change; requires ADR |
 | Refactor Python code without changing fields | Yes | As long as field names, types, and required status still match the schema |

--- a/docs/agent-context/lessons-learned.md
+++ b/docs/agent-context/lessons-learned.md
@@ -1,0 +1,55 @@
+# Lessons Learned
+
+> Consult this file when you need to record a new reusable lesson or understand how lessons are promoted.
+> For the current rules derived from lessons, see [AGENTS.md](../../AGENTS.md) and
+> [docs/agent-context/invariants.md](invariants.md).
+
+---
+
+## Failure-capture workflow
+
+When a mistake is identified (during review, from a reverted commit, or from a CI failure):
+
+1. **Determine if the mistake is reusable** — Could this pattern recur in a different file or context? If yes, continue. If it was a one-time typo or data error, fix it and stop.
+2. **Generalize the lesson** — Extract the underlying pattern, not just the specific instance.
+3. **Record the generalized lesson** — Add it to the "Known patterns" index below.
+4. **Promote to a rule if warranted** — If the lesson is important enough to be a hard constraint, add it to [invariants.md](invariants.md) (forbidden shortcuts) and reference it from `AGENTS.md` if it is cross-cutting.
+5. **Do not keep incident details** — This file captures patterns, not incident logs. Omit commit hashes, dates, and person-specific context.
+
+### Criteria for inclusion
+
+A lesson belongs here if:
+- The mistake pattern could realistically recur across different files or contexts.
+- Understanding the pattern helps prevent future occurrences.
+
+A lesson does **not** belong here if:
+- It was a one-time factual error.
+- It is already fully captured as a forbidden shortcut in [invariants.md](invariants.md).
+- It requires incident-specific context to be useful.
+
+---
+
+## Known patterns (derived rules live elsewhere)
+
+1. **Description-constraint contradictions** — Schema descriptions that assert something contradicted by structural constraints. → Rule in [invariants.md](invariants.md) (forbidden shortcuts) and [contracts-json.instructions.md](../../.github/instructions/contracts-json.instructions.md).
+2. **Diagram-boundary contradictions** — Mermaid diagrams showing data flow that contradicts the artifact ownership table. → Rule in [invariants.md](invariants.md) and [docs.instructions.md](../../.github/instructions/docs.instructions.md).
+3. **Aspirational-as-current prose** — Documentation asserting features that are not enforced by schema or code. → Clarification in [AGENTS.md](../../AGENTS.md) (domain clarifications).
+
+---
+
+## How lessons get promoted
+
+```
+Incident → generalized lesson (this file) → forbidden shortcut (invariants.md) → rule (AGENTS.md)
+```
+
+Not all lessons become rules. A lesson becomes a forbidden shortcut when it represents a pattern that has recurred or has high blast radius if it recurs. A forbidden shortcut becomes a rule in `AGENTS.md` when it is cross-cutting (applies globally, not just to one path or file type).
+
+---
+
+## Update triggers
+
+Update this file when:
+- A new reusable mistake pattern is discovered
+- An existing lesson is promoted to a forbidden shortcut in [invariants.md](invariants.md)
+- The failure-capture workflow itself changes

--- a/docs/agent-context/review-checklist.md
+++ b/docs/agent-context/review-checklist.md
@@ -1,0 +1,88 @@
+# Review Checklist
+
+> Use this checklist for self-review before proposing a change, or for maintainer review of incoming PRs.
+> For the underlying rules, see [AGENTS.md](../../AGENTS.md).
+
+---
+
+## Review priority order
+
+When reviewing Core contract changes, check in this order:
+
+1. **Artifact completeness** — Are all required artifacts updated?
+2. **Invariant compliance** — Do invariants I-01 through I-07 hold?
+3. **Boundary compliance** — Does the change respect `docs/BOUNDARIES.md`?
+
+---
+
+## Artifact completeness
+
+For Core contract changes, all six must be in the same PR:
+
+- [ ] JSON Schema updated (`contracts/json/`)
+- [ ] Python dataclass updated (`contracts/python/src/weaver_contracts/core.py`)
+- [ ] Sample payload updated or created (`examples/sample_payloads/`)
+- [ ] Roundtrip test updated or created (`contracts/python/tests/test_roundtrip_examples.py`)
+- [ ] CHANGELOG entry added
+- [ ] Version bumped in `version.py` and `pyproject.toml`
+
+For Extended contract changes, the same pattern applies but with `extended.py` instead of `core.py`.
+
+---
+
+## Invariant compliance
+
+- [ ] I-01 / I-05: Change does not expose raw tool output to contextweaver or the LLM
+- [ ] I-02: Change does not create a path for unaudited execution
+- [ ] I-03: Change does not require full tool schema injection for routing
+- [ ] I-04: Any new Core field is universally needed (not implementation-specific)
+- [ ] I-06: CapabilityToken constraints (scoped + expiry or single-use) are preserved
+- [ ] I-07: ChainWeaver tool invocations still delegate to agent-kernel
+
+---
+
+## Schema-description consistency
+
+- [ ] No `description` asserts "required" for a field not in the `required` array
+- [ ] No `description` claims extensibility for a field with an `enum` constraint
+- [ ] No `description` asserts a format (e.g., "UUID") not enforced by a `format` or `pattern` constraint
+- [ ] Description text accurately reflects the structural constraints
+
+---
+
+## Cross-file consistency
+
+- [ ] Python dataclass field names, types, and required/optional status match the JSON schema exactly
+- [ ] Sample payload validates against the updated schema
+- [ ] Roundtrip test covers the updated fields
+- [ ] Mermaid diagrams (if modified) match the artifact ownership table in `docs/BOUNDARIES.md`
+
+---
+
+## Documentation and update checks
+
+- [ ] CHANGELOG entry present for non-patch changes
+- [ ] Version numbers consistent across `version.py` and `pyproject.toml`
+- [ ] PR description includes cross-repo impact section (for Core contract changes)
+- [ ] If a term definition changed, `docs/GLOSSARY.md` is updated
+- [ ] If a boundary or invariant changed, `docs/BOUNDARIES.md` or `docs/INVARIANTS.md` is updated via ADR
+- [ ] No new duplicate authority introduced — each rule has one canonical home
+- [ ] Agent-facing docs (`AGENTS.md`, `docs/agent-context/*`) updated if any shared rule, workflow, or invariant changed
+
+---
+
+## Local validation
+
+- [ ] `pytest` passes (`cd contracts/python && pip install -e ".[dev]" && pytest`)
+- [ ] JSON schemas parse without error
+- [ ] Markdownlint passes on all `.md` files
+
+---
+
+## Update triggers
+
+Update this checklist when:
+- A new artifact is added to the required-per-PR set
+- A new invariant is added
+- Review expectations or gates change
+- A new cross-file consistency rule is discovered

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -1,0 +1,120 @@
+# Workflows for Agents
+
+> Consult this file for the authoritative command sequences and documentation governance rules.
+> For the rules themselves, see [AGENTS.md](../../AGENTS.md).
+
+---
+
+## Core contract change workflow
+
+When modifying a Core contract, complete all steps in a single PR:
+
+1. **Update the JSON Schema** in `contracts/json/`. Follow the conventions in `contracts/json/README.md`.
+2. **Update the Python dataclass** in `contracts/python/src/weaver_contracts/core.py`. Field names, types, and required/optional status must match the updated schema exactly.
+3. **Update or create a sample payload** in `examples/sample_payloads/`. The payload must validate against the updated schema.
+4. **Add or update a roundtrip test** in `contracts/python/tests/test_roundtrip_examples.py`.
+5. **Add a CHANGELOG entry** under the appropriate version section.
+6. **Bump the version** in both `contracts/python/src/weaver_contracts/version.py` and `contracts/python/pyproject.toml`.
+
+After completing all six artifacts, run the local validation checks before submitting.
+
+---
+
+## Extended contract change workflow
+
+Extended contracts follow the same artifact pattern (schema + Python + test + CHANGELOG + version bump), but:
+
+- Breaking changes are allowed in MINOR versions.
+- Extended types live in `contracts/python/src/weaver_contracts/extended.py`.
+- Sample payloads are still expected but may be lighter for optional metadata.
+
+---
+
+## Breaking change workflow (ADR process)
+
+Breaking changes to Core contracts must not be submitted as direct PRs. Follow the ADR process defined in `CONTRIBUTING.md`:
+
+1. Open an issue describing the change, affected contracts, and migration path.
+2. Wait for a 3-day discussion period.
+3. Open a PR that includes the contract change, updated payloads, CHANGELOG, version bump, and compatibility matrix update in `docs/VERSIONING.md`.
+4. PR merges after maintainer approval; the issue is closed and linked from the CHANGELOG.
+
+---
+
+## Cross-repo impact flagging
+
+For any Core contract change, add a section to the PR description:
+
+```
+## Cross-repo impact
+- contextweaver: [describe impact or "none"]
+- agent-kernel: [describe impact or "none"]
+- ChainWeaver: [describe impact or "none"]
+```
+
+If the change affects a contract that a sibling repo produces or consumes, coordination is required.
+
+---
+
+## Local validation commands
+
+Run all three before submitting any PR. CI enforces all three.
+
+```bash
+# 1. Python tests
+cd contracts/python
+pip install -e ".[dev]"
+pytest
+
+# 2. JSON schema validation
+cd ../..
+python -c "import json; [json.load(open(f)) for f in __import__('glob').glob('contracts/json/*.schema.json')]"
+
+# 3. Markdown lint
+# Run markdownlint across all .md files in the repo
+```
+
+---
+
+## Commit conventions
+
+| Prefix | When to use |
+|--------|-------------|
+| `docs:` | Documentation-only changes |
+| `contracts:` | Schema or Python type changes |
+| `ci:` | Workflow/CI changes |
+| `fix:` | Bug fixes in tests, scripts, or docs |
+
+**Mixed changes:** Use the prefix for the most impactful change. Mention the secondary scope in the commit body. Example: `contracts: add optional risk_level field to ChoiceCard` with body noting `Also updates docs/GLOSSARY.md`.
+
+---
+
+## Documentation governance
+
+### When docs must be updated
+
+| Trigger | Docs to update |
+|---------|---------------|
+| New or changed Core contract | CHANGELOG, potentially GLOSSARY if term meaning changes |
+| New invariant or boundary change | INVARIANTS.md or BOUNDARIES.md (via ADR), then update AGENTS.md pointer |
+| New workflow or validation command | This file (`workflows.md`) |
+| New recurring mistake identified | `lessons-learned.md` (see failure-capture workflow there) |
+| Review expectations change | `review-checklist.md` |
+| New agent-facing guidance added | AGENTS.md documentation map |
+| Shared rule, workflow, or invariant changed | Agent-facing docs (`AGENTS.md`, `docs/agent-context/*`) |
+
+### How to avoid duplicate authority
+
+- Each governance rule lives in one file.
+- Other files may contain a one-sentence pointer (e.g., "See workflows.md for command details").
+- If you find the same rule stated in two files without a clear canonical/pointer relationship, flag it for cleanup.
+
+---
+
+## Update triggers
+
+Update this file when:
+- A validation command changes
+- The commit convention or PR process changes
+- A new documentation governance rule is established
+- The ADR process is modified in `CONTRIBUTING.md`

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -22,11 +22,16 @@ After completing all six artifacts, run the local validation checks before submi
 
 ## Extended contract change workflow
 
-Extended contracts follow the same artifact pattern (schema + Python + test + CHANGELOG + version bump), but:
+Extended contracts do **not** currently have JSON Schemas; the `contracts/json/` directory is Core-only.
+When modifying an Extended contract, complete all of the following in a single PR:
 
-- Breaking changes are allowed in MINOR versions.
-- Extended types live in `contracts/python/src/weaver_contracts/extended.py`.
-- Sample payloads are still expected but may be lighter for optional metadata.
+1. **Update the Python dataclass** in `contracts/python/src/weaver_contracts/extended.py`.
+2. **Update or create a sample payload** in `examples/sample_payloads/`.
+3. **Add or update a roundtrip test** in `contracts/python/tests/test_roundtrip_examples.py`.
+4. **Add a CHANGELOG entry** under the appropriate version section.
+5. **Bump the version** in both `contracts/python/src/weaver_contracts/version.py` and `contracts/python/pyproject.toml`.
+
+Breaking changes are allowed in MINOR versions for Extended contracts.
 
 ---
 
@@ -71,7 +76,7 @@ cd ../..
 python -c "import json; [json.load(open(f)) for f in __import__('glob').glob('contracts/json/*.schema.json')]"
 
 # 3. Markdown lint
-# Run markdownlint across all .md files in the repo
+# See CONTRIBUTING.md "Markdown Lint" section for the canonical command.
 ```
 
 ---


### PR DESCRIPTION
## Summary

Adds a complete layered documentation system for coding agents (GitHub Copilot, Claude Code, and others) working in this repository. Also fixes two inaccuracies in existing docs discovered during the documentation audit.

## What changed

### New: Agent documentation system (11 files)

**Canonical shared layer:**
- `AGENTS.md` — primary entrypoint for all coding agents. Owns: rules, repo map, authority hierarchy, forbidden behaviors, design decisions not to reopen, code review expectations, definition of done, validation commands, commit conventions.
- `docs/agent-context/architecture.md` — thin pointer to `docs/ARCHITECTURE.md` and `docs/BOUNDARIES.md`.
- `docs/agent-context/workflows.md` — contract change workflows, ADR process, cross-repo impact flagging, validation commands, commit conventions, documentation governance triggers.
- `docs/agent-context/invariants.md` — forbidden shortcuts, must-preserve constraints, safe-vs-unsafe simplification table.
- `docs/agent-context/lessons-learned.md` — failure-capture workflow, promotion chain, known pattern index.
- `docs/agent-context/review-checklist.md` — self-review and maintainer-review checklist with checkbox items for artifact completeness, invariant compliance, schema-description consistency, cross-file consistency, and documentation freshness.

**GitHub Copilot layer:**
- `.github/copilot-instructions.md` — compact review-priority projection for GitHub code review.
- `.github/instructions/contracts-json.instructions.md` — path-scoped rules for `contracts/json/**`.
- `.github/instructions/contracts-python.instructions.md` — path-scoped rules for `contracts/python/**`.
- `.github/instructions/docs.instructions.md` — path-scoped rules for `docs/**`.

**Claude Code layer:**
- `.claude/CLAUDE.md` — Claude-specific operating behavior, contradiction handling, lesson promotion workflow.

### Fixed: Existing docs

- `docs/FAQ.md` — corrected "IDs must be non-empty UUIDs or stable strings" → "IDs must be non-empty strings (`minLength: 1`)" to match JSON schema authority.
- `CONTRIBUTING.md` — added missing Markdown Lint section with exact `markdownlint-cli` command and flags matching CI configuration.
- `CHANGELOG.md` — added Unreleased section documenting all changes in this PR.

## Design principles

- **Single canonical home:** each rule is owned by one file; other files contain explicit projections or pointers.
- **Authority hierarchy:** `docs/INVARIANTS.md` → `docs/BOUNDARIES.md` → `docs/ARCHITECTURE.md` → everything else.
- **Minimal projection surface:** tool-specific files (Copilot, Claude) are thin — they project critical rules and add tool-specific behavior only.
- **Path-scoped rules:** `.github/instructions/` files use `applyTo` frontmatter for context-specific guidance.

## Testing performed

- `pytest -v` — **50 passed** (all roundtrip + schema alignment tests)
- JSON schema validation — **all schemas valid**
- Markdownlint — not run locally (Node.js not available); CI will validate

## Cross-repo impact

This change is documentation-only and does not modify any contract schemas or Python types. No impact on contextweaver, agent-kernel, or ChainWeaver.

## AI agent instruction files reviewed/changed

This PR **is** the agent instruction system. All 11 files are new agent-facing documentation. The system was designed through a multi-phase pipeline: audit → interview → knowledge map → drafting → harmonization → rendering → application.