### PR TITLE
ci: add mypy strict type checking and pytest-cov to CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ A "breaking contract change" is any modification that would cause existing valid
 
 ## Local Development
 
+All commands below assume dev dependencies are installed (`pip install -e ".[dev]"` in `contracts/python/`).
+
 ### Python Package Tests
 
 ```bash

--- a/docs/agent-context/review-checklist.md
+++ b/docs/agent-context/review-checklist.md
@@ -74,7 +74,7 @@ For Extended contract changes, the same pattern applies but with `extended.py` i
 ## Local validation
 
 - [ ] `pytest --cov` passes (`cd contracts/python && pip install -e ".[dev]" && pytest --cov --cov-report=term-missing`)
-- [ ] `mypy` passes (`cd contracts/python && mypy src/`)
+- [ ] `mypy` passes (`cd contracts/python && pip install -e ".[dev]" && mypy src/`)
 - [ ] JSON schemas parse without error
 - [ ] Markdownlint passes on all `.md` files
 


### PR DESCRIPTION
## What changed

Adds two quality gates to the CI pipeline and local development workflow, closing #12 (including the scope expansion in the first comment).

### mypy strict type checking
- Added `mypy>=1.0` to dev dependencies in `contracts/python/pyproject.toml`
- Configured `[tool.mypy]` with `strict = true`, `warn_return_any = true`, `warn_unused_configs = true`
- Added "Run type checks" step (`mypy src/`) to the `python-tests` job in CI, running after install and before tests

### pytest-cov coverage tracking
- Added `pytest-cov>=4.0` to dev dependencies
- Configured `[tool.coverage.run]` with `source = ["weaver_contracts"]`
- Configured `[tool.coverage.report]` with `fail_under = 64` and `show_missing = true`
- Changed CI test step from `pytest -v` to `pytest --cov --cov-report=term-missing -v`

### Documentation updates
- **CONTRIBUTING.md**: Added "Type Checking" subsection; updated pytest command to include `--cov`; added dev-deps prerequisite note to "Local Development" section
- **AGENTS.md**: Updated "Local validation" section from 3 checks to 4 (added mypy); updated commands
- **.claude/CLAUDE.md**: Updated validation command list to include mypy and coverage
- **docs/agent-context/workflows.md**: Updated local validation commands section (3→4 checks)
- **docs/agent-context/review-checklist.md**: Updated validation checklist with mypy and coverage commands; added `pip install` to mypy checklist item
- **CHANGELOG.md**: Added entries under `[Unreleased]`

## Why

The Python dataclasses must mirror JSON schemas exactly. Without type checking, drift is undetectable until runtime. Coverage tracking provides visibility into test gaps, especially as Extended contract tests are added (#17).

## Coverage threshold rationale

Set to **64%** (actual baseline) rather than the aspirational 80%. Current coverage breakdown:
- `__init__.py`: 100%
- `version.py`: 100%
- `core.py`: 88%
- `extended.py`: 0% (tests tracked by #17)
- **Total: 64.71%**

The threshold should be raised to 80% once #17 (Extended contract tests) lands.

## How verified

```
mypy src/                                     → Success: no issues found in 4 source files
pytest --cov --cov-report=term-missing -v     → 50 passed, coverage 64.71% (threshold 64% met)
JSON schema validation                        → All schemas valid
```

## Tradeoffs / risks

- Coverage threshold at 64% is conservative but prevents CI breakage before Extended tests exist
- mypy version unpinned (`>=1.0`) — consistent with existing `pytest>=7.4` pattern

## Cross-repo impact

None. This is a CI/tooling change only — no contract definitions were modified.

Closes #12