### PR TITLE
ci: add mypy strict type checking and pytest-cov to CI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -38,7 +38,7 @@ This file adds Claude-specific operating behavior only.
 Before proposing that work is done:
 
 1. Verify all required artifacts are updated (see definition of done in `AGENTS.md`).
-2. Run the local validation commands from `AGENTS.md`: pytest, JSON schema validation, markdownlint.
+2. Run the local validation commands from `AGENTS.md`: pytest (with coverage), mypy, JSON schema validation, markdownlint.
 3. Check whether the change triggers doc updates — consult the governance table in `docs/agent-context/workflows.md`.
 4. Check cross-file consistency: Python fields match JSON schema, sample payloads validate, tests cover changed fields.
 5. For Core contract changes, draft the cross-repo impact section for the PR description.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,13 @@ jobs:
         working-directory: contracts/python
         run: pip install -e ".[dev]"
 
-      - name: Run tests
+      - name: Run type checks
         working-directory: contracts/python
-        run: pytest -v
+        run: mypy src/
+
+      - name: Run tests with coverage
+        working-directory: contracts/python
+        run: pytest --cov --cov-report=term-missing -v
 
   markdown-lint:
     name: Markdown Lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,19 +151,22 @@ See [docs/agent-context/review-checklist.md](docs/agent-context/review-checklist
 
 ## Local validation
 
-Run all three checks before submitting a PR:
+Run all four checks before submitting a PR:
 
 ```bash
-# 1. Python tests
+# 1. Python tests (with coverage)
 cd contracts/python
 pip install -e ".[dev]"
-pytest
+pytest --cov --cov-report=term-missing
 
-# 2. JSON schema validation
+# 2. Type checking
+mypy src/
+
+# 3. JSON schema validation
 cd ../..
 python -c "import json; [json.load(open(f)) for f in __import__('glob').glob('contracts/json/*.schema.json')]"
 
-# 3. Markdown lint
+# 4. Markdown lint
 # See CONTRIBUTING.md "Markdown Lint" section for the canonical command.
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
 
 ### Added
 
+- `mypy --strict` type checking added to CI and dev workflow (closes #12).
+- `pytest-cov` coverage tracking with 64% threshold (scope expansion of #12). Raise to 80% once Extended tests land (#17).
 - Agent-facing documentation system:
   - `AGENTS.md` — shared entrypoint for all coding agents (rules, repo map, authority hierarchy, forbidden behaviors, design decisions not to reopen).
   - `docs/agent-context/architecture.md` — thin pointer to canonical architecture and boundary docs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,14 @@ A "breaking contract change" is any modification that would cause existing valid
 ```bash
 cd contracts/python
 pip install -e ".[dev]"
-pytest
+pytest --cov --cov-report=term-missing
+```
+
+### Type Checking
+
+```bash
+cd contracts/python
+mypy src/
 ```
 
 ### Validate JSON Schemas

--- a/contracts/python/pyproject.toml
+++ b/contracts/python/pyproject.toml
@@ -15,10 +15,25 @@ dependencies = []
 dev = [
     "pytest>=7.4",
     "jsonschema>=4.17",
+    "mypy>=1.0",
+    "pytest-cov>=4.0",
 ]
 
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.mypy]
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["weaver_contracts"]
+
+[tool.coverage.report]
+# Baseline: 64%. Raise to 80% once Extended contract tests land (#17).
+fail_under = 64
+show_missing = true

--- a/docs/agent-context/review-checklist.md
+++ b/docs/agent-context/review-checklist.md
@@ -73,7 +73,8 @@ For Extended contract changes, the same pattern applies but with `extended.py` i
 
 ## Local validation
 
-- [ ] `pytest` passes (`cd contracts/python && pip install -e ".[dev]" && pytest`)
+- [ ] `pytest --cov` passes (`cd contracts/python && pip install -e ".[dev]" && pytest --cov --cov-report=term-missing`)
+- [ ] `mypy` passes (`cd contracts/python && mypy src/`)
 - [ ] JSON schemas parse without error
 - [ ] Markdownlint passes on all `.md` files
 

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -63,19 +63,22 @@ If the change affects a contract that a sibling repo produces or consumes, coord
 
 ## Local validation commands
 
-Run all three before submitting any PR. CI enforces all three.
+Run all four before submitting any PR. CI enforces all four.
 
 ```bash
-# 1. Python tests
+# 1. Python tests (with coverage)
 cd contracts/python
 pip install -e ".[dev]"
-pytest
+pytest --cov --cov-report=term-missing
 
-# 2. JSON schema validation
+# 2. Type checking
+mypy src/
+
+# 3. JSON schema validation
 cd ../..
 python -c "import json; [json.load(open(f)) for f in __import__('glob').glob('contracts/json/*.schema.json')]"
 
-# 3. Markdown lint
+# 4. Markdown lint
 # See CONTRIBUTING.md "Markdown Lint" section for the canonical command.
 ```
 


### PR DESCRIPTION
## What changed

Adds two quality gates to the CI pipeline and local development workflow, closing #12 (including the scope expansion in the first comment).

### mypy strict type checking
- Added `mypy>=1.0` to dev dependencies in `contracts/python/pyproject.toml`
- Configured `[tool.mypy]` with `strict = true`, `warn_return_any = true`, `warn_unused_configs = true`
- Added "Run type checks" step (`mypy src/`) to the `python-tests` job in CI, running after install and before tests

### pytest-cov coverage tracking
- Added `pytest-cov>=4.0` to dev dependencies
- Configured `[tool.coverage.run]` with `source = ["weaver_contracts"]`
- Configured `[tool.coverage.report]` with `fail_under = 64` and `show_missing = true`
- Changed CI test step from `pytest -v` to `pytest --cov --cov-report=term-missing -v`

### Documentation updates
- **CONTRIBUTING.md**: Added "Type Checking" subsection; updated pytest command to include `--cov`
- **AGENTS.md**: Updated "Local validation" section from 3 checks to 4 (added mypy); updated commands
- **.claude/CLAUDE.md**: Updated validation command list to include mypy and coverage
- **docs/agent-context/workflows.md**: Updated local validation commands section (3→4 checks)
- **docs/agent-context/review-checklist.md**: Updated validation checklist with mypy and coverage commands
- **CHANGELOG.md**: Added entries under `[Unreleased]`

## Why

The Python dataclasses must mirror JSON schemas exactly. Without type checking, drift is undetectable until runtime. Coverage tracking provides visibility into test gaps, especially as Extended contract tests are added (#17).

## Coverage threshold rationale

Set to **64%** (actual baseline) rather than the aspirational 80%. Current coverage breakdown:
- `__init__.py`: 100%
- `version.py`: 100%
- `core.py`: 88%
- `extended.py`: 0% (tests tracked by #17)
- **Total: 64.71%**

The threshold should be raised to 80% once #17 (Extended contract tests) lands.

## How verified

```
mypy src/                                     → Success: no issues found in 4 source files
pytest --cov --cov-report=term-missing -v     → 50 passed, coverage 64.71% (threshold 64% met)
JSON schema validation                        → All schemas valid
```

## Tradeoffs / risks

- Coverage threshold at 64% is conservative but prevents CI breakage before Extended tests exist
- mypy version unpinned (`>=1.0`) — consistent with existing `pytest>=7.4` pattern

## Cross-repo impact

None. This is a CI/tooling change only — no contract definitions were modified.

Closes #12