### PR TITLE
docs: walkthroughs + sequence diagrams for failure, multi-agent, and partial-match routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,81 @@ jobs:
           print(f'Validated {len(files)} payload(s)')
           "
 
+  validate-walkthroughs:
+    name: Validate Walkthrough Payloads
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install jsonschema
+        run: pip install jsonschema
+
+      - name: Validate inline JSON payloads against schemas
+        run: |
+          python -c "
+          import glob, json, re, sys
+          from pathlib import Path
+          from jsonschema import Draft202012Validator
+          from referencing import Registry, Resource
+          from referencing.jsonschema import DRAFT202012
+
+          schemas_by_name = {}
+          registry = Registry()
+          for p in Path('contracts/json').glob('*.schema.json'):
+              name = p.stem.removesuffix('.schema')
+              schema = json.loads(p.read_text(encoding='utf-8'))
+              schemas_by_name[name] = schema
+              registry = registry.with_resource(
+                  uri=schema['\$id'],
+                  resource=Resource(contents=schema, specification=DRAFT202012),
+              )
+
+          fence = chr(96) * 3
+          pattern = re.compile(
+              r'<!-- schema: (\S+) -->\s*' + fence + r'json\s*(.*?)\s*' + fence,
+              re.DOTALL,
+          )
+
+          md_files = sorted(
+              set(glob.glob('examples/**/*.md', recursive=True))
+              | set(glob.glob('docs/**/*.md', recursive=True))
+          )
+
+          failures = []
+          total = 0
+          for f in md_files:
+              text = Path(f).read_text(encoding='utf-8')
+              for m in pattern.finditer(text):
+                  total += 1
+                  schema_name, body = m.group(1), m.group(2)
+                  if schema_name not in schemas_by_name:
+                      failures.append(f'{f}: unknown schema {schema_name!r}')
+                      continue
+                  try:
+                      payload = json.loads(body)
+                  except json.JSONDecodeError as e:
+                      failures.append(f'{f} ({schema_name}): JSON parse error: {e}')
+                      continue
+                  v = Draft202012Validator(schemas_by_name[schema_name], registry=registry)
+                  for err in sorted(v.iter_errors(payload), key=lambda e: list(e.absolute_path)):
+                      path = '/'.join(str(x) for x in err.absolute_path) or '<root>'
+                      failures.append(f'{f} ({schema_name}) at {path}: {err.message}')
+
+          print(f'Validated {total} inline payload(s) across {len(md_files)} Markdown file(s).')
+          if failures:
+              for line in failures:
+                  print(f'FAIL: {line}', file=sys.stderr)
+              sys.exit(1)
+          print('All inline payloads pass schema validation.')
+          "
+
   python-tests:
     name: Python Package Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,9 @@ jobs:
               for line in failures:
                   print(f'FAIL: {line}', file=sys.stderr)
               sys.exit(1)
+          if total == 0:
+              print('FAIL: No <!-- schema: ... --> markers found in any Markdown file.', file=sys.stderr)
+              sys.exit(1)
           print('All inline payloads pass schema validation.')
           PYEOF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Validate inline JSON payloads against schemas
         run: |
-          python -c "
+          python << 'PYEOF'
           import glob, json, re, sys
           from pathlib import Path
           from jsonschema import Draft202012Validator
@@ -86,7 +86,7 @@ jobs:
               schema = json.loads(p.read_text(encoding='utf-8'))
               schemas_by_name[name] = schema
               registry = registry.with_resource(
-                  uri=schema['\$id'],
+                  uri=schema['$id'],
                   resource=Resource(contents=schema, specification=DRAFT202012),
               )
 
@@ -116,7 +116,11 @@ jobs:
                   except json.JSONDecodeError as e:
                       failures.append(f'{f} ({schema_name}): JSON parse error: {e}')
                       continue
-                  v = Draft202012Validator(schemas_by_name[schema_name], registry=registry)
+                  v = Draft202012Validator(
+                      schemas_by_name[schema_name],
+                      registry=registry,
+                      format_checker=Draft202012Validator.FORMAT_CHECKER,
+                  )
                   for err in sorted(v.iter_errors(payload), key=lambda e: list(e.absolute_path)):
                       path = '/'.join(str(x) for x in err.absolute_path) or '<root>'
                       failures.append(f'{f} ({schema_name}) at {path}: {err.message}')
@@ -127,7 +131,7 @@ jobs:
                   print(f'FAIL: {line}', file=sys.stderr)
               sys.exit(1)
           print('All inline payloads pass schema validation.')
-          "
+          PYEOF
 
   python-tests:
     name: Python Package Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
 
 ## [Unreleased]
 
+### Added
+
+- `examples/failure_scenarios.md` — three failure-path walkthroughs (routing failure, authorization denial, partial execution failure) with contract payloads at every boundary. Closes #18.
+- `examples/multi_agent_orchestration.md` — two-agent ChainWeaver-coordinated walkthrough showing the full `RoutingDecision` → `Frame` → re-routing cycle. Closes #22.
+- `examples/partial_capability_routing.md` — partial-match routing walkthrough with three overlapping candidates and a ranked `ChoiceCard`. Closes #26.
+- `docs/SEQUENCE_DIAGRAMS.md` — three new Mermaid sequence diagrams (sections 4 — 6) for the routing-failure, authorization-denial, and partial-execution-failure paths. Diagrams use the same scenarios as `examples/failure_scenarios.md`. Closes #25.
+- CI step in `.github/workflows/ci.yml` that extracts inline JSON payloads from the new walkthroughs (and `docs/SEQUENCE_DIAGRAMS.md`) and validates each against its declared schema in `contracts/json/` using `jsonschema`. Blocks merges on walkthrough/contract drift.
+
+**No Core contract changes** — JSON Schemas, Python types, and existing sample payloads are unchanged.
+
 ---
 
 ## [0.2.0] — 2026-04-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
 - `examples/multi_agent_orchestration.md` — two-agent ChainWeaver-coordinated walkthrough showing the full `RoutingDecision` → `Frame` → re-routing cycle. Closes #22.
 - `examples/partial_capability_routing.md` — partial-match routing walkthrough with three overlapping candidates and a ranked `ChoiceCard`. Closes #26.
 - `docs/SEQUENCE_DIAGRAMS.md` — three new Mermaid sequence diagrams (sections 4 — 6) for the routing-failure, authorization-denial, and partial-execution-failure paths. Diagrams use the same scenarios as `examples/failure_scenarios.md`. Closes #25.
-- CI step in `.github/workflows/ci.yml` that extracts inline JSON payloads from the new walkthroughs (and `docs/SEQUENCE_DIAGRAMS.md`) and validates each against its declared schema in `contracts/json/` using `jsonschema`. Blocks merges on walkthrough/contract drift.
+- CI step in `.github/workflows/ci.yml` that extracts inline JSON payloads from the new walkthroughs (and `docs/SEQUENCE_DIAGRAMS.md`) and validates each against its declared schema in `contracts/json/` using `jsonschema`, with `format`-keyword enforcement (e.g., `date-time`) and a non-zero-marker guard to fail loud on accidental marker removal. Blocks merges on walkthrough/contract drift.
 
 **No Core contract changes** — JSON Schemas, Python types, and existing sample payloads are unchanged.
 

--- a/docs/SEQUENCE_DIAGRAMS.md
+++ b/docs/SEQUENCE_DIAGRAMS.md
@@ -118,3 +118,100 @@ sequenceDiagram
 - Each step is independently authorized via a `CapabilityToken`.
 - contextweaver never interacts with agent-kernel directly; ChainWeaver mediates.
 - The audit log receives a `TraceEvent` for every authorization and execution.
