### PR TITLE
Add CONTRACT_REFERENCE.md and QUICKSTART.md integration guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
 - `examples/partial_capability_routing.md` — partial-match routing walkthrough with three overlapping candidates and a ranked `ChoiceCard`. Closes #26.
 - `docs/SEQUENCE_DIAGRAMS.md` — three new Mermaid sequence diagrams (sections 4 — 6) for the routing-failure, authorization-denial, and partial-execution-failure paths. Diagrams use the same scenarios as `examples/failure_scenarios.md`. Closes #25.
 - CI step in `.github/workflows/ci.yml` that extracts inline JSON payloads from the new walkthroughs (and `docs/SEQUENCE_DIAGRAMS.md`) and validates each against its declared schema in `contracts/json/` using `jsonschema`, with `format`-keyword enforcement (e.g., `date-time`) and a non-zero-marker guard to fail loud on accidental marker removal. Blocks merges on walkthrough/contract drift.
+- `docs/QUICKSTART.md` — quick-start integration guide with Python and JS/TS code, schema validation patterns, and one integration snippet per sibling repo (contextweaver, agent-kernel, ChainWeaver). No runtime dependencies added. Closes #19.
+- `docs/CONTRACT_REFERENCE.md` — single-page field reference for all 16 contract types (9 Core + 7 Extended) with per-field type/required/description tables, source-of-truth links, and per-Extended-type usage guidance, Core relationship, and inline JSON example. Supersedes #21. Closes #20.
+- `docs/FAQ.md` — eight new task-oriented entries covering capability registration, Extended metadata composition, language-agnostic schema validation, version-mismatch handling, telemetry, the Core-field proposal workflow, the Frame-vs-Handle distinction, and spec-conformance testing. Closes #23.
+- `README.md` — Quick Navigation table now links to `docs/QUICKSTART.md` and `docs/CONTRACT_REFERENCE.md`.
 
 **No Core contract changes** — JSON Schemas, Python types, and existing sample payloads are unchanged.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Each repo can be adopted independently. `weaver-spec` defines the contracts that
 | What you need | Where to look |
 | --------------- | --------------- |
 | Ecosystem overview | [docs/VISION.md](docs/VISION.md) |
+| Quick-start (Python + JS/TS) | [docs/QUICKSTART.md](docs/QUICKSTART.md) |
+| Contract field reference | [docs/CONTRACT_REFERENCE.md](docs/CONTRACT_REFERENCE.md) |
 | Layer architecture | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
 | Responsibility boundaries | [docs/BOUNDARIES.md](docs/BOUNDARIES.md) |
 | Non-negotiable invariants | [docs/INVARIANTS.md](docs/INVARIANTS.md) |

