### PR TITLE
test: add Extended contract sample payloads and unit tests

### DIFF
--- a/contracts/python/pyproject.toml
+++ b/contracts/python/pyproject.toml
@@ -34,6 +34,6 @@ testpaths = ["tests"]
 source = ["weaver_contracts"]
 
 [tool.coverage.report]
-# Baseline: 64%. Raise to 80% once Extended contract tests land (#17).
-fail_under = 64
+# Raised to 80% when Extended contract tests landed (#17, PR #34).
+fail_under = 80
 show_missing = true

--- a/contracts/python/tests/test_extended.py
+++ b/contracts/python/tests/test_extended.py
@@ -1,0 +1,260 @@
+"""Tests for Extended contract dataclasses and sample payload construction."""
+
+import json
+import pathlib
+from dataclasses import asdict
+from typing import Optional
+
+import pytest
+
+from weaver_contracts.extended import (
+    ExtendedFrameMetadata,
+    ExtendedSelectableItemMetadata,
+    RedactionPolicy,
+    RiskAssessment,
+    SchemaFingerprint,
+    TelemetryHint,
+    UIHint,
+)
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.parent.parent
+PAYLOADS_DIR = REPO_ROOT / "examples" / "sample_payloads"
+
+
+def load_payload(name: str) -> dict:
+    path = PAYLOADS_DIR / f"{name}.json"
+    with open(path) as f:
+        return json.load(f)
+
+
+def build_telemetry_hint(data: Optional[dict]) -> Optional[TelemetryHint]:
+    if data is None:
+        return None
+    return TelemetryHint(
+        trace_id=data.get("trace_id"),
+        span_id=data.get("span_id"),
+        baggage=data.get("baggage", {}),
+    )
+
+
+def build_schema_fingerprint(
+    data: Optional[dict],
+) -> Optional[SchemaFingerprint]:
+    if data is None:
+        return None
+    return SchemaFingerprint(
+        schema_id=data["schema_id"],
+        schema_version=data["schema_version"],
+        content_hash=data.get("content_hash"),
+        hash_algorithm=data.get("hash_algorithm", "sha256"),
+    )
+
+
+def build_redaction_policy(data: Optional[dict]) -> Optional[RedactionPolicy]:
+    if data is None:
+        return None
+    return RedactionPolicy(
+        policy_id=data["policy_id"],
+        redacted_fields=data.get("redacted_fields", []),
+        truncated_fields=data.get("truncated_fields", []),
+        redaction_reason=data.get("redaction_reason"),
+        pii_detected=data.get("pii_detected", False),
+        pii_types=data.get("pii_types", []),
+    )
+
+
+def build_ui_hint(data: Optional[dict]) -> Optional[UIHint]:
+    if data is None:
+        return None
+    return UIHint(
+        icon=data.get("icon"),
+        color=data.get("color"),
+        priority=data.get("priority"),
+        group=data.get("group"),
+        disabled=data.get("disabled", False),
+        tooltip=data.get("tooltip"),
+    )
+
+
+def build_risk_assessment(data: Optional[dict]) -> Optional[RiskAssessment]:
+    if data is None:
+        return None
+    return RiskAssessment(
+        risk_level=data.get("risk_level", "low"),
+        risk_reasons=data.get("risk_reasons", []),
+        requires_human_approval=data.get("requires_human_approval", False),
+        approval_principal=data.get("approval_principal"),
+        mitigations=data.get("mitigations", []),
+    )
+
+
+class TestTelemetryHint:
+    def test_valid_from_payload(self):
+        payload = load_payload("telemetry_hint")
+        hint = build_telemetry_hint(payload)
+        assert hint is not None
+        assert hint.trace_id == payload["trace_id"]
+        assert hint.span_id == payload["span_id"]
+        assert hint.baggage["tenant"] == "acme"
+
+    def test_defaults_allow_empty_values(self):
+        hint = TelemetryHint()
+        assert hint.trace_id is None
+        assert hint.span_id is None
+        assert hint.baggage == {}
+
+    def test_serialization(self):
+        hint = TelemetryHint(
+            trace_id="trace-1",
+            span_id="span-1",
+            baggage={"k": "v"},
+        )
+        data = asdict(hint)
+        json.dumps(data)
+        assert data["baggage"]["k"] == "v"
+
+
+class TestSchemaFingerprint:
+    def test_valid_from_payload(self):
+        payload = load_payload("schema_fingerprint")
+        fp = build_schema_fingerprint(payload)
+        assert fp is not None
+        assert fp.schema_id == payload["schema_id"]
+        assert fp.schema_version == payload["schema_version"]
+
+    def test_empty_schema_id_raises(self):
+        with pytest.raises(ValueError, match="schema_id must be non-empty"):
+            SchemaFingerprint(schema_id="", schema_version="0.1.1")
+
+    def test_serialization(self):
+        fp = SchemaFingerprint(schema_id="s", schema_version="1.0.0")
+        data = asdict(fp)
+        json.dumps(data)
+        assert data["hash_algorithm"] == "sha256"
+
+
+class TestRedactionPolicy:
+    def test_valid_from_payload(self):
+        payload = load_payload("redaction_policy")
+        policy = build_redaction_policy(payload)
+        assert policy is not None
+        assert policy.policy_id == payload["policy_id"]
+        assert policy.pii_detected is True
+
+    def test_empty_policy_id_raises(self):
+        with pytest.raises(ValueError, match="policy_id must be non-empty"):
+            RedactionPolicy(policy_id="")
+
+    def test_serialization(self):
+        policy = RedactionPolicy(policy_id="rp-1", redacted_fields=["secret"])
+        data = asdict(policy)
+        json.dumps(data)
+        assert data["redacted_fields"] == ["secret"]
+
+
+class TestUIHint:
+    def test_valid_from_payload(self):
+        payload = load_payload("ui_hint")
+        hint = build_ui_hint(payload)
+        assert hint is not None
+        assert hint.icon == payload["icon"]
+        assert hint.priority == payload["priority"]
+
+    def test_defaults(self):
+        hint = UIHint()
+        assert hint.disabled is False
+        assert hint.tooltip is None
+
+    def test_serialization(self):
+        hint = UIHint(icon="bolt", disabled=True)
+        data = asdict(hint)
+        json.dumps(data)
+        assert data["disabled"] is True
+
+
+class TestRiskAssessment:
+    def test_valid_from_payload(self):
+        payload = load_payload("risk_assessment")
+        risk = build_risk_assessment(payload)
+        assert risk is not None
+        assert risk.risk_level == "medium"
+        assert risk.requires_human_approval is True
+
+    def test_invalid_risk_level_raises(self):
+        with pytest.raises(ValueError, match="risk_level must be one of"):
+            RiskAssessment(risk_level="unknown")
+
+    def test_serialization(self):
+        risk = RiskAssessment(risk_level="low", risk_reasons=["read-only"])
+        data = asdict(risk)
+        json.dumps(data)
+        assert data["risk_reasons"] == ["read-only"]
+
+
+class TestExtendedFrameMetadata:
+    def test_valid_from_payload(self):
+        payload = load_payload("extended_frame_metadata")
+        metadata = ExtendedFrameMetadata(
+            redaction_policy=build_redaction_policy(
+                payload.get("redaction_policy")
+            ),
+            telemetry=build_telemetry_hint(payload.get("telemetry")),
+            schema_fingerprint=build_schema_fingerprint(
+                payload.get("schema_fingerprint")
+            ),
+            confidence_score=payload.get("confidence_score"),
+            source_capability_version=payload.get("source_capability_version"),
+            extra=payload.get("extra", {}),
+        )
+        assert metadata.redaction_policy is not None
+        assert metadata.redaction_policy.policy_id == "rp-safe-default"
+        assert metadata.telemetry is not None
+        assert metadata.telemetry.trace_id == "trace-20260308-002"
+
+    def test_defaults(self):
+        metadata = ExtendedFrameMetadata()
+        assert metadata.redaction_policy is None
+        assert metadata.telemetry is None
+        assert metadata.extra == {}
+
+    def test_serialization(self):
+        metadata = ExtendedFrameMetadata(
+            telemetry=TelemetryHint(trace_id="trace-3"),
+            extra={"region": "eu-west-1"},
+        )
+        data = asdict(metadata)
+        json.dumps(data)
+        assert data["telemetry"]["trace_id"] == "trace-3"
+
+
+class TestExtendedSelectableItemMetadata:
+    def test_valid_from_payload(self):
+        payload = load_payload("extended_selectable_item_metadata")
+        metadata = ExtendedSelectableItemMetadata(
+            ui_hint=build_ui_hint(payload.get("ui_hint")),
+            risk_assessment=build_risk_assessment(
+                payload.get("risk_assessment")
+            ),
+            estimated_duration_ms=payload.get("estimated_duration_ms"),
+            requires_confirmation=payload.get("requires_confirmation", False),
+            extra=payload.get("extra", {}),
+        )
+        assert metadata.ui_hint is not None
+        assert metadata.ui_hint.icon == "rocket"
+        assert metadata.risk_assessment is not None
+        assert metadata.risk_assessment.risk_level == "low"
+
+    def test_defaults(self):
+        metadata = ExtendedSelectableItemMetadata()
+        assert metadata.ui_hint is None
+        assert metadata.risk_assessment is None
+        assert metadata.requires_confirmation is False
+
+    def test_serialization(self):
+        metadata = ExtendedSelectableItemMetadata(
+            ui_hint=UIHint(icon="wand"),
+            estimated_duration_ms=500,
+        )
+        data = asdict(metadata)
+        json.dumps(data)
+        assert data["estimated_duration_ms"] == 500