+
+---
+
+## 4. Routing Failure (No Matching Capabilities)
+
+Used when contextweaver cannot find any registered capability above the match threshold. The full narrative walkthrough is [`examples/failure_scenarios.md`](../examples/failure_scenarios.md) — scenario 1.
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant contextweaver
+
+    Caller->>contextweaver: compile_context(state, candidate_tools)
+    Note over contextweaver: Score candidates against intent.<br/>0 of N clear the match threshold.
+    Note over contextweaver: Build fallback ChoiceCard with a single<br/>"no-match" SelectableItem (capability_id omitted).
+    contextweaver-->>Caller: RoutingDecision(selected_item_id="no-match")
+
+    Note over Caller: Detect "no-match" sentinel<br/>and surface to user / retry.
+```
+
+**Key observations:**
+
+- agent-kernel is **not** invoked: no `PolicyDecision`, no `TraceEvent`, no execution side effects.
+- The schema still requires `choice_cards.minItems: 1` and `items.minItems: 1` — contextweaver satisfies it with a fallback `SelectableItem` whose `capability_id` is omitted, so the caller can detect "no match" without inventing a new contract field.
+- `context_summary` carries the diagnostic ("0 of N capabilities above threshold") for audit and follow-up routing.
+
+---
+
+## 5. Authorization Denial (CapabilityToken Rejected)
+
+Used when routing succeeds but the policy engine refuses to authorize the requested capability — for example, the `CapabilityToken` scope does not include the selected capability, or the token has expired. The full narrative walkthrough is [`examples/failure_scenarios.md`](../examples/failure_scenarios.md) — scenario 2.
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant contextweaver
+    participant AgentKernel as agent-kernel
+    participant PolicyEngine as Policy Engine
+    participant AuditLog as Audit Log
+
+    Caller->>contextweaver: compile_context(state, candidate_tools)
+    contextweaver-->>Caller: RoutingDecision(selected_item_id)
+
+    Caller->>AgentKernel: execute(RoutingDecision, CapabilityToken)
+    AgentKernel->>PolicyEngine: authorize(capability_id, token)
+    Note over PolicyEngine: Token scope does not include<br/>requested capability_id.
+    PolicyEngine-->>AgentKernel: PolicyDecision(decision="deny", reason)
+    AgentKernel->>AuditLog: TraceEvent(capability_denied, outcome="failure")
+
+    AgentKernel-->>Caller: PolicyDecision(deny)
+```
+
+**Key observations:**
+
+- No `Tool.invoke` call is made; no `Frame` and no `Handle` are produced.
+- `PolicyDecision` crosses from agent-kernel to the caller for diagnostics (per the `docs/BOUNDARIES.md` artifact ownership table).
+- The `TraceEvent.decision_id` matches `PolicyDecision.decision_id`, making the denial fully attributable in audit.
+- This path is the canonical enforcement point for invariants I-02 (every execution authorized + auditable) and I-06 (`CapabilityToken`s are scoped).
+
+---
+
+## 6. Partial Execution Failure (Tool Errors Mid-Stream)
+
+Used when authorization succeeds and the tool starts executing but errors before producing a usable artifact (timeout, network failure, unhandled exception in the tool implementation). The firewall still produces a `Frame` so the caller has an LLM-safe record of the failure. The full narrative walkthrough is [`examples/failure_scenarios.md`](../examples/failure_scenarios.md) — scenario 3.
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant AgentKernel as agent-kernel
+    participant PolicyEngine as Policy Engine
+    participant Tool
+    participant Firewall
+    participant AuditLog as Audit Log
+
+    Caller->>AgentKernel: execute(RoutingDecision, CapabilityToken)
+    AgentKernel->>PolicyEngine: authorize(capability_id, token)
+    PolicyEngine-->>AgentKernel: PolicyDecision(allow)
+    AgentKernel->>AuditLog: TraceEvent(capability_authorized, outcome="success")
+
+    AgentKernel->>Tool: invoke(args)
+    Note over Tool: Backend times out.<br/>Tool raises BackendTimeoutError.<br/>No raw artifact produced.
+    Tool-->>AgentKernel: error envelope (class + sanitized message)
+
+    AgentKernel->>Firewall: build_error_frame(error)
+    Note over Firewall: Strip stack trace, internal IDs.<br/>Emit Frame with handle_refs=[].
+    Firewall-->>AgentKernel: Frame(error state, handle_refs=[])
+    AgentKernel->>AuditLog: TraceEvent(capability_executed, outcome="failure", error_message)
+
+    AgentKernel-->>Caller: Frame(error state)
+```
+
+**Key observations:**
+
+- Even on failure, the contract guarantees a `Frame` for caller consumption — there is no "raw error" escape hatch (invariant I-01 still applies).
+- `handle_refs` is empty because no artifact was produced. `HandleStore` is **not** involved in this scenario.
+- The firewall is responsible for redacting backend internals (stack traces, hostnames, internal request IDs) before they reach `structured_data`.
+- The success and failure `TraceEvent`s share `decision_id`, so the audit log records "this capability was authorized then executed with failure" as a coherent pair.

--- a/examples/failure_scenarios.md
+++ b/examples/failure_scenarios.md
@@ -1,0 +1,260 @@
+# Failure Scenarios Walkthrough
+
+This example traces three failure paths through the Weaver stack: routing failure (no matching capabilities), authorization denial (`CapabilityToken` rejected by the policy engine), and partial execution failure (tool errors mid-stream). Each scenario shows the contract payloads produced at every boundary so adopters can build error-tolerant integrations.
+
+The happy path is covered in [`minimal_e2e_sequence.md`](minimal_e2e_sequence.md). The Mermaid diagrams for the same three scenarios are in [`docs/SEQUENCE_DIAGRAMS.md`](../docs/SEQUENCE_DIAGRAMS.md) sections 4 — 6.
+
+---
+
+## Scenarios
+
+| Scenario | Where it fails | Caller receives | Primary invariants exercised |
+| ---------- | ---------------- | ----------------- | ------------------------------ |
+| 1. Routing failure | contextweaver — no capability matches the request | `RoutingDecision` with a fallback `ChoiceCard` and a `context_summary` explaining the miss | I-03 |
+| 2. Authorization denial | agent-kernel — policy engine rejects the `CapabilityToken` | `PolicyDecision` with `decision = "deny"` and a `TraceEvent` of type `capability_denied` | I-02, I-06 |
+| 3. Partial execution failure | agent-kernel — tool starts but errors before producing a usable artifact | `Frame` with an error summary, empty `handle_refs`, and a `TraceEvent` with `outcome = "failure"` | I-01, I-02, I-05 |
+
+Inline payload conventions: every JSON block is preceded by a `<!-- schema: <name> -->` marker that names the schema it validates against. CI extracts these blocks and validates them against `contracts/json/<name>.schema.json`.
+
+---
+
+## Scenario 1: Routing failure (no matching capabilities)
+
+### Setup
+
+A caller submits a request whose intent does not overlap any capability registered in the agent's tool inventory.
+
+- **User request:** "Calculate my company's tax liability for Q3."
+- **Registered capabilities (excerpt):** `org.myapp.search_docs`, `org.myapp.fetch_doc_page`, `org.myapp.list_recent_docs`. None of them perform tax calculations or numeric reasoning.
+
+### Step 1: contextweaver evaluates the request
+
+contextweaver scores every registered capability against the request intent. None of them clear the minimum match threshold.
+
+Rather than emit an empty payload (the schema requires `choice_cards` with `minItems: 1` and each `ChoiceCard` requires `items` with `minItems: 1`), contextweaver emits a fallback `ChoiceCard` carrying a single sentinel `SelectableItem`. The fallback item has no `capability_id`, so the caller can detect it programmatically.
+
+### Step 2: RoutingDecision emitted
+
+<!-- schema: routing_decision -->
+```json
+{
+  "id": "rd-20260513-fail-001",
+  "choice_cards": [
+    {
+      "id": "card-no-match",
+      "context_hint": "No registered capability matches the request. Surface the fallback to the caller for clarification or escalation.",
+      "items": [
+        {
+          "id": "no-match",
+          "label": "No matching capability",
+          "description": "No registered capability can satisfy this request. Ask the caller to rephrase or escalate to a human reviewer."
+        }
+      ]
+    }
+  ],
+  "selected_item_id": "no-match",
+  "selected_card_id": "card-no-match",
+  "timestamp": "2026-05-13T09:14:22Z",
+  "context_summary": "0 of 247 registered capabilities scored above the match threshold for request: 'Calculate my company's tax liability for Q3'. Returning fallback ChoiceCard."
+}
+```
+
+### Step 3: Caller receives the RoutingDecision
+
+The caller inspects `selected_item_id`. The literal value `"no-match"` (or absence of `capability_id` on the resolved item) is the documented signal that no execution will occur.
+
+Because contextweaver does not execute capabilities (per [`docs/BOUNDARIES.md`](../docs/BOUNDARIES.md) — "Routing does not execute"), agent-kernel is never invoked, no `PolicyDecision` is produced, and no `TraceEvent` is appended for this turn. The caller decides how to surface the miss — typically a clarification prompt back to the user.
+
+---
+
+## Scenario 2: Authorization denial (CapabilityToken rejected)
+
+### Setup
+
+Routing succeeds and selects a real capability, but the caller's `CapabilityToken` does not authorize that capability. The denial happens inside agent-kernel's policy engine.
+
+- **User request:** "Delete the production retry-policy document."
+- **Selected capability:** `org.myapp.delete_doc_page`.
+- **Token scope:** the caller's session token authorizes `org.myapp.search_docs`, `org.myapp.fetch_doc_page`, and `org.myapp.list_recent_docs` — but **not** `org.myapp.delete_doc_page`.
+
+### Step 1: RoutingDecision produced (succeeds)
+
+contextweaver returns a normal `RoutingDecision`. Routing has no visibility into authorization; the scope mismatch is detected one layer later by agent-kernel.
+
+### Step 2: CapabilityToken presented to agent-kernel
+
+<!-- schema: capability_token -->
+```json
+{
+  "token_id": "tok-20260513-readonly-42",
+  "principal": "agent-session-7f3a",
+  "scope": [
+    "org.myapp.search_docs",
+    "org.myapp.fetch_doc_page",
+    "org.myapp.list_recent_docs"
+  ],
+  "issued_at": "2026-05-13T09:00:00Z",
+  "expires_at": "2026-05-13T10:00:00Z",
+  "single_use": false,
+  "issuer": "agent-kernel-prod-1",
+  "metadata": {
+    "session_id": "sess-20260513-xyz",
+    "request_id": "req-20260513-002"
+  }
+}
+```
+
+### Step 3: Policy engine evaluates the request
+
+The policy engine checks the requested `capability_id` against the token scope:
+
+- Is `org.myapp.delete_doc_page` listed in `scope`? **No.**
+- Is the token unexpired? Yes (`expires_at` 2026-05-13T10:00:00Z is after `2026-05-13T09:14:30Z`).
+- Result: scope mismatch — deny.
+
+### Step 4: PolicyDecision emitted
+
+<!-- schema: policy_decision -->
+```json
+{
+  "decision_id": "pd-20260513-deny-001",
+  "decision": "deny",
+  "capability_id": "org.myapp.delete_doc_page",
+  "principal": "agent-session-7f3a",
+  "token_id": "tok-20260513-readonly-42",
+  "reason": "Token scope does not include the requested capability. Requested 'org.myapp.delete_doc_page'; scope authorizes only documentation read operations.",
+  "timestamp": "2026-05-13T09:14:30Z"
+}
+```
+
+### Step 5: TraceEvent appended to the audit log
+
+<!-- schema: trace_event -->
+```json
+{
+  "event_id": "te-20260513-deny-001",
+  "event_type": "capability_denied",
+  "timestamp": "2026-05-13T09:14:30Z",
+  "capability_id": "org.myapp.delete_doc_page",
+  "principal": "agent-session-7f3a",
+  "decision_id": "pd-20260513-deny-001",
+  "outcome": "failure",
+  "error_message": "Token scope does not include requested capability."
+}
+```
+
+### Step 6: Caller receives the PolicyDecision
+
+agent-kernel does **not** invoke the tool, does **not** produce a `Frame`, and does **not** generate a `Handle`. The caller receives the `PolicyDecision` (`docs/BOUNDARIES.md` artifact ownership: PolicyDecision may cross from agent-kernel to caller for diagnostics). The denial is fully attributable through `decision_id` ↔ `event_id`.
+
+---
+
+## Scenario 3: Partial execution failure (tool errors mid-stream)
+
+### Setup
+
+Routing and authorization both succeed. Tool invocation begins but fails before producing a usable artifact (a timeout, a network error, or an exception inside the tool implementation).
+
+- **User request:** "Search the docs for 'retry policies'."
+- **Selected capability:** `org.myapp.search_docs`.
+- **Token:** authorizes `org.myapp.search_docs`, unexpired.
+- **Failure mode:** the search index backend times out 8 seconds into the request; the tool wrapper raises `BackendTimeoutError` before any result rows are produced.
+
+### Step 1: PolicyDecision allow (succeeds)
+
+<!-- schema: policy_decision -->
+```json
+{
+  "decision_id": "pd-20260513-allow-077",
+  "decision": "allow",
+  "capability_id": "org.myapp.search_docs",
+  "principal": "agent-session-7f3a",
+  "token_id": "tok-20260513-readonly-42",
+  "timestamp": "2026-05-13T09:21:00Z"
+}
+```
+
+### Step 2: TraceEvent `capability_authorized` appended
+
+<!-- schema: trace_event -->
+```json
+{
+  "event_id": "te-20260513-auth-077",
+  "event_type": "capability_authorized",
+  "timestamp": "2026-05-13T09:21:00Z",
+  "capability_id": "org.myapp.search_docs",
+  "principal": "agent-session-7f3a",
+  "decision_id": "pd-20260513-allow-077",
+  "outcome": "success"
+}
+```
+
+### Step 3: Tool invocation begins and fails
+
+The tool wrapper calls the backend search service. After 8 seconds the backend returns no rows and the wrapper raises `BackendTimeoutError("upstream timeout after 8000ms")`. No raw result document is produced.
+
+### Step 4: Firewall produces an error Frame
+
+Even with no raw artifact to summarize, the firewall must still emit a `Frame` so the caller has an LLM-safe record of what happened. `handle_refs` is empty because no artifact was stored — there is nothing to reference. `structured_data` carries the error envelope (firewall-filtered: only the error class and a sanitized message, not stack traces or backend internals).
+
+<!-- schema: frame -->
+```json
+{
+  "frame_id": "frame-20260513-err-077",
+  "capability_id": "org.myapp.search_docs",
+  "summary": "Search failed: the documentation backend timed out after 8 seconds. No results were returned. The caller may retry; if the failure persists, escalate to the docs platform team.",
+  "structured_data": {
+    "status": "error",
+    "error_class": "BackendTimeoutError",
+    "error_message": "upstream timeout after 8000ms",
+    "retriable": true
+  },
+  "handle_refs": [],
+  "redaction_notes": "No raw artifact was produced. Backend hostname, internal request ID, and stack trace were stripped from the error envelope before populating structured_data.",
+  "created_at": "2026-05-13T09:21:08Z"
+}
+```
+
+### Step 5: TraceEvent `capability_executed` with failure outcome
+
+<!-- schema: trace_event -->
+```json
+{
+  "event_id": "te-20260513-exec-077",
+  "event_type": "capability_executed",
+  "timestamp": "2026-05-13T09:21:08Z",
+  "capability_id": "org.myapp.search_docs",
+  "principal": "agent-session-7f3a",
+  "decision_id": "pd-20260513-allow-077",
+  "frame_id": "frame-20260513-err-077",
+  "outcome": "failure",
+  "error_message": "BackendTimeoutError: upstream timeout after 8000ms"
+}
+```
+
+### Step 6: Caller receives the error Frame
+
+The caller (or ChainWeaver, when present) receives the `Frame`. Because `handle_refs` is empty, there is nothing to resolve via the `HandleStore`. The `summary` is safe to inject into a subsequent LLM turn; the LLM never sees the raw `BackendTimeoutError` traceback, only the firewall-filtered message.
+
+---
+
+## Invariants Demonstrated
+
+| Scenario | Invariant | How it is satisfied |
+| ---------- | ----------- | --------------------- |
+| 1 | I-03 — Routing does not require full schema injection | contextweaver decides "no match" using `ChoiceCard` scoring, not by injecting full tool schemas |
+| 2 | I-02 — Every execution is authorized and auditable | The denial produces both a `PolicyDecision` (`decision = "deny"`) and a paired `TraceEvent` (`event_type = "capability_denied"`) |
+| 2 | I-06 — `CapabilityToken`s are scoped | The token's `scope` array drives the denial; an unscoped token would be rejected at issuance |
+| 3 | I-01 — LLM never sees raw tool output by default | The error envelope in `structured_data` is firewall-filtered; the raw `BackendTimeoutError` traceback stays inside agent-kernel |
+| 3 | I-02 — Every execution is authorized and auditable | `capability_authorized` (success) and `capability_executed` (failure) `TraceEvent`s are both appended |
+| 3 | I-05 — contextweaver receives `Frame`s, not raw output | The caller and any downstream contextweaver ingest only the error `Frame` — never the underlying exception |
+
+---
+
+## Cross-references
+
+- Boundary rules referenced: [`docs/BOUNDARIES.md`](../docs/BOUNDARIES.md) — routing does not execute; `PolicyDecision` may cross to caller for diagnostics; raw tool output never leaves agent-kernel.
+- Invariants: [`docs/INVARIANTS.md`](../docs/INVARIANTS.md) — I-01, I-02, I-03, I-05, I-06.
+- Sequence diagrams for the same three scenarios: [`docs/SEQUENCE_DIAGRAMS.md`](../docs/SEQUENCE_DIAGRAMS.md) sections 4 — 6.
+- Happy-path counterpart: [`minimal_e2e_sequence.md`](minimal_e2e_sequence.md).
+- Multi-agent orchestration counterpart: [`multi_agent_orchestration.md`](multi_agent_orchestration.md).

--- a/examples/multi_agent_orchestration.md
+++ b/examples/multi_agent_orchestration.md
@@ -82,7 +82,7 @@ contextweaver receives the conversation state plus the candidate capabilities re
   "selected_item_id": "search-docs",
   "selected_card_id": "card-research",
   "timestamp": "2026-05-13T11:02:00Z",
-  "context_summary": "ChainWeaver flow flow-20260513-001, step 1 of 2 (research). Routed to documentation search."
+  "context_summary": "ChainWeaver flow_id flow-20260513-001, step 1 of 2 (research). Routed to documentation search."
 }
 ```
 