--- a/docs/CONTRACT_REFERENCE.md
+++ b/docs/CONTRACT_REFERENCE.md
@@ -1,0 +1,388 @@
+# Contract Field Reference
+
+A single-page field reference for every Weaver contract type — both Core (9) and Extended (7).
+
+For narrative and adoption guidance, read [ARCHITECTURE.md](ARCHITECTURE.md), [BOUNDARIES.md](BOUNDARIES.md), and [GLOSSARY.md](GLOSSARY.md). For a runnable code path, use [QUICKSTART.md](QUICKSTART.md).
+
+---
+
+## Source of truth and authority
+
+- **Core types** — the JSON Schemas in [`contracts/json/`](../contracts/json/) are the language-agnostic source of truth. The Python dataclasses in [`contracts/python/src/weaver_contracts/core.py`](../contracts/python/src/weaver_contracts/core.py) mirror them exactly.
+- **Extended types** — the Python dataclasses in [`contracts/python/src/weaver_contracts/extended.py`](../contracts/python/src/weaver_contracts/extended.py) are the source of truth. Extended contracts have no JSON Schemas yet and may have breaking changes in MINOR versions (see [VERSIONING.md](VERSIONING.md)).
+
+If this document ever disagrees with a schema or dataclass, the schema or dataclass wins. Open an issue.
+
+---
+
+## Conventions
+
+- **Required** means listed in the JSON Schema's `required` array (Core) or has no default in the Python dataclass (Extended).
+- **Type** uses JSON Schema vocabulary for Core (`string`, `object`, `array<X>`, `string | null`, `enum{…}`, `date-time` for ISO 8601) and Python typing vocabulary for Extended (`str`, `Optional[X]`, `List[X]`, `Dict[str, str]`).
+- ID fields require `minLength: 1` (non-empty strings). IDs are not required to be UUIDs; slug-style identifiers are common in sample payloads.
+- All Core schemas set `additionalProperties: true`, so adopters may add namespaced fields (e.g., `x_myorg_*`) without breaking validation.
+
+---
+
+## Core types (9)
+
+### SelectableItem
+
+**Purpose:** A single option presented to the LLM within a `ChoiceCard`.
+
+**Source of truth:** [`contracts/json/selectable_item.schema.json`](../contracts/json/selectable_item.schema.json) · [`core.py` SelectableItem](../contracts/python/src/weaver_contracts/core.py)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `string` (minLength 1) | Yes | Unique identifier within its `ChoiceCard`. |
+| `label` | `string` (minLength 1) | Yes | Short human-readable label. Safe to include in an LLM prompt. |
+| `description` | `string` (minLength 1) | Yes | Concise description. Must not include raw tool-schema details (see I-03). |
+| `capability_id` | `string` | No | Reference to the `Capability` this item maps to (used by agent-kernel). |
+| `metadata` | `object` | No | Implementation-specific metadata. `additionalProperties: true`. |
+
+### ChoiceCard
+
+**Purpose:** A curated, bounded menu of `SelectableItem` objects presented to the LLM.
+
+**Source of truth:** [`contracts/json/choice_card.schema.json`](../contracts/json/choice_card.schema.json) · [`core.py` ChoiceCard](../contracts/python/src/weaver_contracts/core.py)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `string` (minLength 1) | Yes | Unique identifier for this `ChoiceCard`. |
+| `items` | `array<SelectableItem>` (minItems 1, maxItems 20) | Yes | Ordered options. 3–7 is the practical range for LLM selection. |
+| `context_hint` | `string` | No | Optional guidance for the LLM about how to interpret this card. |
+| `metadata` | `object` | No | Implementation-specific metadata. |
+
+### RoutingDecision
+
+**Purpose:** The output of the contextweaver routing phase. Wraps one or more `ChoiceCard` objects with selection state and a timestamp.
+
+**Source of truth:** [`contracts/json/routing_decision.schema.json`](../contracts/json/routing_decision.schema.json) · [`core.py` RoutingDecision](../contracts/python/src/weaver_contracts/core.py)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `string` (minLength 1) | Yes | Unique identifier for this routing decision. |
+| `choice_cards` | `array<ChoiceCard>` (minItems 1) | Yes | One or more cards presented during this cycle. |
+| `timestamp` | `string` (date-time) | Yes | ISO 8601 creation time. |
+| `selected_item_id` | `string \| null` | No | Item the LLM chose; null while awaiting response. |
+| `selected_card_id` | `string \| null` | No | Card containing the selected item. |
+| `context_summary` | `string` | No | Brief diagnostic summary for audit. |
+| `metadata` | `object` | No | Implementation-specific metadata. |
+
+### Capability
+
+**Purpose:** A named, versioned unit of executable functionality registered in agent-kernel.
+
+**Source of truth:** [`contracts/json/capability.schema.json`](../contracts/json/capability.schema.json) · [`core.py` Capability](../contracts/python/src/weaver_contracts/core.py)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `string` (minLength 1) | Yes | Stable, namespaced identifier (e.g., `org.myapp.search_docs`). |
+| `name` | `string` (minLength 1) | Yes | Human-readable name. |
+| `version` | `string` (minLength 1) | Yes | Semantic version of this capability. |
+| `description` | `string` (minLength 1) | Yes | What the capability does and when to use it. |
+| `input_schema_ref` | `string` | No | URI to the JSON Schema describing valid inputs. |
+| `output_schema_ref` | `string` | No | URI to the JSON Schema describing the `Frame` content. |
+| `tags` | `array<string>` | No | Optional tags for categorization. |
+| `metadata` | `object` | No | Implementation-specific metadata. |
+
+### CapabilityToken
+
+**Purpose:** A scoped authorization credential for capability invocation. Issued by agent-kernel.
+
+**Source of truth:** [`contracts/json/capability_token.schema.json`](../contracts/json/capability_token.schema.json) · [`core.py` CapabilityToken](../contracts/python/src/weaver_contracts/core.py)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `token_id` | `string` (minLength 1) | Yes | Unique identifier for this token. |
+| `principal` | `string` (minLength 1) | Yes | Identity (user, agent, or service) this token was issued to. |
+| `scope` | `array<string>` (minItems 1) | Yes | Capability IDs this token authorizes. Unbounded scope is not permitted (I-06). |
+| `issued_at` | `string` (date-time) | Yes | ISO 8601 issuance timestamp. |
+| `expires_at` | `string \| null` (date-time) | Conditional | Required unless `single_use=true`. Enforced by an `anyOf` constraint in the schema and by `__post_init__` in Python. |
+| `single_use` | `boolean` (default `false`) | No | When `true`, the token is invalidated after one successful authorization. |
+| `issuer` | `string` | No | Optional identifier of the issuing agent-kernel instance. |
+| `metadata` | `object` | No | Implementation-specific metadata. |
+
+The token must either be single-use **or** carry an expiry. This is invariant I-06 and is enforced structurally by the `anyOf` clause in the schema and at construction time in Python. The word "signed" used in the Glossary is aspirational — the current contract does not encode cryptographic verification.
+
+### PolicyDecision
+
+**Purpose:** The authorization verdict produced by agent-kernel's policy engine.
+
+**Source of truth:** [`contracts/json/policy_decision.schema.json`](../contracts/json/policy_decision.schema.json) · [`core.py` PolicyDecision](../contracts/python/src/weaver_contracts/core.py)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `decision_id` | `string` (minLength 1) | Yes | Used to correlate with `TraceEvent` entries. |
+| `decision` | `enum{"allow","deny"}` | Yes | The verdict. |
+| `capability_id` | `string` (minLength 1) | Yes | The capability evaluated. |
+| `principal` | `string` (minLength 1) | Yes | Principal whose authorization was evaluated. |
+| `timestamp` | `string` (date-time) | Yes | ISO 8601 decision time. |
+| `token_id` | `string \| null` | No | `CapabilityToken` ID used, if any. |
+| `reason` | `string` | No | Human-readable explanation. Recommended for `deny`. |
+| `metadata` | `object` | No | Implementation-specific metadata. |
+
+### Frame
+
+**Purpose:** Safe, filtered view of a tool execution result. Produced by the agent-kernel firewall.
+
+**Source of truth:** [`contracts/json/frame.schema.json`](../contracts/json/frame.schema.json) · [`core.py` Frame](../contracts/python/src/weaver_contracts/core.py)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `frame_id` | `string` (minLength 1) | Yes | Unique identifier for this `Frame`. |
+| `capability_id` | `string` (minLength 1) | Yes | Capability that produced this `Frame`. |
+| `summary` | `string` (minLength 1) | Yes | LLM-safe summary. Never contains raw output (I-01, I-05). |
+| `created_at` | `string` (date-time) | Yes | ISO 8601 creation timestamp. |
+| `structured_data` | `object \| null` | No | Firewall-filtered structured subset approved for LLM consumption. |
+| `handle_refs` | `array<string>` (each minLength 1) | No | `Handle` IDs referencing raw artifacts. Resolution requires authorization. |
+| `redaction_notes` | `string` | No | Description of what was redacted or filtered. |
+| `metadata` | `object` | No | Implementation-specific metadata. |
+
+### Handle
+
+**Purpose:** Opaque, access-controlled reference to a raw artifact. The artifact lives in the HandleStore; the `Handle` carries only the reference plus access metadata.
+
+**Source of truth:** [`contracts/json/handle.schema.json`](../contracts/json/handle.schema.json) · [`core.py` Handle](../contracts/python/src/weaver_contracts/core.py)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `handle_id` | `string` (minLength 1) | Yes | Reference identifier. Must not be sufficient for unauthorized access. |
+| `capability_id` | `string` (minLength 1) | Yes | Capability that produced the referenced artifact. |
+| `artifact_type` | `string` (minLength 1) | Yes | MIME or semantic type (e.g., `application/json`, `image/png`). |
+| `created_at` | `string` (date-time) | Yes | ISO 8601 creation timestamp. |
+| `expires_at` | `string \| null` (date-time) | No | Optional artifact expiry. |
+| `access_policy` | `string` | No | Reference to the policy governing who can resolve this `Handle`. |
+| `byte_size` | `integer \| null` (minimum 0) | No | Optional artifact size for capacity planning. |
+| `metadata` | `object` | No | Implementation-specific metadata. |
+
+### TraceEvent
+
+**Purpose:** Immutable audit log entry for a single significant lifecycle event. Append-only.
+
+**Source of truth:** [`contracts/json/trace_event.schema.json`](../contracts/json/trace_event.schema.json) · [`core.py` TraceEvent](../contracts/python/src/weaver_contracts/core.py)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `event_id` | `string` (minLength 1) | Yes | Unique event identifier. |
+| `event_type` | `enum{…}` | Yes | One of the values listed below. |
+| `timestamp` | `string` (date-time) | Yes | ISO 8601 event time. |
+| `capability_id` | `string \| null` | No | Capability involved, if applicable. |
+| `principal` | `string \| null` | No | Principal involved, if applicable. |
+| `decision_id` | `string \| null` | No | Associated `PolicyDecision`, if applicable. |
+| `frame_id` | `string \| null` | No | Associated `Frame`, if applicable. |
+| `handle_id` | `string \| null` | No | Associated `Handle`, if applicable. |
+| `outcome` | `enum{"success","failure","partial"}` | No | High-level outcome. |
+| `error_message` | `string \| null` | No | Error message for failure events. |
+| `metadata` | `object` | No | Implementation-specific metadata. |
+
+**Allowed `event_type` values:** `capability_authorized`, `capability_denied`, `capability_executed`, `firewall_applied`, `handle_created`, `handle_resolved`, `token_issued`, `token_invalidated`, `flow_started`, `flow_step_started`, `flow_step_completed`, `flow_completed`, `flow_failed`. Adding a new value requires a spec update (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
+
+---
+
+## Extended types (7)
+
+Extended types are optional. None is required for spec compliance. They live in [`contracts/python/src/weaver_contracts/extended.py`](../contracts/python/src/weaver_contracts/extended.py) only — there are no JSON Schemas for Extended types yet. Per [VERSIONING.md](VERSIONING.md), Extended contracts may have breaking changes in MINOR versions.
+
+Adopters typically attach Extended objects to their own payloads via the `metadata` field of a Core contract (Core schemas set `additionalProperties: true`), or by composing them into Extended wrappers like `ExtendedFrameMetadata`.
+
+### TelemetryHint
+
+**Purpose:** Observability metadata attachable to any event or contract.
+
+**Source of truth:** [`extended.py` TelemetryHint](../contracts/python/src/weaver_contracts/extended.py)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `trace_id` | `Optional[str]` (default `None`) | No | Distributed-trace identifier. |
+| `span_id` | `Optional[str]` (default `None`) | No | Span identifier within the trace. |
+| `baggage` | `Dict[str, str]` (default `{}`) | No | Free-form trace baggage. |
+
+**Relationship to Core:** Carried as metadata alongside any Core contract — most commonly on `Frame` or `TraceEvent` payloads.
+
+**Example:**
+
+```json
+{
+  "trace_id": "trace-20260308-001",
+  "span_id": "span-20260308-001",
+  "baggage": {"tenant": "acme", "request_id": "req-20260308-001"}
+}
+```
+
+### SchemaFingerprint
+
+**Purpose:** Records the schema version and content hash for a contract payload, supporting schema evolution and drift detection.
+
+**Source of truth:** [`extended.py` SchemaFingerprint](../contracts/python/src/weaver_contracts/extended.py)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `schema_id` | `str` (non-empty) | Yes | The schema's `$id` (or another stable identifier). |
+| `schema_version` | `str` (non-empty) | Yes | Version of the schema referenced. |
+| `content_hash` | `Optional[str]` (default `None`) | No | Hex digest of the payload (length depends on `hash_algorithm`). |
+| `hash_algorithm` | `str` (default `"sha256"`) | No | Hash algorithm; default produces a 64-character hex digest. |
+
+**Relationship to Core:** Pairs with any Core payload to declare "this object validates against schema X version Y". Useful when receiver and sender may have different schema generations.
+
+**Example:**
+
+```json
+{
+  "schema_id": "https://weaver-spec.dev/contracts/v0/frame.schema.json",
+  "schema_version": "0.2.0",
+  "content_hash": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+  "hash_algorithm": "sha256"
+}
+```
+
+### RedactionPolicy
+
+**Purpose:** Describes the redaction rules applied by the firewall when producing a `Frame`.
+
+**Source of truth:** [`extended.py` RedactionPolicy](../contracts/python/src/weaver_contracts/extended.py)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `policy_id` | `str` (non-empty) | Yes | Identifier of the policy applied. |
+| `redacted_fields` | `List[str]` (default `[]`) | No | Field paths that were redacted. |
+| `truncated_fields` | `List[str]` (default `[]`) | No | Field paths that were truncated. |
+| `redaction_reason` | `Optional[str]` (default `None`) | No | Human-readable reason. |
+| `pii_detected` | `bool` (default `False`) | No | Whether PII was found in raw output. |
+| `pii_types` | `List[str]` (default `[]`) | No | Categories of PII detected. |
+
+**Relationship to Core:** Documents the firewall transformation that produced a `Frame`. Composed into `ExtendedFrameMetadata.redaction_policy`.
+
+**Example:**
+
+```json
+{
+  "policy_id": "policy-default-2026Q1",
+  "redacted_fields": ["headers.authorization"],
+  "truncated_fields": ["body.text"],
+  "redaction_reason": "Detected secret in upstream response.",
+  "pii_detected": true,
+  "pii_types": ["email"]
+}
+```
+
+### UIHint
+
+**Purpose:** Display guidance for UI layers that render `ChoiceCard` items.
+
+**Source of truth:** [`extended.py` UIHint](../contracts/python/src/weaver_contracts/extended.py)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `icon` | `Optional[str]` (default `None`) | No | Icon identifier or URI. |
+| `color` | `Optional[str]` (default `None`) | No | Display color (CSS, theme token, etc.). |
+| `priority` | `Optional[int]` (default `None`) | No | Display priority. |
+| `group` | `Optional[str]` (default `None`) | No | Logical grouping label. |
+| `disabled` | `bool` (default `False`) | No | Whether the item should be rendered as disabled. |
+| `tooltip` | `Optional[str]` (default `None`) | No | Hover tooltip text. |
+
+**Relationship to Core:** Pairs with a `SelectableItem` or `ChoiceCard` for clients that render the menu. Composed into `ExtendedSelectableItemMetadata.ui_hint`.
+
+**Example:**
+
+```json
+{
+  "icon": "search",
+  "color": "#1f6feb",
+  "priority": 1,
+  "group": "retrieval",
+  "tooltip": "Full-text search across docs."
+}
+```
+
+### RiskAssessment
+
+**Purpose:** Optional risk metadata for a capability invocation.
+
+**Source of truth:** [`extended.py` RiskAssessment](../contracts/python/src/weaver_contracts/extended.py)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `risk_level` | `enum{"low","medium","high","critical"}` (default `"low"`) | No | Risk classification. Validated in `__post_init__`. |
+| `risk_reasons` | `List[str]` (default `[]`) | No | Free-form rationale entries. |
+| `requires_human_approval` | `bool` (default `False`) | No | Whether the invocation requires a human approver. |
+| `approval_principal` | `Optional[str]` (default `None`) | No | Identity required to approve. |
+| `mitigations` | `List[str]` (default `[]`) | No | Mitigations already applied. |
+
+**Relationship to Core:** Pairs with a `RoutingDecision`, `PolicyDecision`, or `SelectableItem` to convey risk. Composed into `ExtendedSelectableItemMetadata.risk_assessment`.
+
+**Example:**
+
+```json
+{
+  "risk_level": "high",
+  "risk_reasons": ["destructive_action"],
+  "requires_human_approval": true,
+  "approval_principal": "user:operator-on-call",
+  "mitigations": ["dry_run_preview"]
+}
+```
+
+### ExtendedFrameMetadata
+
+**Purpose:** Wrapper that bundles common Extended metadata for a `Frame`.
+
+**Source of truth:** [`extended.py` ExtendedFrameMetadata](../contracts/python/src/weaver_contracts/extended.py)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `redaction_policy` | `Optional[RedactionPolicy]` (default `None`) | No | Policy applied by the firewall. |
+| `telemetry` | `Optional[TelemetryHint]` (default `None`) | No | Observability metadata. |
+| `schema_fingerprint` | `Optional[SchemaFingerprint]` (default `None`) | No | Schema version and content hash. |
+| `confidence_score` | `Optional[float]` (default `None`) | No | Optional confidence value attached by the firewall. |
+| `source_capability_version` | `Optional[str]` (default `None`) | No | Version of the capability that produced the underlying artifact. |
+| `extra` | `Dict[str, Any]` (default `{}`) | No | Free-form additional metadata. |
+
+**Relationship to Core:** Attach to a `Frame` (typically inside `Frame.metadata`) to enrich it without modifying the Core schema.
+
+**Example:**
+
+```json
+{
+  "redaction_policy": {
+    "policy_id": "policy-default-2026Q1",
+    "redacted_fields": ["headers.authorization"]
+  },
+  "telemetry": {"trace_id": "trace-20260308-001"},
+  "confidence_score": 0.93,
+  "source_capability_version": "1.4.0"
+}
+```
+
+### ExtendedSelectableItemMetadata
+
+**Purpose:** Wrapper that bundles UI and risk metadata for a `SelectableItem`.
+
+**Source of truth:** [`extended.py` ExtendedSelectableItemMetadata](../contracts/python/src/weaver_contracts/extended.py)
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `ui_hint` | `Optional[UIHint]` (default `None`) | No | Display metadata. |
+| `risk_assessment` | `Optional[RiskAssessment]` (default `None`) | No | Risk metadata. |
+| `estimated_duration_ms` | `Optional[int]` (default `None`) | No | Estimated time to complete the action. |
+| `requires_confirmation` | `bool` (default `False`) | No | Whether the UI should require a confirmation step. |
+| `extra` | `Dict[str, Any]` (default `{}`) | No | Free-form additional metadata. |
+
+**Relationship to Core:** Attach to a `SelectableItem` (typically inside `SelectableItem.metadata`) to provide UI and risk hints without modifying the Core schema.
+
+**Example:**
+
+```json
+{
+  "ui_hint": {"icon": "delete", "color": "#cf222e"},
+  "risk_assessment": {"risk_level": "high", "requires_human_approval": true},
+  "estimated_duration_ms": 800,
+  "requires_confirmation": true
+}
+```
+
+---
+
+## Updating this reference
+
+This file mirrors the JSON Schemas in [`contracts/json/`](../contracts/json/) and the Python dataclasses in [`extended.py`](../contracts/python/src/weaver_contracts/extended.py). When either source changes, update the corresponding row(s) in the same PR. Treat the schema or dataclass as authoritative; this document is derived.

--- a/docs/CONTRACT_REFERENCE.md
+++ b/docs/CONTRACT_REFERENCE.md
@@ -19,7 +19,7 @@ If this document ever disagrees with a schema or dataclass, the schema or datacl
 
 - **Required** means listed in the JSON Schema's `required` array (Core) or has no default in the Python dataclass (Extended).
 - **Type** uses JSON Schema vocabulary for Core (`string`, `object`, `array<X>`, `string | null`, `enum{…}`, `date-time` for ISO 8601) and Python typing vocabulary for Extended (`str`, `Optional[X]`, `List[X]`, `Dict[str, str]`).
-- ID fields require `minLength: 1` (non-empty strings). IDs are not required to be UUIDs; slug-style identifiers are common in sample payloads.
+- Required ID fields (e.g., `SelectableItem.id`, `ChoiceCard.id`, `RoutingDecision.id`, `Capability.id`, `CapabilityToken.token_id`, `PolicyDecision.decision_id`, `Frame.frame_id`, `Handle.handle_id`, `TraceEvent.event_id`) carry `minLength: 1`. Optional ID-like fields (e.g., `SelectableItem.capability_id`, `RoutingDecision.selected_item_id`, `TraceEvent.capability_id`) are plain `string` or `string | null` without `minLength`. IDs are not required to be UUIDs; slug-style identifiers are common in sample payloads.
 - All Core schemas set `additionalProperties: true`, so adopters may add namespaced fields (e.g., `x_myorg_*`) without breaking validation.
 
 ---

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -160,7 +160,7 @@ Two versions are compatible when they share the same MAJOR version. The Python p
 ```python
 from weaver_contracts.version import CONTRACT_VERSION, is_compatible
 
-assert is_compatible(peer_version)   # raises if MAJOR differs
+assert is_compatible(peer_version)   # returns False if MAJOR differs; assert raises AssertionError
 ```
 
 In languages other than Python, do the same MAJOR-version comparison yourself. The compatibility table in [VERSIONING.md](VERSIONING.md) tracks which sibling-repo versions are known to interoperate with which contract versions. If you publish your service, declare your supported contract MAJOR(s) explicitly so consumers know which payloads to send.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -92,3 +92,117 @@ No. The Python package (`weaver_contracts`) is a convenience layer for Python im
 ## What Python versions are supported?
 
 The `weaver_contracts` package requires Python 3.9+. It uses only the standard library at runtime (no third-party dependencies). `jsonschema` is a development/test dependency only.
+
+---
+
+## How do I add a new capability to my agent?
+
+A `Capability` is a registry entry, not a class to instantiate at runtime. The minimum steps:
+
+1. Pick a stable, namespaced `id` (e.g., `org.myapp.search_docs`). Capability IDs are immutable once published — treat them like API endpoints.
+2. Construct a `Capability` with `id`, `name`, `version`, and `description`. Optionally declare `input_schema_ref` and `output_schema_ref` URIs pointing to your service's own JSON Schemas (these are not enforced by weaver-spec).
+3. Register the `Capability` in your agent-kernel's capability registry so that contextweaver can include it as a `SelectableItem` candidate.
+4. Surface the capability to contextweaver — the routing layer must be able to discover it so it can produce `ChoiceCard` entries pointing at it.
+
+See `Capability` in [CONTRACT_REFERENCE.md](CONTRACT_REFERENCE.md) for the full field table, and the contextweaver integration snippet in [QUICKSTART.md](QUICKSTART.md) for how a `SelectableItem` references a `capability_id`.
+
+---
+
+## How do I extend Frame metadata without modifying Core?
+
+Use `ExtendedFrameMetadata` (or your own namespaced fields) and attach it via `Frame.metadata`. Core schemas declare `additionalProperties: true`, so adopter-specific keys never break validation. Concretely:
+
+```python
+from weaver_contracts import Frame
+from weaver_contracts.extended import (
+    ExtendedFrameMetadata,
+    RedactionPolicy,
+    TelemetryHint,
+)
+from dataclasses import asdict
+from datetime import datetime, timezone
+
+extended = ExtendedFrameMetadata(
+    redaction_policy=RedactionPolicy(policy_id="policy-2026Q1"),
+    telemetry=TelemetryHint(trace_id="trace-001"),
+)
+frame = Frame(
+    frame_id="f-001",
+    capability_id="org.myapp.search_docs",
+    summary="Found 3 documents.",
+    created_at=datetime.now(timezone.utc),
+    metadata={"extended": asdict(extended)},
+)
+```
+
+Do not propose adding `redaction_policy`, `telemetry`, etc. as direct Core fields — that violates invariant I-04 (Core contracts minimal and stable).
+
+---
+
+## How do I validate payloads against schemas in my language?
+
+Use any JSON Schema Draft 2020-12 validator. The pattern is identical across languages:
+
+- **Python:** `jsonschema` (`Draft202012Validator`, with `format_checker` enabled).
+- **JavaScript/TypeScript:** `ajv` (`ajv/dist/2020`) plus `ajv-formats` for `date-time` and similar formats.
+- **Java/Kotlin:** `networknt/json-schema-validator` (set `SpecVersionDetector` to Draft 2020-12).
+- **Go:** `santhosh-tekuri/jsonschema/v5`.
+- **Rust:** `jsonschema` crate (`Draft202012`).
+
+Critical detail: always enable the format-keyword checker. Without it, `date-time` and similar formats are not enforced, and you will accept payloads the rest of the ecosystem rejects. Copy-paste examples for Python and JS/TS live in [QUICKSTART.md](QUICKSTART.md) and [`contracts/json/README.md`](../contracts/json/README.md).
+
+---
+
+## How do I handle contract version mismatches between services?
+
+Two versions are compatible when they share the same MAJOR version. The Python package exposes a helper:
+
+```python
+from weaver_contracts.version import CONTRACT_VERSION, is_compatible
+
+assert is_compatible(peer_version)   # raises if MAJOR differs
+```
+
+In languages other than Python, do the same MAJOR-version comparison yourself. The compatibility table in [VERSIONING.md](VERSIONING.md) tracks which sibling-repo versions are known to interoperate with which contract versions. If you publish your service, declare your supported contract MAJOR(s) explicitly so consumers know which payloads to send.
+
+A breaking Core contract change always increments MAJOR and goes through the ADR process described in [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+---
+
+## How do I add telemetry to my contract flows?
+
+Use the Extended `TelemetryHint` type for trace IDs and baggage, and emit a `TraceEvent` for each significant lifecycle step (authorization, execution, firewall application, handle creation, etc.). The `TraceEvent.event_type` enum lists the canonical event types (`capability_authorized`, `capability_executed`, `firewall_applied`, …) — see [CONTRACT_REFERENCE.md](CONTRACT_REFERENCE.md) for the complete list. Attach `TelemetryHint` either inside a `Frame.metadata` or in a parallel `ExtendedFrameMetadata.telemetry` field. Invariant I-02 already requires every execution to be audited, so `TraceEvent` is the canonical observability hook; telemetry hints are additive.
+
+---
+
+## How do I propose a new field for a Core contract?
+
+Most "new field" proposals belong in Extended, not Core. Before opening an issue, ask:
+
+1. Would every adopter — contextweaver-only, agent-kernel-only, and ChainWeaver — need this field? If not, it belongs in Extended (see invariant I-04).
+2. Does it weaken any existing constraint? Loosening an `enum`, dropping a `required` entry, removing a `minLength` — these are breaking changes regardless of whether existing payloads remain valid.
+
+If the field genuinely belongs in Core, open an ADR-proposal issue using the `.github/ISSUE_TEMPLATE/adr_proposal.yml` form. Follow the ADR process in [CONTRIBUTING.md](../CONTRIBUTING.md): issue → minimum 3 business days of discussion → PR that lands all six artifacts (schema, dataclass, sample payload, roundtrip test, CHANGELOG, version bump) plus an ADR file in [`docs/adr/`](adr/). Cross-repo impact must be flagged in the PR description.
+
+---
+
+## What's the difference between Frame and Handle?
+
+A `Frame` is the LLM-safe view; a `Handle` is an opaque reference to the raw artifact.
+
+- A `Frame` is what contextweaver and the LLM see. Its `summary` is human-readable and firewall-filtered. It never contains raw output (invariants I-01, I-05).
+- A `Handle` is an access-controlled pointer to the full artifact, which lives in the HandleStore. The `Handle` itself carries no payload; resolving it back to raw bytes requires authorization through agent-kernel.
+
+A `Frame` may reference one or more handles via `handle_refs`. Adopters that need the raw artifact (for archival, replay, or downstream processing) resolve a handle through the kernel; adopters that only need to feed the LLM consume the `Frame` and never touch the handle. This separation exists because raw output may contain secrets, PII, large binaries, or injection vectors — see [BOUNDARIES.md](BOUNDARIES.md) for the artifact-ownership table.
+
+---
+
+## How do I test my implementation against the spec?
+
+Validate your payloads against the JSON Schemas in [`contracts/json/`](../contracts/json/) at every layer boundary. A practical conformance pattern:
+
+1. **Schema validation in unit tests.** For every contract your service produces or consumes, write a test that loads the schema (Draft 2020-12, format-checker enabled) and validates a representative payload. The sample payloads in [`examples/sample_payloads/`](../examples/sample_payloads/) are a good source of starter fixtures.
+2. **Invariant assertions.** Add tests that exercise the constraints in [INVARIANTS.md](INVARIANTS.md) that apply to your layer — for example, "every `Frame` we emit has a non-empty `summary` and never contains raw payload text" or "every `CapabilityToken` we accept has `expires_at` or `single_use=true`".
+3. **Walkthrough fixtures.** Use the failure scenarios and orchestration walkthroughs in [`examples/`](../examples/) as integration fixtures.
+
+A canonical, repo-managed conformance suite is tracked separately (issue #4).

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,314 @@
+# Quick-Start Integration Guide
+
+A minimal, copy-paste path for getting productive with the Weaver contracts in Python or JavaScript/TypeScript.
+
+For deeper background, read [ADOPTION_GUIDE.md](ADOPTION_GUIDE.md) (which adoption mode fits you) and [CONTRACT_REFERENCE.md](CONTRACT_REFERENCE.md) (full field reference). For boundary rules and invariants you must respect, see [BOUNDARIES.md](BOUNDARIES.md) and [INVARIANTS.md](INVARIANTS.md).
+
+---
+
+## What this guide covers
+
+- Installing the language-agnostic JSON Schemas and the optional Python package.
+- Constructing, serializing, deserializing, and validating Core contracts.
+- Constructing an Extended (optional) contract for telemetry.
+- One integration snippet per sibling repo (contextweaver, agent-kernel, ChainWeaver).
+
+This guide does **not** add any runtime dependencies to your application beyond the JSON Schema validator of your choice (and, optionally, the `weaver_contracts` Python package).
+
+---
+
+## Prerequisites
+
+- For the Python path: Python 3.9 or newer.
+- For the JS/TS path: Node.js 18 or newer, with `ajv` for validation.
+- A clone of this repository (for direct schema access) **or** the published JSON Schema files served at the `$id` URIs declared in each schema.
+
+---
+
+## Python
+
+### Install
+
+The Python package vendors the same field shapes as the JSON Schemas as stdlib `dataclasses`. Pick whichever install line works for your environment:
+
+```bash
+# From PyPI (preferred once the release is available):
+pip install weaver_contracts
+
+# From a local checkout (always works):
+pip install -e ./contracts/python
+```
+
+Install the `dev` extras (`pytest`, `jsonschema`, `mypy`, `pytest-cov`) only if you intend to run the spec's own tests or do schema validation in development.
+
+### Construct a Core contract
+
+```python
+from datetime import datetime, timezone
+
+from weaver_contracts import (
+    SelectableItem,
+    ChoiceCard,
+    RoutingDecision,
+)
+
+item = SelectableItem(
+    id="search-docs",
+    label="Search documentation",
+    description="Full-text search across the product documentation index.",
+    capability_id="org.myapp.search_docs",
+)
+card = ChoiceCard(
+    id="card-retrieval",
+    items=[item],
+    context_hint="Select the most appropriate document retrieval action.",
+)
+decision = RoutingDecision(
+    id="rd-20260308-001",
+    choice_cards=[card],
+    timestamp=datetime.now(timezone.utc),
+    selected_item_id="search-docs",
+    selected_card_id="card-retrieval",
+)
+```
+
+Construction-time validation runs in each dataclass's `__post_init__`. For example, a `SelectableItem` with an empty `id` raises `ValueError` immediately.
+
+### Serialize and deserialize
+
+The Python types are plain dataclasses, so any JSON-friendly serializer works. The shortest stdlib path is `dataclasses.asdict` plus a small helper for `datetime`:
+
+```python
+import json
+from dataclasses import asdict
+from datetime import datetime
+
+def _default(value):
+    if isinstance(value, datetime):
+        return value.isoformat()
+    raise TypeError(f"Not serializable: {type(value).__name__}")
+
+payload = json.dumps(asdict(decision), default=_default)
+```
+
+To deserialize, parse the JSON and re-hydrate the dataclasses by hand (or use your preferred deserialization library — `pydantic`, `attrs`, `cattrs`, etc.). The `weaver_contracts` package deliberately does not ship a deserializer to keep its surface minimal.
+
+### Validate a payload against a JSON Schema
+
+The JSON Schemas in [`contracts/json/`](../contracts/json/) are the language-agnostic source of truth. Use any Draft 2020-12 validator:
+
+```python
+import json
+import jsonschema
+
+with open("contracts/json/routing_decision.schema.json") as fh:
+    schema = json.load(fh)
+with open("examples/sample_payloads/routing_decision.json") as fh:
+    payload = json.load(fh)
+
+jsonschema.validate(
+    payload,
+    schema,
+    format_checker=jsonschema.Draft202012Validator.FORMAT_CHECKER,
+)
+```
+
+The `format_checker` argument is what catches `date-time` violations on fields such as `timestamp`, `issued_at`, and `created_at`. The repository's CI uses the same call.
+
+### Construct an Extended (optional) contract
+
+Extended contracts are not required for spec compliance. They carry optional metadata such as telemetry and risk hints.
+
+```python
+from weaver_contracts.extended import TelemetryHint
+
+telemetry = TelemetryHint(
+    trace_id="trace-20260308-001",
+    span_id="span-20260308-001",
+    baggage={"tenant": "acme", "request_id": "req-20260308-001"},
+)
+```
+
+Extended types can be attached to your own payloads via the contract's `metadata` field (`additionalProperties: true` on every Core schema makes this safe). See [CONTRACT_REFERENCE.md](CONTRACT_REFERENCE.md) for the full Extended catalog and per-type relationships.
+
+### Check version compatibility
+
+```python
+from weaver_contracts.version import CONTRACT_VERSION, is_compatible
+
+print(CONTRACT_VERSION)                # e.g. "0.2.0"
+print(is_compatible("0.1.0"))          # True — same MAJOR
+print(is_compatible("1.0.0"))          # False — different MAJOR
+```
+
+`is_compatible` enforces the contract promise documented in [VERSIONING.md](VERSIONING.md): two versions interoperate when they share the same MAJOR.
+
+---
+
+## JavaScript / TypeScript
+
+### Validate with ajv
+
+The repository's [`contracts/json/README.md`](../contracts/json/README.md) documents this pattern; it is reproduced here for completeness.
+
+```js
+// 1. Install: npm install ajv ajv-formats
+const Ajv2020 = require("ajv/dist/2020");
+const addFormats = require("ajv-formats");
+
+const ajv = new Ajv2020({ strict: false });
+addFormats(ajv);
+
+// Load the Core schemas you need. choice_card refs selectable_item; routing_decision refs choice_card.
+ajv.addSchema(require("./contracts/json/selectable_item.schema.json"));
+ajv.addSchema(require("./contracts/json/choice_card.schema.json"));
+
+const validate = ajv.compile(
+  require("./contracts/json/routing_decision.schema.json"),
+);
+
+const payload = require("./examples/sample_payloads/routing_decision.json");
+if (!validate(payload)) {
+  console.error(validate.errors);
+  process.exit(1);
+}
+```
+
+`addFormats` is what enforces `date-time` and other format keywords. The `Ajv2020` import matches the Draft 2020-12 dialect declared by every schema's `$schema` field.
+
+### Construct a contract-conformant object
+
+```ts
+// Authoring style — these object literals mirror the JSON Schema shapes.
+// Required fields per selectable_item.schema.json: id, label, description.
+const item = {
+  id: "search-docs",
+  label: "Search documentation",
+  description: "Full-text search across the product documentation index.",
+  capability_id: "org.myapp.search_docs",
+};
+```
+
+### Type generation hint
+
+If you want compile-time types in TypeScript without hand-writing interfaces, run a JSON-Schema-to-TypeScript codegen step against `contracts/json/*.schema.json`:
+
+```bash
+npx json-schema-to-typescript contracts/json/routing_decision.schema.json \
+  --no-additionalProperties=false \
+  > types/RoutingDecision.ts
+```
+
+The flag preserves the `additionalProperties: true` declared on every Core schema. See [contracts/json/README.md](../contracts/json/README.md) for schema design principles you may need to honor at the type level.
+
+---
+
+## Per-sibling-repo integration
+
+Each sibling repo produces or consumes a specific subset of the contracts. The snippets below show the minimum each side needs.
+
+### contextweaver — producing a RoutingDecision
+
+contextweaver compiles bounded `ChoiceCard` lists and emits a `RoutingDecision`. It never executes a tool and never receives raw output (see [INVARIANTS.md](INVARIANTS.md) I-03 and I-05).
+
+```python
+from datetime import datetime, timezone
+
+from weaver_contracts import (
+    SelectableItem,
+    ChoiceCard,
+    RoutingDecision,
+)
+
+def build_routing_decision(candidates, intent) -> RoutingDecision:
+    items = [
+        SelectableItem(
+            id=cap.short_id,
+            label=cap.label,
+            description=cap.short_description,
+            capability_id=cap.id,
+        )
+        for cap in rank(candidates, intent)[:7]   # bounded list per I-03
+    ]
+    card = ChoiceCard(id=f"card-{intent.slug}", items=items)
+    return RoutingDecision(
+        id=f"rd-{intent.slug}",
+        choice_cards=[card],
+        timestamp=datetime.now(timezone.utc),
+    )
+```
+
+### agent-kernel — consuming a RoutingDecision, producing Frame + Handle
+
+agent-kernel validates the `CapabilityToken`, authorizes the capability (emits a `PolicyDecision`), executes the tool, and produces a `Frame` (LLM-safe) plus optional `Handle` (opaque reference to the raw artifact). Raw output never leaves the kernel.
+
+```python
+from datetime import datetime, timezone
+
+from weaver_contracts import (
+    RoutingDecision,
+    CapabilityToken,
+    PolicyDecision,
+    Frame,
+    Handle,
+)
+
+def execute(decision: RoutingDecision, token: CapabilityToken):
+    capability_id = _resolve(decision)
+    policy = PolicyDecision(
+        decision_id=f"pd-{decision.id}",
+        decision="allow",
+        capability_id=capability_id,
+        principal=token.principal,
+        token_id=token.token_id,
+        timestamp=datetime.now(timezone.utc),
+    )
+    raw = _invoke_tool(capability_id, _args(decision))   # internal to kernel
+    handle = Handle(
+        handle_id=f"h-{decision.id}",
+        capability_id=capability_id,
+        artifact_type="application/json",
+        created_at=datetime.now(timezone.utc),
+        byte_size=len(raw),
+    )
+    frame = Frame(
+        frame_id=f"f-{decision.id}",
+        capability_id=capability_id,
+        summary=_safe_summary(raw),
+        created_at=datetime.now(timezone.utc),
+        handle_refs=[handle.handle_id],
+    )
+    return policy, frame, handle
+```
+
+The `_safe_summary` step is the firewall boundary required by invariants I-01 and I-05. See [BOUNDARIES.md](BOUNDARIES.md) for the artifact-ownership table this code respects.
+
+### ChainWeaver — orchestrating multi-agent flow
+
+ChainWeaver coordinates multi-step flows. Tool-invocation steps must delegate to agent-kernel (or a compatible execution layer) — see I-07.
+
+```python
+from weaver_contracts import RoutingDecision
+
+def run_flow(steps, token):
+    state = {}
+    for step in steps:
+        decision: RoutingDecision = step.route(state)
+        # Delegate execution; do not call tools directly.
+        policy, frame, _handle = agent_kernel.execute(decision, token)
+        if policy.decision == "deny":
+            return _abort(policy)
+        state[step.id] = frame
+    return state
+```
+
+The full multi-agent walkthrough is in [`examples/multi_agent_orchestration.md`](../examples/multi_agent_orchestration.md).
+
+---
+
+## Next steps
+
+- **Pick your adoption mode:** [ADOPTION_GUIDE.md](ADOPTION_GUIDE.md) lists the seven supported modes and the minimum contracts each requires.
+- **Look up fields:** [CONTRACT_REFERENCE.md](CONTRACT_REFERENCE.md) has the complete field tables for all 16 Core and Extended types.
+- **Common questions:** [FAQ.md](FAQ.md) covers extending contracts, version mismatches, telemetry, and spec compliance.
+- **Read the worked examples:** [`examples/minimal_e2e_sequence.md`](../examples/minimal_e2e_sequence.md), [`examples/failure_scenarios.md`](../examples/failure_scenarios.md), [`examples/multi_agent_orchestration.md`](../examples/multi_agent_orchestration.md), [`examples/partial_capability_routing.md`](../examples/partial_capability_routing.md).

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -95,25 +95,40 @@ To deserialize, parse the JSON and re-hydrate the dataclasses by hand (or use yo
 
 ### Validate a payload against a JSON Schema
 
-The JSON Schemas in [`contracts/json/`](../contracts/json/) are the language-agnostic source of truth. Use any Draft 2020-12 validator:
+The JSON Schemas in [`contracts/json/`](../contracts/json/) are the language-agnostic source of truth. Use any Draft 2020-12 validator.
+
+`routing_decision.schema.json` `$ref`s `choice_card.schema.json`, which in turn `$ref`s `selectable_item.schema.json`. With a plain `jsonschema.validate(...)` call, those references would trigger remote URL resolution and fail offline. Pre-load every Core schema into a `referencing.Registry` so validation stays local — this is the same pattern the repository's CI uses (`Draft202012Validator` + `iter_errors`, with format checking enabled):
 
 ```python
 import json
-import jsonschema
+from pathlib import Path
 
-with open("contracts/json/routing_decision.schema.json") as fh:
-    schema = json.load(fh)
-with open("examples/sample_payloads/routing_decision.json") as fh:
-    payload = json.load(fh)
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT202012
 
-jsonschema.validate(
-    payload,
+registry = Registry()
+for schema_path in Path("contracts/json").glob("*.schema.json"):
+    schema = json.loads(schema_path.read_text())
+    registry = registry.with_resource(
+        uri=schema["$id"],
+        resource=Resource(contents=schema, specification=DRAFT202012),
+    )
+
+schema = json.loads(Path("contracts/json/routing_decision.schema.json").read_text())
+payload = json.loads(Path("examples/sample_payloads/routing_decision.json").read_text())
+
+validator = Draft202012Validator(
     schema,
-    format_checker=jsonschema.Draft202012Validator.FORMAT_CHECKER,
+    registry=registry,
+    format_checker=Draft202012Validator.FORMAT_CHECKER,
 )
+errors = sorted(validator.iter_errors(payload), key=lambda e: list(e.absolute_path))
+if errors:
+    raise SystemExit("\n".join(f"{'/'.join(map(str, e.absolute_path)) or '<root>'}: {e.message}" for e in errors))
 ```
 
-The `format_checker` argument is what catches `date-time` violations on fields such as `timestamp`, `issued_at`, and `created_at`. The repository's CI uses the same call.
+The `format_checker` argument is what catches `date-time` violations on fields such as `timestamp`, `issued_at`, and `created_at`. CI enables the same Draft 2020-12 format checker — see [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) (`validate-walkthroughs` job).
 
 ### Construct an Extended (optional) contract
 
@@ -228,7 +243,7 @@ def build_routing_decision(candidates, intent) -> RoutingDecision:
             description=cap.short_description,
             capability_id=cap.id,
         )
-        for cap in rank(candidates, intent)[:7]   # bounded list per I-03
+        for cap in rank(candidates, intent)[:7]   # 3-7 is the practical range; choice_card.schema.json caps at maxItems: 20
     ]
     card = ChoiceCard(id=f"card-{intent.slug}", items=items)
     return RoutingDecision(


### PR DESCRIPTION
## Description

Adds two new documentation files and extends the existing FAQ to improve adoption and integration.
Closes #19, #20, #23.

### `docs/CONTRACT_REFERENCE.md` (new) — closes #20

A single-page field reference for all 16 contract types (9 Core + 7 Extended). Includes:

- Purpose statement and source-of-truth links for each type
- Complete field tables with type, required status, and description
- Conventions for reading the reference (required fields, type vocabulary, ID constraints, `additionalProperties`)
- Notes on Extended-type versioning and the distinction between Core and Extended sources of truth
- Guidance on updating the reference when schemas or dataclasses change

### `docs/QUICKSTART.md` (new) — closes #19

A minimal, copy-paste integration guide for Python and JavaScript/TypeScript. Includes:

- Installation instructions for JSON Schemas and the optional Python package
- Concrete code examples for constructing, serializing, deserializing, and validating Core contracts
- Extended contract construction (TelemetryHint example)
- Per-sibling-repo integration snippets (contextweaver, agent-kernel, ChainWeaver)
- Links to deeper resources (ADOPTION_GUIDE, BOUNDARIES, INVARIANTS, worked examples)

### `docs/FAQ.md` (extended) — closes #23

Adds 8 new Q&A entries covering the most common adopter questions:

- Version mismatch handling (`is_compatible`, MAJOR compatibility)
- Adding fields to Core vs. Extended contracts
- CapabilityToken expiry enforcement
- Validating payloads against JSON Schemas (Python and JS/TS, with Draft 2020-12)
- Telemetry integration with `TelemetryHint` and `TraceEvent`
- Bypassing the Frame firewall
- Viewing the contract version in the installed package

### Supporting changes

- `README.md` — adds links to both new docs
- `CHANGELOG.md` — adds entries for all three additions under the next-release section

---

## Type of change

- [x] Docs only (no contract changes)
- [ ] Additive contract change (new optional field or new type — non-breaking)
- [ ] Breaking contract change (requires ADR — see [CONTRIBUTING.md](CONTRIBUTING.md))
- [ ] CI / tooling change

---

## Six-artifact checklist

- [ ] JSON Schema updated (`contracts/json/`) — or **N/A**
- [ ] Python dataclass updated (`contracts/python/src/weaver_contracts/core.py`) — or **N/A**
- [ ] Sample payload updated (`examples/sample_payloads/`) — or **N/A**
- [ ] Roundtrip test updated (`contracts/python/tests/test_roundtrip_examples.py`) — or **N/A**
- [x] CHANGELOG entry added (`CHANGELOG.md`)
- [ ] Version bumped (`version.py` + `pyproject.toml`) — or **N/A**

---

## Invariants

- [x] I have verified that invariants I-01 through I-07 in `docs/INVARIANTS.md` are not violated by this change.

(No contract changes; documentation only.)

---

## Cross-repo impact

- [ ] **contextweaver** — needs coordinated update
- [ ] **agent-kernel** — needs coordinated update
- [ ] **ChainWeaver** — needs coordinated update
- [x] **No cross-repo impact**

---

## Notes

- `CONTRACT_REFERENCE.md` mirrors the JSON Schemas in `contracts/json/` and Python dataclasses in `contracts/python/src/weaver_contracts/`. It is derived documentation; the schemas and dataclasses remain authoritative.
- `QUICKSTART.md` provides the fastest path to productivity for adopters in Python and JS/TS. Validation examples use the same `referencing.Registry` / `Draft202012Validator` pattern as the `validate-walkthroughs` CI job.
- Both new files are discoverable from `README.md` and cross-reference each other and the existing canonical docs (`ARCHITECTURE.md`, `BOUNDARIES.md`, `GLOSSARY.md`, `VERSIONING.md`, `CONTRIBUTING.md`).
- All three documents are consistent with the current schemas (`v0`) and Python package (`0.2.0`).