--- a/contracts/python/tests/test_extended.py
+++ b/contracts/python/tests/test_extended.py
@@ -126,6 +126,10 @@ class TestSchemaFingerprint:
         with pytest.raises(ValueError, match="schema_id must be non-empty"):
             SchemaFingerprint(schema_id="", schema_version="0.1.1")
 
+    def test_empty_schema_version_raises(self):
+        with pytest.raises(ValueError, match="schema_version must be non-empty"):
+            SchemaFingerprint(schema_id="s", schema_version="")
+
     def test_serialization(self):
         fp = SchemaFingerprint(schema_id="s", schema_version="1.0.0")
         data = asdict(fp)

--- a/examples/sample_payloads/extended_frame_metadata.json
+++ b/examples/sample_payloads/extended_frame_metadata.json
@@ -21,7 +21,7 @@
   "schema_fingerprint": {
     "schema_id": "https://weaver-spec.dev/contracts/v0/frame.schema.json",
     "schema_version": "0.1.1",
-    "content_hash": "1111222233334444555566667777888899990000",
+    "content_hash": "1111222233334444555566667777888899990000111122223333444455556666",
     "hash_algorithm": "sha256"
   },
   "confidence_score": 0.92,

--- a/examples/sample_payloads/extended_frame_metadata.json
+++ b/examples/sample_payloads/extended_frame_metadata.json
@@ -1,0 +1,33 @@
+{
+  "redaction_policy": {
+    "policy_id": "rp-safe-default",
+    "redacted_fields": [
+      "password"
+    ],
+    "truncated_fields": [
+      "raw_payload"
+    ],
+    "redaction_reason": "Default safe rendering policy",
+    "pii_detected": false,
+    "pii_types": []
+  },
+  "telemetry": {
+    "trace_id": "trace-20260308-002",
+    "span_id": "span-20260308-002",
+    "baggage": {
+      "workflow": "routing"
+    }
+  },
+  "schema_fingerprint": {
+    "schema_id": "https://weaver-spec.dev/contracts/v0/frame.schema.json",
+    "schema_version": "0.1.1",
+    "content_hash": "1111222233334444555566667777888899990000",
+    "hash_algorithm": "sha256"
+  },
+  "confidence_score": 0.92,
+  "source_capability_version": "2.4.1",
+  "extra": {
+    "region": "eu-west-1",
+    "latency_ms": 128
+  }
+}