@@ -247,7 +247,7 @@ contextweaver scores code-generation capabilities against the new intent ("produ
   "selected_item_id": "gen-yaml",
   "selected_card_id": "card-codegen",
   "timestamp": "2026-05-13T11:02:03Z",
-  "context_summary": "ChainWeaver flow flow-20260513-001, step 2 of 2 (codegen). Input: structured_data.recommended_values from frame-20260513-step1-001. Selected YAML output per caller's original phrasing ('config.yaml')."
+  "context_summary": "ChainWeaver flow_id flow-20260513-001, step 2 of 2 (codegen). Input: structured_data.recommended_values from frame-20260513-step1-001. Selected YAML output per caller's original phrasing ('config.yaml')."
 }
 ```
 

--- a/examples/multi_agent_orchestration.md
+++ b/examples/multi_agent_orchestration.md
@@ -1,0 +1,391 @@
+# Multi-Agent ChainWeaver Orchestration
+
+This example traces a two-agent flow coordinated by ChainWeaver: a research agent gathers context, then a code-generation agent uses that context to produce a config snippet. The walkthrough shows the full contract lifecycle across both turns — `RoutingDecision` → `PolicyDecision` → `Frame` + `Handle` + `TraceEvent` → re-routing on the second cycle.
+
+The single-agent happy path is in [`minimal_e2e_sequence.md`](minimal_e2e_sequence.md). Failure paths (auth denial, partial execution) are in [`failure_scenarios.md`](failure_scenarios.md).
+
+---
+
+## Scenario
+
+**User request:** "Find the recommended retry configuration in our docs and generate a `config.yaml` snippet for it."
+
+**Two-step decomposition (decided by ChainWeaver):**
+
+1. **Research step** — invoke the research agent to find the recommended retry policy in the documentation.
+2. **Code-generation step** — invoke the code-generation agent with the research `Frame` as context, producing the requested config snippet.
+
+**Why ChainWeaver and not a single agent:** the research and code-generation capabilities live in different agents with different `CapabilityToken` scopes. ChainWeaver mediates the handoff without ever touching raw tool output (per invariant I-07).
+
+---
+
+## Layer ownership for this flow
+
+| Step | Layer that owns it | Boundary crossing |
+| ------ | -------------------- | ------------------- |
+| Decompose request into steps | ChainWeaver | n/a (internal) |
+| Route step 1 to a capability | contextweaver | ChainWeaver → contextweaver |
+| Authorize + execute step 1 | agent-kernel | ChainWeaver → agent-kernel |
+| Firewall step 1 output | agent-kernel | internal to kernel |
+| Pass `Frame` to step 2 routing | ChainWeaver | agent-kernel → ChainWeaver → contextweaver |
+| Authorize + execute step 2 | agent-kernel | ChainWeaver → agent-kernel |
+| Aggregate final response | ChainWeaver | ChainWeaver → caller |
+
+Every "raw output" arrow stays strictly inside agent-kernel — this is the firewall guarantee from [`docs/BOUNDARIES.md`](../docs/BOUNDARIES.md).
+
+Inline payload conventions: every JSON block is preceded by a `<!-- schema: <name> -->` marker that names the schema it validates against. CI extracts these blocks and validates them against `contracts/json/<name>.schema.json`.
+
+---
+
+## Step 1: ChainWeaver decomposes the request
+
+ChainWeaver receives the caller's request and decides it needs two sequential capability invocations. It assembles the flow state, then asks contextweaver to route the first step.
+
+ChainWeaver does **not** call tools or inspect raw output. Its only responsibilities at this point are step sequencing and forwarding `Frame` objects between steps (per invariant I-07).
+
+---
+
+## Step 2: contextweaver routes the research step
+
+contextweaver receives the conversation state plus the candidate capabilities relevant to the research intent ("find recommended retry configuration in docs"). It selects three retrieval-flavored capabilities and emits a `RoutingDecision`.
+
+<!-- schema: routing_decision -->
+```json
+{
+  "id": "rd-20260513-step1-001",
+  "choice_cards": [
+    {
+      "id": "card-research",
+      "context_hint": "Select the documentation retrieval capability that best answers: 'recommended retry configuration'.",
+      "items": [
+        {
+          "id": "search-docs",
+          "label": "Search documentation",
+          "description": "Full-text search across the product documentation index.",
+          "capability_id": "org.myapp.search_docs"
+        },
+        {
+          "id": "fetch-page",
+          "label": "Fetch a known documentation page",
+          "description": "Retrieve a specific documentation page by slug.",
+          "capability_id": "org.myapp.fetch_doc_page"
+        },
+        {
+          "id": "list-recent",
+          "label": "List recently updated docs",
+          "description": "Retrieve the 10 most recently modified documentation articles.",
+          "capability_id": "org.myapp.list_recent_docs"
+        }
+      ]
+    }
+  ],
+  "selected_item_id": "search-docs",
+  "selected_card_id": "card-research",
+  "timestamp": "2026-05-13T11:02:00Z",
+  "context_summary": "ChainWeaver flow flow-20260513-001, step 1 of 2 (research). Routed to documentation search."
+}
+```
+
+ChainWeaver receives this `RoutingDecision` and forwards it (with the appropriate `CapabilityToken`) to agent-kernel.
+
+---
+
+## Step 3: agent-kernel authorizes and executes the research step
+
+agent-kernel validates the `CapabilityToken` for the research scope, authorizes the capability, and invokes the search tool. The firewall produces a `Frame` summarizing the result, plus a `Handle` for the raw search response.
+
+### CapabilityToken used
+
+<!-- schema: capability_token -->
+```json
+{
+  "token_id": "tok-20260513-research-step1",
+  "principal": "chainweaver-flow-20260513-001",
+  "scope": [
+    "org.myapp.search_docs",
+    "org.myapp.fetch_doc_page",
+    "org.myapp.list_recent_docs"
+  ],
+  "issued_at": "2026-05-13T11:02:00Z",
+  "expires_at": "2026-05-13T11:07:00Z",
+  "single_use": true,
+  "issuer": "agent-kernel-prod-1",
+  "metadata": {
+    "flow_id": "flow-20260513-001",
+    "step_index": 1
+  }
+}
+```
+
+### PolicyDecision (allow)
+
+<!-- schema: policy_decision -->
+```json
+{
+  "decision_id": "pd-20260513-step1-allow",
+  "decision": "allow",
+  "capability_id": "org.myapp.search_docs",
+  "principal": "chainweaver-flow-20260513-001",
+  "token_id": "tok-20260513-research-step1",
+  "timestamp": "2026-05-13T11:02:01Z"
+}
+```
+
+### Frame produced (research result, firewall-filtered)
+
+<!-- schema: frame -->
+```json
+{
+  "frame_id": "frame-20260513-step1-001",
+  "capability_id": "org.myapp.search_docs",
+  "summary": "Found the canonical retry-policy guidance in 'Retry Policies Overview'. Recommended values: max_attempts=5, initial_backoff_ms=200, multiplier=2.0, max_backoff_ms=5000, jitter=true. The recommendation is enforced via the retry_policy block in job-level config.",
+  "structured_data": {
+    "top_result": {
+      "title": "Retry Policies Overview",
+      "slug": "docs/retry-policies",
+      "relevance_score": 0.96
+    },
+    "recommended_values": {
+      "max_attempts": 5,
+      "initial_backoff_ms": 200,
+      "multiplier": 2.0,
+      "max_backoff_ms": 5000,
+      "jitter": true
+    }
+  },
+  "handle_refs": ["handle-20260513-step1-raw"],
+  "redaction_notes": "Raw search response (internal document IDs, ranking signals, shard metadata) stored as Handle. Only the top result's title, slug, score, and the extracted recommended values are exposed.",
+  "created_at": "2026-05-13T11:02:02Z"
+}
+```
+
+### Handle for the raw research artifact
+
+<!-- schema: handle -->
+```json
+{
+  "handle_id": "handle-20260513-step1-raw",
+  "capability_id": "org.myapp.search_docs",
+  "artifact_type": "application/json",
+  "created_at": "2026-05-13T11:02:02Z",
+  "expires_at": "2026-05-13T12:02:02Z",
+  "access_policy": "policy.researcher.session-scoped",
+  "byte_size": 184320
+}
+```
+
+### TraceEvents appended
+
+<!-- schema: trace_event -->
+```json
+{
+  "event_id": "te-20260513-step1-auth",
+  "event_type": "capability_authorized",
+  "timestamp": "2026-05-13T11:02:01Z",
+  "capability_id": "org.myapp.search_docs",
+  "principal": "chainweaver-flow-20260513-001",
+  "decision_id": "pd-20260513-step1-allow",
+  "outcome": "success"
+}
+```
+
+<!-- schema: trace_event -->
+```json
+{
+  "event_id": "te-20260513-step1-exec",
+  "event_type": "capability_executed",
+  "timestamp": "2026-05-13T11:02:02Z",
+  "capability_id": "org.myapp.search_docs",
+  "principal": "chainweaver-flow-20260513-001",
+  "decision_id": "pd-20260513-step1-allow",
+  "frame_id": "frame-20260513-step1-001",
+  "handle_id": "handle-20260513-step1-raw",
+  "outcome": "success"
+}
+```
+
+agent-kernel returns the `Frame` to ChainWeaver. The `Handle` reference is included; the raw artifact remains in the kernel-controlled `HandleStore`.
+
+---
+
+## Step 4: ChainWeaver hands the research Frame to step 2 routing
+
+ChainWeaver receives the step 1 `Frame`. It does not inspect the underlying raw response (it has no access to the `Handle`'s contents without authorization). It folds the `Frame.summary` and the relevant `structured_data` slice into the conversation state for step 2.
+
+ChainWeaver then asks contextweaver to route step 2, with the step 1 `Frame` available as context.
+
+---
+
+## Step 5: contextweaver routes the code-generation step
+
+contextweaver scores code-generation capabilities against the new intent ("produce a `config.yaml` snippet for these retry values"). It emits a new `RoutingDecision`.
+
+<!-- schema: routing_decision -->
+```json
+{
+  "id": "rd-20260513-step2-002",
+  "choice_cards": [
+    {
+      "id": "card-codegen",
+      "context_hint": "Select the code-generation capability that produces a YAML snippet for the retry values extracted in step 1.",
+      "items": [
+        {
+          "id": "gen-yaml",
+          "label": "Generate YAML config snippet",
+          "description": "Render a YAML snippet from a structured key-value map.",
+          "capability_id": "org.myapp.gen_yaml_snippet"
+        },
+        {
+          "id": "gen-json",
+          "label": "Generate JSON config snippet",
+          "description": "Render a JSON snippet from a structured key-value map.",
+          "capability_id": "org.myapp.gen_json_snippet"
+        }
+      ]
+    }
+  ],
+  "selected_item_id": "gen-yaml",
+  "selected_card_id": "card-codegen",
+  "timestamp": "2026-05-13T11:02:03Z",
+  "context_summary": "ChainWeaver flow flow-20260513-001, step 2 of 2 (codegen). Input: structured_data.recommended_values from frame-20260513-step1-001. Selected YAML output per caller's original phrasing ('config.yaml')."
+}
+```
+
+---
+
+## Step 6: agent-kernel authorizes and executes the code-generation step
+
+A fresh `CapabilityToken` is issued for the code-generation scope. Each flow step gets its own token — re-using the research token would either fail the scope check or violate I-06 (`single_use: true` on the prior token already invalidated it).
+
+### CapabilityToken used (step 2)
+
+<!-- schema: capability_token -->
+```json
+{
+  "token_id": "tok-20260513-codegen-step2",
+  "principal": "chainweaver-flow-20260513-001",
+  "scope": [
+    "org.myapp.gen_yaml_snippet",
+    "org.myapp.gen_json_snippet"
+  ],
+  "issued_at": "2026-05-13T11:02:03Z",
+  "expires_at": "2026-05-13T11:07:03Z",
+  "single_use": true,
+  "issuer": "agent-kernel-prod-1",
+  "metadata": {
+    "flow_id": "flow-20260513-001",
+    "step_index": 2,
+    "prior_frame_id": "frame-20260513-step1-001"
+  }
+}
+```
+
+### PolicyDecision (allow)
+
+<!-- schema: policy_decision -->
+```json
+{
+  "decision_id": "pd-20260513-step2-allow",
+  "decision": "allow",
+  "capability_id": "org.myapp.gen_yaml_snippet",
+  "principal": "chainweaver-flow-20260513-001",
+  "token_id": "tok-20260513-codegen-step2",
+  "timestamp": "2026-05-13T11:02:04Z"
+}
+```
+
+### Frame produced (final code snippet)
+
+<!-- schema: frame -->
+```json
+{
+  "frame_id": "frame-20260513-step2-002",
+  "capability_id": "org.myapp.gen_yaml_snippet",
+  "summary": "Generated a 7-line YAML snippet for the retry policy block. The snippet follows the schema documented in docs/retry-policies and is ready to paste into a job-level config.",
+  "structured_data": {
+    "language": "yaml",
+    "snippet": "retry_policy:\n  max_attempts: 5\n  initial_backoff_ms: 200\n  multiplier: 2.0\n  max_backoff_ms: 5000\n  jitter: true\n",
+    "byte_size": 132
+  },
+  "handle_refs": [],
+  "redaction_notes": "Output is a pure transformation of structured_data from frame-20260513-step1-001 plus a static template. No external artifact retained; no Handle produced.",
+  "created_at": "2026-05-13T11:02:04Z"
+}
+```
+
+### TraceEvents appended
+
+<!-- schema: trace_event -->
+```json
+{
+  "event_id": "te-20260513-step2-auth",
+  "event_type": "capability_authorized",
+  "timestamp": "2026-05-13T11:02:04Z",
+  "capability_id": "org.myapp.gen_yaml_snippet",
+  "principal": "chainweaver-flow-20260513-001",
+  "decision_id": "pd-20260513-step2-allow",
+  "outcome": "success"
+}
+```
+
+<!-- schema: trace_event -->
+```json
+{
+  "event_id": "te-20260513-step2-exec",
+  "event_type": "capability_executed",
+  "timestamp": "2026-05-13T11:02:04Z",
+  "capability_id": "org.myapp.gen_yaml_snippet",
+  "principal": "chainweaver-flow-20260513-001",
+  "decision_id": "pd-20260513-step2-allow",
+  "frame_id": "frame-20260513-step2-002",
+  "outcome": "success"
+}
+```
+
+---
+
+## Step 7: ChainWeaver aggregates the final response
+
+ChainWeaver has both step `Frame`s. It assembles a final response that surfaces the code snippet (step 2) plus a one-line provenance note pointing at the research source (step 1's `summary`). Optionally, the aggregated payload is emitted as a flow-completion `TraceEvent`:
+
+<!-- schema: trace_event -->
+```json
+{
+  "event_id": "te-20260513-flow-complete",
+  "event_type": "flow_completed",
+  "timestamp": "2026-05-13T11:02:05Z",
+  "principal": "chainweaver-flow-20260513-001",
+  "outcome": "success",
+  "metadata": {
+    "flow_id": "flow-20260513-001",
+    "step_count": 2,
+    "frame_ids": ["frame-20260513-step1-001", "frame-20260513-step2-002"]
+  }
+}
+```
+
+The caller receives the aggregated result. The LLM that drives the next conversation turn sees only the two `Frame.summary` strings and the structured snippet — never any raw search index payload, ranking signal, or backend metadata.
+
+---
+
+## Invariants Demonstrated
+
+| Invariant | How it is satisfied in this flow |
+| ----------- | ----------------------------------- |
+| I-01 — LLM never sees raw tool output | The step 1 raw search response is held only in the `Handle`-referenced store; the LLM sees only the firewall-filtered `Frame` |
+| I-02 — Every execution is authorized and auditable | Each step produces a paired `PolicyDecision` + `TraceEvent`; the flow ends with a `flow_completed` event |
+| I-03 — Routing without full schema injection | Each `ChoiceCard` carries 2 – 3 items; no full tool schemas are injected into the LLM prompt for either step |
+| I-05 — contextweaver receives Frames, not raw output | The step 2 routing input is the step 1 `Frame`; contextweaver never sees the raw search response |
+| I-06 — `CapabilityToken`s are scoped | Each step uses its own token with a narrow scope and `single_use: true` |
+| I-07 — ChainWeaver delegates execution to the kernel | ChainWeaver issues no tool calls of its own; every capability invocation passes through agent-kernel |
+
+---
+
+## Cross-references
+
+- Architecture: [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) — three-layer model and data flow.
+- Boundaries: [`docs/BOUNDARIES.md`](../docs/BOUNDARIES.md) — artifact ownership; ChainWeaver does not own execution.
+- Invariants: [`docs/INVARIANTS.md`](../docs/INVARIANTS.md) — I-01 through I-07.
+- Sequence diagrams: [`docs/SEQUENCE_DIAGRAMS.md`](../docs/SEQUENCE_DIAGRAMS.md) section 3 (full-stack happy path).
+- Failure modes for the same flow shape: [`failure_scenarios.md`](failure_scenarios.md).
+- Partial-match routing decisions: [`partial_capability_routing.md`](partial_capability_routing.md).

--- a/examples/partial_capability_routing.md
+++ b/examples/partial_capability_routing.md
@@ -51,7 +51,7 @@ contextweaver emits a single `ChoiceCard` containing the top three candidates in
   "choice_cards": [
     {
       "id": "card-sales-by-region",
-      "context_hint": "Three capabilities partially match 'show me yesterday's sales by region'. They are listed in descending fit order; the first is the strongest match if a freshly-computed answer is acceptable.",
+      "context_hint": "Three capabilities partially match the request: show me yesterday's sales by region. They are listed in descending fit order; the first is the strongest match if a freshly-computed answer is acceptable.",
       "items": [
         {
           "id": "run-sql-query",
@@ -77,7 +77,7 @@ contextweaver emits a single `ChoiceCard` containing the top three candidates in
   "selected_item_id": "run-sql-query",
   "selected_card_id": "card-sales-by-region",
   "timestamp": "2026-05-13T13:45:00Z",
-  "context_summary": "Partial-match routing for 'Show me yesterday's sales by region'. Top 3 candidates by fit score: run_sql_query=0.81 (full semantic match, expressible filter), open_saved_dashboard=0.62 (named dashboard exists, timeframe mismatch), export_data=0.47 (rows available, no aggregation). Cut-off threshold=0.40; 244 lower-scoring capabilities filtered out before card assembly."
+  "context_summary": "Partial-match routing for the request: Show me yesterday's sales by region. Top 3 candidates by fit score: run_sql_query=0.81 (full semantic match, expressible filter), open_saved_dashboard=0.62 (named dashboard exists, timeframe mismatch), export_data=0.47 (rows available, no aggregation). Cut-off threshold=0.40; 244 lower-scoring capabilities filtered out before card assembly."
 }
 ```
 