--- a/examples/sample_payloads/extended_selectable_item_metadata.json
+++ b/examples/sample_payloads/extended_selectable_item_metadata.json
@@ -1,0 +1,27 @@
+{
+  "ui_hint": {
+    "icon": "rocket",
+    "color": "blue",
+    "priority": 5,
+    "group": "recommended",
+    "disabled": false,
+    "tooltip": "Fastest option for this context."
+  },
+  "risk_assessment": {
+    "risk_level": "low",
+    "risk_reasons": [
+      "read-only operation"
+    ],
+    "requires_human_approval": false,
+    "approval_principal": null,
+    "mitigations": [
+      "sandboxed execution"
+    ]
+  },
+  "estimated_duration_ms": 1500,
+  "requires_confirmation": true,
+  "extra": {
+    "runbook": "rbk-42",
+    "team": "platform"
+  }
+}

--- a/examples/sample_payloads/redaction_policy.json
+++ b/examples/sample_payloads/redaction_policy.json
@@ -1,0 +1,16 @@
+{
+  "policy_id": "rp-standard-001",
+  "redacted_fields": [
+    "ssn",
+    "api_key"
+  ],
+  "truncated_fields": [
+    "stack_trace"
+  ],
+  "redaction_reason": "PII and secret handling policy",
+  "pii_detected": true,
+  "pii_types": [
+    "person_name",
+    "credential"
+  ]
+}

--- a/examples/sample_payloads/risk_assessment.json
+++ b/examples/sample_payloads/risk_assessment.json
@@ -1,0 +1,13 @@
+{
+  "risk_level": "medium",
+  "risk_reasons": [
+    "writes external system",
+    "handles sensitive metadata"
+  ],
+  "requires_human_approval": true,
+  "approval_principal": "ops-reviewer",
+  "mitigations": [
+    "dry-run available",
+    "audit trail enabled"
+  ]
+}

--- a/examples/sample_payloads/schema_fingerprint.json
+++ b/examples/sample_payloads/schema_fingerprint.json
@@ -1,0 +1,6 @@
+{
+  "schema_id": "https://weaver-spec.dev/contracts/v0/frame.schema.json",
+  "schema_version": "0.1.1",
+  "content_hash": "3f786850e387550fdab836ed7e6dc881de23001b",
+  "hash_algorithm": "sha256"
+}

--- a/examples/sample_payloads/schema_fingerprint.json
+++ b/examples/sample_payloads/schema_fingerprint.json
@@ -1,6 +1,6 @@
 {
   "schema_id": "https://weaver-spec.dev/contracts/v0/frame.schema.json",
   "schema_version": "0.1.1",
-  "content_hash": "3f786850e387550fdab836ed7e6dc881de23001b",
+  "content_hash": "3f786850e387550fdab836ed7e6dc881de2300123f786850e387550fdab836ed",
   "hash_algorithm": "sha256"
 }

--- a/examples/sample_payloads/telemetry_hint.json
+++ b/examples/sample_payloads/telemetry_hint.json
@@ -1,0 +1,8 @@
+{
+  "trace_id": "trace-20260308-001",
+  "span_id": "span-20260308-001",
+  "baggage": {
+    "tenant": "acme",
+    "request_id": "req-20260308-001"
+  }
+}

--- a/examples/sample_payloads/ui_hint.json
+++ b/examples/sample_payloads/ui_hint.json
@@ -1,0 +1,8 @@
+{
+  "icon": "shield-check",
+  "color": "teal",
+  "priority": 10,
+  "group": "security",
+  "disabled": false,
+  "tooltip": "Requires elevated permissions."
+}


### PR DESCRIPTION
### What/Why

Closes #17

- Adds unit tests for all Extended contract types in contracts/python/tests/test_extended.py
- Adds 7 valid sample payloads for Extended types in examples/sample_payloads/
- No changes to core contracts, schemas, or CI config

### Testing performed
- All tests pass (pytest, 72 tests, coverage 91.60%)
- Type checks (mypy) clean
- All sample payloads validate as JSON
- Coverage threshold raised to 80% (`fail_under = 80`); `extended.py` at 100%

### Docs/AI agent instructions
- No changes to docs or agent instructions required (Extended contracts are Python-only, not covered by JSON schemas or doc invariants)

### Risks/rollout notes
- None; additive tests and payloads only

---

### Review fixes

**bbd012e** — Corrected `content_hash` in `schema_fingerprint.json` and the nested `schema_fingerprint` object in `extended_frame_metadata.json`: both had 40-char (SHA-1 length) values while `hash_algorithm` was set to `sha256`. Updated to 64-char placeholders for internal consistency.

**2c4f542** — Raised `fail_under` from 64 → 80 in `pyproject.toml` (the file comment named #17 as the trigger; coverage is 91.60%). Added `test_empty_schema_version_raises` to `TestSchemaFingerprint`, covering the previously untested `schema_version` guard in `SchemaFingerprint.__post_init__`; `extended.py` is now at 100% coverage.

See PR for validation evidence and details.