--- a/examples/partial_capability_routing.md
+++ b/examples/partial_capability_routing.md
@@ -95,7 +95,7 @@ If the caller's selector picks a different ranked option (for example, `open-sav
 
 ## Why ChoiceCard and SelectableItem Are Separate
 
-This walkthrough makes the rationale concrete (the separation is also called out in [`AGENTS.md`](../AGENTS.md) — "Design decisions not to reopen"):
+[`AGENTS.md`](../AGENTS.md) — "Design decisions not to reopen" — calls out a parallel separation, **ChoiceCard vs RoutingDecision**, for the same reason: keep the LLM-facing surface lean. The ChoiceCard-vs-SelectableItem split below follows the same logic one level deeper:
 
 - A **`SelectableItem`** is the minimum information the LLM needs to pick one option: a label, a short description, and an opaque `capability_id`. Crucially it does **not** carry the capability's input schema, internal arg types, or implementation hints. If `SelectableItem` carried full tool schemas, every routing turn would re-inflate the prompt (the exact problem invariant I-03 prevents).
 

--- a/examples/partial_capability_routing.md
+++ b/examples/partial_capability_routing.md
@@ -1,0 +1,126 @@
+# Partial-Capability Routing
+
+This example shows how contextweaver handles a request that overlaps several capabilities without being a perfect match for any of them. The routing layer ranks candidates and presents them as a single `ChoiceCard`. The LLM (or the caller's selector) picks one based on the ranked summary — no full tool schemas are injected.
+
+The single-best-match happy path is in [`minimal_e2e_sequence.md`](minimal_e2e_sequence.md). Multi-step coordination across selected agents is in [`multi_agent_orchestration.md`](multi_agent_orchestration.md).
+
+---
+
+## Scenario
+
+**User request:** "Show me yesterday's sales by region."
+
+**Why this is a partial match:** the request is data-shaped but ambiguous. Several registered capabilities could plausibly serve it, and none is a single, unambiguous winner:
+
+| Capability ID | What it does | Fit notes |
+| --------------- | -------------- | ----------- |
+| `org.myapp.run_sql_query` | Runs an ad-hoc SQL query against the sales warehouse | Strong fit — can compute the answer directly, but needs a query expression. |
+| `org.myapp.open_saved_dashboard` | Opens an existing saved dashboard by name | Partial fit — a "Sales by region" dashboard exists, but it shows the trailing 7 days, not yesterday specifically. |
+| `org.myapp.export_data` | Exports a filtered dataset slice to CSV/Parquet | Partial fit — can deliver the rows, but requires an explicit filter spec and does not aggregate by region. |
+
+contextweaver presents all three as a ranked `ChoiceCard`. Ranking is the routing layer's job; **execution** is still gated by agent-kernel after the selection is made (per invariant I-07 / `docs/BOUNDARIES.md`).
+
+Inline payload conventions: every JSON block is preceded by a `<!-- schema: <name> -->` marker that names the schema it validates against. CI extracts these blocks and validates them against `contracts/json/<name>.schema.json`.
+
+---
+
+## Step 1: contextweaver scores candidate capabilities
+
+contextweaver evaluates the request intent against every capability in scope. It produces a numeric match score per capability using whatever signal mix it implements (semantic similarity on description text, tag overlap, recent caller success rate, etc. — the contract does not pin a specific ranking algorithm).
+
+In this example the scores come out:
+
+| Capability | Score | Rationale (recorded in `context_summary`) |
+| ------------ | ------- | -------------------------------------------- |
+| `org.myapp.run_sql_query` | 0.81 | Full semantic match for "sales by region"; arbitrary date filter is trivially expressible. |
+| `org.myapp.open_saved_dashboard` | 0.62 | Named dashboard exists but timeframe mismatch (7-day vs. "yesterday"). |
+| `org.myapp.export_data` | 0.47 | Can return raw rows but does not aggregate; would require a follow-up step. |
+
+Only the top three are surfaced. Capabilities scoring below the cut-off threshold (e.g., document search at 0.18) are filtered out before the `ChoiceCard` is built. This is what keeps the `ChoiceCard` items list small (3 – 7 is the documented practical range — see `choice_card.schema.json`).
+
+---
+
+## Step 2: RoutingDecision produced with ranked items
+
+contextweaver emits a single `ChoiceCard` containing the top three candidates in descending score order. Each `SelectableItem` carries the `label`, `description`, and `capability_id` the LLM needs to choose — nothing more. Full input schemas, argument types, and tool internals stay out of the prompt (invariant I-03).
+
+<!-- schema: routing_decision -->
+```json
+{
+  "id": "rd-20260513-partial-001",
+  "choice_cards": [
+    {
+      "id": "card-sales-by-region",
+      "context_hint": "Three capabilities partially match 'show me yesterday's sales by region'. They are listed in descending fit order; the first is the strongest match if a freshly-computed answer is acceptable.",
+      "items": [
+        {
+          "id": "run-sql-query",
+          "label": "Run an ad-hoc SQL query (recommended)",
+          "description": "Compute yesterday's sales aggregated by region against the warehouse. Returns a result set in one call. Best when an authoritative, freshly-computed answer is required.",
+          "capability_id": "org.myapp.run_sql_query"
+        },
+        {
+          "id": "open-saved-dashboard",
+          "label": "Open the 'Sales by region' saved dashboard",
+          "description": "Open the curated dashboard. Caveat: the dashboard's default range is the trailing 7 days, not yesterday specifically. Prefer this when the caller wants the curated visualization.",
+          "capability_id": "org.myapp.open_saved_dashboard"
+        },
+        {
+          "id": "export-data",
+          "label": "Export the raw sales slice for yesterday",
+          "description": "Return raw rows for yesterday filtered to the sales fact table. Does not aggregate by region — a follow-up aggregation step is required. Use only when the caller wants the underlying data.",
+          "capability_id": "org.myapp.export_data"
+        }
+      ]
+    }
+  ],
+  "selected_item_id": "run-sql-query",
+  "selected_card_id": "card-sales-by-region",
+  "timestamp": "2026-05-13T13:45:00Z",
+  "context_summary": "Partial-match routing for 'Show me yesterday's sales by region'. Top 3 candidates by fit score: run_sql_query=0.81 (full semantic match, expressible filter), open_saved_dashboard=0.62 (named dashboard exists, timeframe mismatch), export_data=0.47 (rows available, no aggregation). Cut-off threshold=0.40; 244 lower-scoring capabilities filtered out before card assembly."
+}
+```
+
+The LLM (or the caller's selector logic) sees the ranked items and selects `run-sql-query` — the top-ranked option. contextweaver records the selection on the same `RoutingDecision` (`selected_item_id` + `selected_card_id`) and emits it.
+
+---
+
+## Step 3: Caller passes the selection to agent-kernel
+
+agent-kernel will validate a `CapabilityToken` for `org.myapp.run_sql_query` and execute the query. That part of the flow follows the standard happy path documented in [`minimal_e2e_sequence.md`](minimal_e2e_sequence.md); only the routing phase is unusual here.
+
+If the caller's selector picks a different ranked option (for example, `open-saved-dashboard` because the user wanted a visual), the same `RoutingDecision` shape is produced — only `selected_item_id` changes. Re-routing or re-ranking does **not** require a new `ChoiceCard`; the existing one already enumerates the alternatives.
+
+---
+
+## Why ChoiceCard and SelectableItem Are Separate
+
+This walkthrough makes the rationale concrete (the separation is also called out in [`AGENTS.md`](../AGENTS.md) — "Design decisions not to reopen"):
+
+- A **`SelectableItem`** is the minimum information the LLM needs to pick one option: a label, a short description, and an opaque `capability_id`. Crucially it does **not** carry the capability's input schema, internal arg types, or implementation hints. If `SelectableItem` carried full tool schemas, every routing turn would re-inflate the prompt (the exact problem invariant I-03 prevents).
+
+- A **`ChoiceCard`** wraps an ordered set of `SelectableItem`s with a `context_hint` (how to interpret the choices), a stable `id` (for audit cross-reference), and structural constraints (`minItems: 1`, `maxItems: 20`). The card is the unit the LLM is asked to choose from. The card's `id` lets a follow-up step refer to "the same choice surface" without re-listing the items.
+
+If the two were merged, the LLM prompt would have to carry either too much (per-item tool detail) or too little (no card-level framing). Keeping them separate lets adopters tune the card payload independently of the item payload.
+
+The `RoutingDecision` then wraps the `ChoiceCard`s with the selection result (`selected_item_id`, `selected_card_id`) and audit-friendly metadata (`timestamp`, `context_summary`). That separation is what lets routing produce structurally identical payloads regardless of whether a selection has been made yet.
+
+---
+
+## Invariants Demonstrated
+
+| Invariant | How it is satisfied |
+| ----------- | --------------------- |
+| I-03 — Routing without full schema injection | Each `SelectableItem` carries only `label`, `description`, and `capability_id` — no input schemas, no arg types. The full prompt for selection scales O(items), not O(tool surface area). |
+| I-04 — Core contracts minimal and stable | The ranking signal is recorded in `context_summary` (free-form) rather than promoted to a Core field. Future ranking algorithms can record different signals without a Core contract change. |
+
+---
+
+## Cross-references
+
+- Architecture: [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) — three-layer model; routing does not execute.
+- Boundaries: [`docs/BOUNDARIES.md`](../docs/BOUNDARIES.md) — contextweaver produces `RoutingDecision` and `ChoiceCard`; agent-kernel handles execution.
+- Invariants: [`docs/INVARIANTS.md`](../docs/INVARIANTS.md) — I-03 (no full schema injection), I-04 (Core minimal).
+- Design rationale: [`AGENTS.md`](../AGENTS.md) — "Design decisions not to reopen" → ChoiceCard vs RoutingDecision separation.
+- Happy-path single-best-match counterpart: [`minimal_e2e_sequence.md`](minimal_e2e_sequence.md).
+- Multi-agent counterpart (when a flow needs two selections in sequence): [`multi_agent_orchestration.md`](multi_agent_orchestration.md).


### PR DESCRIPTION
## Description

Lands the documentation cluster identified in the most recent issue triage: three new walkthroughs in `examples/` plus three new Mermaid sequence diagrams in `docs/SEQUENCE_DIAGRAMS.md`, all anchored to the existing Core schemas. Also adds a CI step that enforces drift-detection between the walkthrough JSON snippets and the contract schemas — including JSON Schema `format`-keyword enforcement and a non-zero-marker guard so accidental marker removal fails loud.

**Closes:** #18, #22, #25, #26.

### What changed

- **`examples/failure_scenarios.md`** (new) — three failure-path walkthroughs: routing failure (no matching capabilities), authorization denial (token scope mismatch), partial execution failure (tool errors mid-stream). Each scenario shows the contract payloads at every boundary. (#18)
- **`examples/multi_agent_orchestration.md`** (new) — two-agent ChainWeaver-coordinated flow (research → code-gen) through the full `RoutingDecision` → `Frame` → re-routing cycle, with payloads at each step and explicit layer-ownership labels. Audit-debug strings reference the flow as `flow_id flow-…`, matching the `metadata.flow_id` field in the payloads. (#22)
- **`examples/partial_capability_routing.md`** (new) — partial-match routing with three overlapping candidates ranked as a single `ChoiceCard`. Documents (with a concrete example) why `ChoiceCard` and `SelectableItem` remain separate types, citing the parallel `ChoiceCard`-vs-`RoutingDecision` decision in [`AGENTS.md`](AGENTS.md). (#26)
- **`docs/SEQUENCE_DIAGRAMS.md`** — three new Mermaid diagrams (sections 4–6) for the three failure scenarios. Diagrams use the same scenarios as the narrative walkthrough so adopters can read either format and cross-reference. (#25)
- **`.github/workflows/ci.yml`** — new `validate-walkthroughs` job that scans `examples/**/*.md` and `docs/**/*.md` for `<!-- schema: <name> -->`-marked JSON blocks and validates each against `contracts/json/<name>.schema.json`. `$ref`s are resolved through a pre-populated `referencing.Registry` so validation is offline; `format_checker=Draft202012Validator.FORMAT_CHECKER` enforces `date-time` and other built-in format keywords; the script fails with a clear message if zero markers are found across the scanned files. Step uses a `python << 'PYEOF'` heredoc so the Python source is one-to-one with the rendered YAML (no shell-escape artefacts).
- **`CHANGELOG.md`** — `## [Unreleased] ### Added` entries for the above. No version bump (docs-only).

### Why the new CI job

The `validate-walkthroughs` job is broader than the strict scope of the four issues. It exists to make this PR (and future walkthroughs) self-policing — without it, walkthrough JSON snippets could silently drift from the contracts. The job adds one Python dependency (`jsonschema`, already a dev dep of the Python package) and runs in a dedicated CI job.

---

## Type of change

- [x] Docs only (no contract changes)
- [ ] Additive contract change (new optional field or new type — non-breaking)
- [ ] Breaking contract change (requires ADR — see [CONTRIBUTING.md](CONTRIBUTING.md))
- [x] CI / tooling change

---

## Six-artifact checklist

No Core contract changes. All six artifacts marked N/A.

- [x] JSON Schema updated (`contracts/json/`) — **N/A** (no contract change)
- [x] Python dataclass updated (`contracts/python/src/weaver_contracts/core.py`) — **N/A**
- [x] Sample payload updated (`examples/sample_payloads/`) — **N/A** (walkthroughs ship inline JSON; standalone payload files tracked separately in #11)
- [x] Roundtrip test updated (`contracts/python/tests/test_roundtrip_examples.py`) — **N/A**
- [x] CHANGELOG entry added (`CHANGELOG.md`) — done, under `## [Unreleased]`
- [x] Version bumped (`version.py` + `pyproject.toml`) — **N/A** (docs-only)

---

## Invariants

- [x] I have verified that invariants I-01 through I-07 in `docs/INVARIANTS.md` are not violated by this change.

**Invariants exercised by the new walkthroughs (positive demonstrations only — no invariant is altered):**

| Walkthrough | Invariants exercised |
| --- | --- |
| `failure_scenarios.md` | I-01, I-02, I-03, I-05, I-06 |
| `multi_agent_orchestration.md` | I-01, I-02, I-03, I-05, I-06, I-07 |
| `partial_capability_routing.md` | I-03, I-04 |

**Mermaid diagram cross-check vs `docs/BOUNDARIES.md` artifact ownership table:**

| Diagram | Boundary check |
| --- | --- |
| §4 Routing failure | `RoutingDecision` produced by contextweaver, returned to caller. agent-kernel not invoked. No Frame/Handle/PolicyDecision. ✓ |
| §5 Authorization denial | `PolicyDecision` crosses from agent-kernel to caller for diagnostics (allowed per ownership table). `TraceEvent` → audit log. No Frame/Handle. ✓ |
| §6 Partial execution failure | Raw tool error envelope stays inside agent-kernel; firewall emits `Frame` with `handle_refs=[]` (no artifact to store). `HandleStore` not invoked. ✓ |

---

## Cross-repo impact

- [ ] **contextweaver** — needs coordinated update
- [ ] **agent-kernel** — needs coordinated update
- [ ] **ChainWeaver** — needs coordinated update
- [x] No cross-repo impact

**This PR has no contract-level cross-repo impact** (no Core contract changes). However, the new walkthroughs are designed to be referenced by conformance tests in the sibling repos. The following follow-up issues will be filed after this PR merges (so they reference merged file paths):

- `dgenio/contextweaver`:
  - "Add conformance fixture: routing failure / no-matching-capabilities path" — references `failure_scenarios.md` §1.
  - "Add conformance fixture: partial-capability ChoiceCard ranking" — references `partial_capability_routing.md`.
- `dgenio/agent-kernel`:
  - "Add conformance test: CapabilityToken denial path" — references `failure_scenarios.md` §2.
  - "Add conformance test: partial execution failure produces Frame with error state" — references `failure_scenarios.md` §3.
- `dgenio/ChainWeaver`:
  - "Add reference flow: two-agent research → code-gen orchestration" — references `multi_agent_orchestration.md`.

---

## How verified

- `npx markdownlint-cli README.md CONTRIBUTING.md CHANGELOG.md 'docs/**/*.md' 'contracts/**/*.md' 'examples/*.md'` → exit 0, no warnings.
- New CI job run locally: **23 inline payload(s) validated across 20 Markdown file(s) with `format_checker` enforced; zero-marker guard verified.**
- Existing CI checks rerun locally: 9 schemas valid, 10 sample payloads valid.
- Boundary cross-check (table above) confirms every Mermaid diagram is consistent with `docs/BOUNDARIES.md`.
- CI on the head SHA: all 7 jobs green (Validate JSON Schemas, Validate Walkthrough Payloads, Markdown Lint, Internal Document Links, Python Package Tests on 3.9/3.11/3.12).

## Tradeoffs / risks

- The inline-JSON-extraction CI step relies on a Markdown comment convention (`<!-- schema: <name> -->`). Future walkthrough authors must add this marker for their payloads to be validated; the convention is documented in each new walkthrough and the job fails loud if zero markers are found across the scanned files.
- New CI dep (`jsonschema`) is isolated to one job; no impact on the Python package install surface.
- Diagram numbering continues at §4 to avoid breaking inbound links to existing §1–§3.

## Scope notes

Adjacent improvements deferred:
- README "Quick Navigation" table update to link the new walkthroughs (intentionally skipped — not asked for by any of the four issues).
- Filling in remaining Core sample payloads (#11) and conformance suite (#4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
