### PR TITLE
contracts: cross-project Extended artifact contracts (0.5.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
 
           schemas_by_name = {}
           registry = Registry()
-          for p in Path('contracts/json').glob('*.schema.json'):
+          for p in Path('contracts/json').rglob('*.schema.json'):
               name = p.stem.removesuffix('.schema')
               schema = json.loads(p.read_text(encoding='utf-8'))
               schemas_by_name[name] = schema

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,8 @@ This repository is **documentation + contracts only**.
 | `.github/CODEOWNERS` | Auto-assignment rules for PR review | Adding new paths or reviewers |
 | `.pre-commit-config.yaml` | Pre-commit hook bundle mirroring the CI gates (JSON/YAML/markdown lint, contracts-index freshness, pytest on push) | Onboarding a new contributor; adding a new local validation gate |
 | `.yamllint.yml` | yamllint config tuned for GitHub-flavored YAML (issue forms, workflows) | Adding new YAML files or adjusting workflow style |
-| `contracts/json/` | JSON Schemas (Draft 2020-12) | Adding or modifying contract definitions |
+| `contracts/json/` | Core JSON Schemas (Draft 2020-12) | Adding or modifying Core contract definitions |
+| `contracts/json/extended/` | Extended JSON Schemas (Draft 2020-12) | Adding or modifying Extended contract definitions |
 | `contracts/python/src/weaver_contracts/core.py` | Core contract dataclasses (9 types) | When schemas change — must update in same PR |
 | `contracts/python/src/weaver_contracts/extended.py` | Extended metadata types | Adding optional metadata contracts |
 | `contracts/python/src/weaver_contracts/version.py` | `CONTRACT_VERSION` constant | Every version bump |
@@ -66,7 +67,7 @@ For JSON schema conventions specifically, `contracts/json/README.md` is authorit
 
 JSON Schemas are the language-agnostic source of truth for all **Core** contract definitions. Python Core types must mirror them exactly — same field names, same types, same required/optional status. Zero divergence.
 
-Extended contracts currently have no JSON Schemas — the Python dataclasses in `extended.py` are the source of truth for Extended types.
+Extended contracts may define JSON Schemas under `contracts/json/extended/`. Where an Extended schema exists, it leads and the Python dataclass in `extended.py` must mirror it (same as Core). The original metadata types (`TelemetryHint`, `SchemaFingerprint`, `RedactionPolicy`, `UIHint`, `RiskAssessment`, `ExtendedFrameMetadata`, `ExtendedSelectableItemMetadata`) remain Python-source-of-truth pending their schema retrofit (#46).
 
 ---
 
@@ -213,6 +214,7 @@ For mixed changes, use the prefix for the most impactful change. Mention the sec
 | [docs/DEPRECATIONS.md](docs/DEPRECATIONS.md) | Deprecation register and removal policy |
 | [docs/SCHEMA_HOSTING.md](docs/SCHEMA_HOSTING.md) | `$id` URL pattern, immutability rule, content-addressed index |
 | [docs/DOCS_CONVENTIONS.md](docs/DOCS_CONVENTIONS.md) | Markup convention for normative requirements vs informative notes vs examples |
+| [docs/ARTIFACT_CONTRACTS.md](docs/ARTIFACT_CONTRACTS.md) | Cross-project Extended artifact vocabulary (memory, session handoff, lesson/skill cards, evaluation, safety gate) |
 | [docs/agent-context/architecture.md](docs/agent-context/architecture.md) | Pointers to canonical architecture and boundary docs |
 | [docs/agent-context/workflows.md](docs/agent-context/workflows.md) | Authoritative commands, change sequences, documentation governance |
 | [docs/agent-context/invariants.md](docs/agent-context/invariants.md) | Hard constraints, forbidden shortcuts, safe-vs-unsafe changes |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
 
 ### Added
 
+- Eight new **Extended** cross-project artifact contracts in
+  `weaver_contracts.extended`, each shipped with the full artifact set (JSON
+  Schema under `contracts/json/extended/`, sample payload under
+  `examples/sample_payloads/`, roundtrip test in `tests/test_extended.py`,
+  schema-alignment test in the new `tests/test_extended_schema_alignment.py`,
+  glossary entry, plus coverage/index regeneration):
+  `ReviewArtifact` (Closes #65); `MemoryArtifact` + `SessionHandoff`
+  (Closes #56); `LessonCard` + `SkillCard` (Closes #64); `EvaluationArtifact`
+  (Closes #67); `ArtifactSafetyGateRequest` + `ArtifactSafetyReport`
+  (Closes #63). `EvaluationArtifact` rejects, at construction time, a
+  `high_risk` support state paired with a `deploy` recommendation (a high-risk
+  evaluation is not deployment evidence).
+- `contracts/json/extended/` — first Extended JSON Schemas (8 files). Their
+  `$id` URIs live under the `extended/` namespace and are picked up
+  automatically by `scripts/generate_contracts_index.py`.
+- `docs/ARTIFACT_CONTRACTS.md` — consolidated, informative spec page for the
+  cross-project artifact vocabulary: shared envelope, taxonomy, and a
+  CI-validated inline example per type.
+- `contracts/python/tests/test_extended_schema_alignment.py` — validates every
+  Extended sample payload against its Extended schema, with targeted negative
+  cases.
 - `.pre-commit-config.yaml` — pre-commit hook bundle mirroring the CI gates: `pre-commit-hooks` (trailing whitespace, end-of-file, large file guard, JSON/YAML/TOML/merge-conflict checks), `yamllint`, `markdownlint-cli2`, a local hook running `scripts/check_schema_fields.py`, a local hook running `scripts/generate_contracts_index.py --check`, and a `pre-push`-staged hook that runs the `weaver_contracts` pytest suite. Setup instructions added to `CONTRIBUTING.md`. `pre-commit` and `yamllint` added to `[project.optional-dependencies] dev` in `contracts/python/pyproject.toml`. Closes #14.
 - `.yamllint.yml` — yamllint config tuned for GitHub-flavored YAML (relaxed line length, `truthy.check-keys: false` to permit `on:` in workflows).
 - CI job `yamllint` in `.github/workflows/ci.yml` — lints `.github/ISSUE_TEMPLATE/`, `.github/workflows/`, `.yamllint.yml`, and `.pre-commit-config.yaml` via `yamllint==1.35.1` so malformed templates fail in CI rather than at GitHub form-render time. Closes #35.
@@ -58,8 +79,25 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
   `docs/INTEGRATION_MAP.md`, `contracts/COVERAGE.md`, and
   `examples/interoperability/`.
 - `AGENTS.md` repo map updated with `.github/prompts/`, `.pre-commit-config.yaml`, `.yamllint.yml`, `docs/DOCS_CONVENTIONS.md`, `examples/interoperability/`, `docs/LIFECYCLE.md`, `docs/INTEGRATION_MAP.md`, `scripts/generate_coverage_table.py`, and `contracts/COVERAGE.md`.
+- `scripts/check_schema_fields.py` now scans `contracts/json/**/*.schema.json`
+  recursively so Extended schemas are validated alongside Core.
+- `.github/workflows/ci.yml` — the walkthrough inline-JSON validator resolves
+  schemas recursively (`contracts/json/**`), so inline examples can reference
+  Extended schemas.
+- `AGENTS.md` ("schemas lead" section, repo map, documentation map) and
+  `docs/agent-context/workflows.md` (Extended-contract workflow) updated to
+  reflect that Extended schemas now live under `contracts/json/extended/`; the
+  original 7 Extended metadata types remain Python-source-of-truth pending #46.
+- `contracts/json/README.md` documents the `extended/` subdirectory.
+- Regenerated `contracts/COVERAGE.md` (now 24 contract types) and
+  `well-known/contracts.json` (Extended entries populated; `contract_version`
+  → 0.5.0).
 
-**No Core contract changes** — no JSON schema fields added or removed, no Python dataclass surface changes, no `CONTRACT_VERSION` bump.
+**No Core contract changes** — no Core JSON schema fields added or removed, no
+Core Python dataclass surface changes. This cycle adds eight additive
+**Extended** contract types, which bumps `CONTRACT_VERSION` 0.4.0 → 0.5.0
+(MINOR, per the Extended-contract workflow). No sibling-repo coordination is
+required: the new types are optional and opt-in.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
   `ReviewArtifact` (Closes #65); `MemoryArtifact` + `SessionHandoff`
   (Closes #56); `LessonCard` + `SkillCard` (Closes #64); `EvaluationArtifact`
   (Closes #67); `ArtifactSafetyGateRequest` + `ArtifactSafetyReport`
-  (Closes #63). `EvaluationArtifact` rejects, at construction time, a
-  `high_risk` support state paired with a `deploy` recommendation (a high-risk
-  evaluation is not deployment evidence).
+  (Closes #63). `EvaluationArtifact` rejects — in both the JSON Schema and at
+  Python construction time — a `high_risk` support state paired with a `deploy`
+  recommendation (a high-risk evaluation is not deployment evidence).
 - `contracts/json/extended/` — first Extended JSON Schemas (8 files). Their
   `$id` URIs live under the `extended/` namespace and are picked up
   automatically by `scripts/generate_contracts_index.py`.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This repo is the contract layer for all of the above. You do not need to adopt e
 | Non-negotiable invariants | [docs/INVARIANTS.md](docs/INVARIANTS.md) |
 | End-to-end lifecycle | [docs/LIFECYCLE.md](docs/LIFECYCLE.md) |
 | Cross-repo integration map | [docs/INTEGRATION_MAP.md](docs/INTEGRATION_MAP.md) |
+| Cross-project artifact contracts | [docs/ARTIFACT_CONTRACTS.md](docs/ARTIFACT_CONTRACTS.md) |
 | Term definitions | [docs/GLOSSARY.md](docs/GLOSSARY.md) |
 | Sequence diagrams | [docs/SEQUENCE_DIAGRAMS.md](docs/SEQUENCE_DIAGRAMS.md) |
 | Versioning rules | [docs/VERSIONING.md](docs/VERSIONING.md) |

--- a/contracts/COVERAGE.md
+++ b/contracts/COVERAGE.md
@@ -17,12 +17,12 @@ CI runs the same script with `--check` and fails if this file is stale.
 
 ## Summary
 
-- Total contract types: **16**
-- JSON Schemas: **9 / 16**
-- Python classes: **16 / 16**
-- Sample payloads: **16 / 16**
-- Roundtrip tests: **16 / 16**
-- Schema validation tests: **3 / 16**
+- Total contract types: **24**
+- JSON Schemas: **17 / 24**
+- Python classes: **24 / 24**
+- Sample payloads: **24 / 24**
+- Roundtrip tests: **24 / 24**
+- Schema validation tests: **11 / 24**
 
 ## Coverage table
 
@@ -44,6 +44,14 @@ CI runs the same script with `--check` and fails if this file is stale.
 | Extended | `RiskAssessment` | -- | OK | OK | OK | -- |
 | Extended | `ExtendedFrameMetadata` | -- | OK | OK | OK | -- |
 | Extended | `ExtendedSelectableItemMetadata` | -- | OK | OK | OK | -- |
+| Extended | `ReviewArtifact` | OK | OK | OK | OK | OK |
+| Extended | `MemoryArtifact` | OK | OK | OK | OK | OK |
+| Extended | `SessionHandoff` | OK | OK | OK | OK | OK |
+| Extended | `LessonCard` | OK | OK | OK | OK | OK |
+| Extended | `SkillCard` | OK | OK | OK | OK | OK |
+| Extended | `EvaluationArtifact` | OK | OK | OK | OK | OK |
+| Extended | `ArtifactSafetyGateRequest` | OK | OK | OK | OK | OK |
+| Extended | `ArtifactSafetyReport` | OK | OK | OK | OK | OK |
 
 ## Legend
 

--- a/contracts/json/README.md
+++ b/contracts/json/README.md
@@ -1,6 +1,8 @@
 # JSON Schemas
 
-This directory contains JSON Schema definitions for all Core Weaver contracts.
+This directory contains JSON Schema definitions for the Weaver contracts. Core
+contracts live at the top level; Extended contracts live under
+[`extended/`](extended/).
 
 ## Schema List
 
@@ -15,6 +17,17 @@ This directory contains JSON Schema definitions for all Core Weaver contracts.
 | `frame.schema.json` | Safe, filtered view of a tool execution result |
 | `handle.schema.json` | Opaque reference to a raw artifact in the HandleStore |
 | `trace_event.schema.json` | Immutable audit log entry |
+
+## Extended schemas (`extended/`)
+
+The [`extended/`](extended/) subdirectory holds schemas for optional Extended
+contracts (not required for spec compliance; see invariant I-04). Their `$id`
+URIs live under the `extended/` namespace, e.g.
+`https://weaver-spec.dev/contracts/v0/extended/memory_artifact.schema.json`.
+Extended schemas follow the same design principles below and are picked up
+automatically by `scripts/generate_contracts_index.py`. See
+[`../../docs/ARTIFACT_CONTRACTS.md`](../../docs/ARTIFACT_CONTRACTS.md) for the
+cross-project artifact vocabulary.
 
 ## Usage
 

--- a/contracts/json/extended/artifact_safety_gate_request.schema.json
+++ b/contracts/json/extended/artifact_safety_gate_request.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/artifact_safety_gate_request.schema.json",
+  "title": "ArtifactSafetyGateRequest",
+  "description": "Extended. Inputs to an optional artifact safety gate run that validates agent-produced code/files before a high-impact action. Implementation-neutral: it does not name a specific scanner or rule set.",
+  "type": "object",
+  "required": ["request_id", "repository_root"],
+  "properties": {
+    "request_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for this gate request."
+    },
+    "repository_root": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Root of the repository or workspace being checked."
+    },
+    "artifact_paths": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Paths of the artifacts to check (code, config, docs, manifests)."
+    },
+    "diff_scope": {
+      "type": ["string", "null"],
+      "description": "Optional diff scope, e.g. a git ref range, to bound what is checked."
+    },
+    "policy_level": {
+      "type": "string",
+      "description": "Producer-defined policy strictness, e.g. standard, strict."
+    },
+    "output_format": {
+      "type": "string",
+      "description": "Requested report format, e.g. json."
+    },
+    "capability_id": {
+      "type": ["string", "null"],
+      "description": "Optional Capability ID this gate maps to in agent-kernel."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional implementation-specific metadata.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/artifact_safety_report.schema.json
+++ b/contracts/json/extended/artifact_safety_report.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/artifact_safety_report.schema.json",
+  "title": "ArtifactSafetyReport",
+  "description": "Extended. Output of an artifact safety gate run. The mode field distinguishes an advisory check from a blocking gate; decision is the pass/fail verdict; findings carry severity, message, an optional stable fingerprint, and a remediation hint.",
+  "type": "object",
+  "required": ["report_id", "gate_id", "decision", "created_at"],
+  "properties": {
+    "report_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for this report."
+    },
+    "gate_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the gate/check that produced this report."
+    },
+    "decision": {
+      "type": "string",
+      "enum": ["pass", "fail"],
+      "description": "Pass/fail verdict for the checked artifacts."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when the report was produced."
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["advisory", "blocking"],
+      "description": "Whether the gate is advisory (informational) or blocking (must pass before the action)."
+    },
+    "request_id": {
+      "type": ["string", "null"],
+      "description": "Optional ArtifactSafetyGateRequest ID this report answers."
+    },
+    "target_ref": {
+      "type": ["string", "null"],
+      "description": "Optional reference to what was checked (e.g. a commit or diff range)."
+    },
+    "summary": {
+      "type": ["string", "null"],
+      "description": "Optional short human-readable summary."
+    },
+    "findings": {
+      "type": "array",
+      "description": "Individual findings produced by the gate.",
+      "items": {
+        "type": "object",
+        "required": ["finding_id", "severity", "message"],
+        "properties": {
+          "finding_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Stable identifier for this finding."
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["info", "low", "medium", "high", "critical"],
+            "description": "Severity of the finding."
+          },
+          "message": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Human-readable description of the finding."
+          },
+          "fingerprint": {
+            "type": ["string", "null"],
+            "description": "Optional stable fingerprint for deduplication across runs."
+          },
+          "remediation": {
+            "type": ["string", "null"],
+            "description": "Optional remediation hint."
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Optional structured provenance (tool, version, ruleset).",
+      "additionalProperties": true
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional implementation-specific metadata.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/evaluation_artifact.schema.json
+++ b/contracts/json/extended/evaluation_artifact.schema.json
@@ -102,5 +102,15 @@
       "additionalProperties": true
     }
   },
-  "additionalProperties": true
+  "additionalProperties": true,
+  "if": {
+    "properties": { "support_state": { "const": "high_risk" } },
+    "required": ["support_state"]
+  },
+  "then": {
+    "not": {
+      "properties": { "recommendation_kind": { "const": "deploy" } },
+      "required": ["recommendation_kind"]
+    }
+  }
 }

--- a/contracts/json/extended/evaluation_artifact.schema.json
+++ b/contracts/json/extended/evaluation_artifact.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/evaluation_artifact.schema.json",
+  "title": "EvaluationArtifact",
+  "description": "Extended. A statistical / offline model-evaluation report carried with explicit semantics so agents cannot misuse a headline score. The support_state and recommendation_kind fields encode that a high-risk evaluation is not deployment evidence.",
+  "type": "object",
+  "required": ["artifact_id", "producer", "created_at"],
+  "properties": {
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for this evaluation artifact."
+    },
+    "producer": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The system that produced the evaluation (e.g. skdr-eval)."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when the evaluation was produced."
+    },
+    "artifact_type": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Kind of evaluation, e.g. offline_policy_evaluation."
+    },
+    "producer_version": {
+      "type": ["string", "null"],
+      "description": "Optional producer version for reproducibility."
+    },
+    "target_estimand": {
+      "type": ["string", "null"],
+      "description": "What is being estimated (e.g. the policy value under a target distribution)."
+    },
+    "candidate_policy": {
+      "type": ["string", "null"],
+      "description": "Identifier of the candidate policy being evaluated."
+    },
+    "baseline_policy": {
+      "type": ["string", "null"],
+      "description": "Identifier of the baseline/comparison policy."
+    },
+    "metrics": {
+      "type": "object",
+      "description": "Value estimates and headline metrics.",
+      "additionalProperties": true
+    },
+    "uncertainty": {
+      "type": "object",
+      "description": "Uncertainty quantification (confidence intervals, standard errors).",
+      "additionalProperties": true
+    },
+    "support_state": {
+      "type": "string",
+      "enum": ["ok", "caution", "high_risk"],
+      "description": "Overall support/diagnostic state. high_risk means the evidence cannot back a deploy decision."
+    },
+    "support_diagnostics": {
+      "type": "object",
+      "description": "Diagnostics behind the support_state (overlap, effective sample size).",
+      "additionalProperties": true
+    },
+    "propensity_diagnostics": {
+      "type": "object",
+      "description": "Diagnostics on propensity/weighting assumptions.",
+      "additionalProperties": true
+    },
+    "sensitivity": {
+      "type": "string",
+      "enum": ["public", "internal", "confidential", "restricted"],
+      "description": "Sensitivity level governing how the report may be surfaced."
+    },
+    "warnings": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Heuristic warnings (distinct from mathematical assumptions)."
+    },
+    "recommendation": {
+      "type": ["string", "null"],
+      "description": "Optional human-readable recommendation text."
+    },
+    "recommendation_kind": {
+      "type": ["string", "null"],
+      "enum": ["deploy", "do_not_deploy", "experiment_ready", "needs_more_data", null],
+      "description": "Machine-readable recommendation. 'deploy' is not permitted when support_state is 'high_risk'."
+    },
+    "limitations": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Stated limitations of the evaluation."
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Optional structured provenance (dataset, code version, run id).",
+      "additionalProperties": true
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional implementation-specific metadata.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/lesson_card.schema.json
+++ b/contracts/json/extended/lesson_card.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/lesson_card.schema.json",
+  "title": "LessonCard",
+  "description": "Extended. A reusable lesson derived from traces and approved for reuse. Not a raw trace, raw memory, or generic prompt fragment. The lifecycle_state gates activation: a lesson should pass review before becoming active.",
+  "type": "object",
+  "required": ["lesson_id", "title", "body", "created_at"],
+  "properties": {
+    "lesson_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for this lesson."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short human-readable title."
+    },
+    "body": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The lesson content."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when the lesson was created."
+    },
+    "lifecycle_state": {
+      "type": "string",
+      "enum": ["draft", "in_review", "active", "deprecated"],
+      "description": "Lifecycle state; activation requires passing through review."
+    },
+    "scope": {
+      "type": ["string", "null"],
+      "description": "Optional reuse scope, e.g. repo, team, org, global."
+    },
+    "sensitivity": {
+      "type": "string",
+      "enum": ["public", "internal", "confidential", "restricted"],
+      "description": "Sensitivity level governing how the lesson may be surfaced."
+    },
+    "applicability": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Conditions or tags describing when the lesson applies."
+    },
+    "source_refs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "References to the traces/memory the lesson was derived from (provenance)."
+    },
+    "expires_at": {
+      "type": ["string", "null"],
+      "description": "Optional ISO 8601 expiry timestamp."
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Optional structured provenance.",
+      "additionalProperties": true
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional implementation-specific metadata.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/memory_artifact.schema.json
+++ b/contracts/json/extended/memory_artifact.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/memory_artifact.schema.json",
+  "title": "MemoryArtifact",
+  "description": "Extended. A durable or semi-durable agent memory record, distinct from transient conversation context, raw tool output, and traces. Carries its own sensitivity and provenance because memory content may be sensitive.",
+  "type": "object",
+  "required": ["memory_id", "memory_type", "content", "source", "created_at"],
+  "properties": {
+    "memory_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for this memory record."
+    },
+    "memory_type": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Producer-defined kind of memory, e.g. preference, repo_convention, fact."
+    },
+    "content": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The memory content, in a representation safe to store and reuse."
+    },
+    "source": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Where this memory came from (provenance origin)."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when the memory was first recorded."
+    },
+    "updated_at": {
+      "type": ["string", "null"],
+      "description": "Optional ISO 8601 timestamp of the last update."
+    },
+    "scope": {
+      "type": ["string", "null"],
+      "description": "Optional reuse scope, e.g. session, user, org, global."
+    },
+    "sensitivity": {
+      "type": "string",
+      "enum": ["public", "internal", "confidential", "restricted"],
+      "description": "Sensitivity level governing how the memory may be surfaced."
+    },
+    "confidence": {
+      "type": ["number", "null"],
+      "description": "Optional confidence in the memory's accuracy (typically 0.0-1.0)."
+    },
+    "expires_at": {
+      "type": ["string", "null"],
+      "description": "Optional ISO 8601 expiry timestamp."
+    },
+    "dependency_refs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "References to other artifacts this memory depends on."
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Optional structured provenance (how/why the memory was derived).",
+      "additionalProperties": true
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional implementation-specific metadata.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/review_artifact.schema.json
+++ b/contracts/json/extended/review_artifact.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/review_artifact.schema.json",
+  "title": "ReviewArtifact",
+  "description": "Extended. A minimal, language-neutral interchange shape for trace/review artifacts exchanged between Weaver-stack projects (context build records, execution records, policy decisions, review notes, safety reports). An interchange shape, not a storage system.",
+  "type": "object",
+  "required": ["artifact_id", "artifact_type", "source_project", "created_at"],
+  "properties": {
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for this artifact."
+    },
+    "artifact_type": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Producer-defined kind of artifact, e.g. context_build, execution_record, policy_decision, review_note, safety_report."
+    },
+    "source_project": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Project that produced this artifact (e.g. contextweaver, agent-kernel, lessonweaver)."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when the artifact was created."
+    },
+    "subject_ref": {
+      "type": ["string", "null"],
+      "description": "Optional reference to the subject the artifact is about (e.g. a flow, capability, or commit)."
+    },
+    "summary": {
+      "type": ["string", "null"],
+      "description": "Optional short, human-readable summary."
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "References to supporting evidence (traces, payloads, logs)."
+    },
+    "decision_refs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "References to decisions associated with this artifact (e.g. PolicyDecision IDs)."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional implementation-specific metadata. Namespace project-specific keys.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/session_handoff.schema.json
+++ b/contracts/json/extended/session_handoff.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/session_handoff.schema.json",
+  "title": "SessionHandoff",
+  "description": "Extended. A compact continuity pack carried between agent sessions. Summarizes the state needed to resume work and references (does not inline) durable memory.",
+  "type": "object",
+  "required": ["handoff_id", "from_session_id", "created_at", "summary"],
+  "properties": {
+    "handoff_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for this handoff."
+    },
+    "from_session_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the session being handed off from."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when the handoff was created."
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Compact continuity summary of the session state."
+    },
+    "to_session_id": {
+      "type": ["string", "null"],
+      "description": "Optional identifier of the resuming session, if already known."
+    },
+    "sensitivity": {
+      "type": "string",
+      "enum": ["public", "internal", "confidential", "restricted"],
+      "description": "Sensitivity level governing how the handoff may be surfaced."
+    },
+    "open_threads": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Unresolved threads or follow-ups to carry into the next session."
+    },
+    "memory_refs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "References to MemoryArtifact IDs relevant to continuity."
+    },
+    "expires_at": {
+      "type": ["string", "null"],
+      "description": "Optional ISO 8601 expiry timestamp."
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Optional structured provenance.",
+      "additionalProperties": true
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional implementation-specific metadata.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/skill_card.schema.json
+++ b/contracts/json/extended/skill_card.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/skill_card.schema.json",
+  "title": "SkillCard",
+  "description": "Extended. A reusable procedure/skill derived from traces and approved for reuse. The lifecycle_state gates activation; steps and preconditions describe how and when to apply the skill.",
+  "type": "object",
+  "required": ["skill_id", "name", "description", "created_at"],
+  "properties": {
+    "skill_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for this skill."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Short human-readable name."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "What the skill does."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when the skill was created."
+    },
+    "lifecycle_state": {
+      "type": "string",
+      "enum": ["draft", "in_review", "active", "deprecated"],
+      "description": "Lifecycle state; activation requires passing through review."
+    },
+    "steps": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Ordered steps describing how to apply the skill."
+    },
+    "preconditions": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Conditions that must hold before applying the skill."
+    },
+    "scope": {
+      "type": ["string", "null"],
+      "description": "Optional reuse scope, e.g. repo, team, org, global."
+    },
+    "sensitivity": {
+      "type": "string",
+      "enum": ["public", "internal", "confidential", "restricted"],
+      "description": "Sensitivity level governing how the skill may be surfaced."
+    },
+    "source_refs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "References to the traces/memory the skill was derived from (provenance)."
+    },
+    "expires_at": {
+      "type": ["string", "null"],
+      "description": "Optional ISO 8601 expiry timestamp."
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Optional structured provenance.",
+      "additionalProperties": true
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional implementation-specific metadata.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/python/pyproject.toml
+++ b/contracts/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "weaver_contracts"
-version = "0.4.0"
+version = "0.5.0"
 description = "Minimal Python contracts for the Weaver Stack (contextweaver, agent-kernel, ChainWeaver)"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/contracts/python/src/weaver_contracts/extended.py
+++ b/contracts/python/src/weaver_contracts/extended.py
@@ -136,3 +136,385 @@ class ExtendedSelectableItemMetadata:
     estimated_duration_ms: Optional[int] = None
     requires_confirmation: bool = False
     extra: Dict[str, Any] = field(default_factory=dict)
+
+
+# ===========================================================================
+# Cross-project artifact contracts
+#
+# The types below are standalone, language-neutral artifacts exchanged between
+# Weaver-stack repos and adjacent tools (lessonweaver, skdr-eval, vibeguard).
+# They are Extended (optional, not required for spec compliance per I-04) and
+# share a common envelope: a non-empty string id, an ISO-8601 `created_at`
+# string, an optional `sensitivity` level, optional `provenance`, and a
+# `metadata` extension bag. See docs/ARTIFACT_CONTRACTS.md for the taxonomy
+# that distinguishes these from one another and from Core contracts.
+# ===========================================================================
+
+# Shared sensitivity vocabulary for artifact contracts.
+_SENSITIVITY_LEVELS = frozenset(
+    {"public", "internal", "confidential", "restricted"}
+)
+
+# Shared lifecycle states for reusable, review-gated artifacts (lessons, skills).
+_LIFECYCLE_STATES = frozenset({"draft", "in_review", "active", "deprecated"})
+
+
+# ---------------------------------------------------------------------------
+# ReviewArtifact — minimal cross-project trace/review interchange shape
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ReviewArtifact:
+    """A minimal, language-neutral interchange shape for trace/review artifacts.
+
+    Sibling projects produce or consume trace-like records (context build
+    records, execution records, policy decisions, review notes, safety
+    reports). This is the interchange envelope, not a storage system. Richer,
+    project-specific fields belong under ``metadata`` (namespaced).
+    """
+
+    artifact_id: str
+    artifact_type: str
+    source_project: str
+    created_at: str
+    subject_ref: Optional[str] = None
+    summary: Optional[str] = None
+    evidence_refs: List[str] = field(default_factory=list)
+    decision_refs: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.artifact_id:
+            raise ValueError("ReviewArtifact.artifact_id must be non-empty")
+        if not self.artifact_type:
+            raise ValueError("ReviewArtifact.artifact_type must be non-empty")
+        if not self.source_project:
+            raise ValueError("ReviewArtifact.source_project must be non-empty")
+        if not self.created_at:
+            raise ValueError("ReviewArtifact.created_at must be non-empty")
+
+
+# ---------------------------------------------------------------------------
+# MemoryArtifact — durable or semi-durable agent memory record
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MemoryArtifact:
+    """A durable or semi-durable agent memory record.
+
+    Distinct from transient conversation context, raw tool output, and traces:
+    a MemoryArtifact is a curated, reusable fact/preference/convention carrying
+    its own sensitivity and provenance. Memory content may be sensitive, so
+    ``sensitivity`` and ``provenance`` are first-class.
+    """
+
+    memory_id: str
+    memory_type: str
+    content: str
+    source: str
+    created_at: str
+    updated_at: Optional[str] = None
+    scope: Optional[str] = None
+    sensitivity: str = "internal"
+    confidence: Optional[float] = None
+    expires_at: Optional[str] = None
+    dependency_refs: List[str] = field(default_factory=list)
+    provenance: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.memory_id:
+            raise ValueError("MemoryArtifact.memory_id must be non-empty")
+        if not self.memory_type:
+            raise ValueError("MemoryArtifact.memory_type must be non-empty")
+        if not self.content:
+            raise ValueError("MemoryArtifact.content must be non-empty")
+        if not self.source:
+            raise ValueError("MemoryArtifact.source must be non-empty")
+        if not self.created_at:
+            raise ValueError("MemoryArtifact.created_at must be non-empty")
+        if self.sensitivity not in _SENSITIVITY_LEVELS:
+            raise ValueError(
+                f"MemoryArtifact.sensitivity must be one of {_SENSITIVITY_LEVELS}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# SessionHandoff — compact continuity pack between sessions
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SessionHandoff:
+    """A compact continuity pack carried between agent sessions.
+
+    Summarizes state needed to resume work without replaying full context. It
+    references (does not inline) durable memory via ``memory_refs``.
+    """
+
+    handoff_id: str
+    from_session_id: str
+    created_at: str
+    summary: str
+    to_session_id: Optional[str] = None
+    sensitivity: str = "internal"
+    open_threads: List[str] = field(default_factory=list)
+    memory_refs: List[str] = field(default_factory=list)
+    expires_at: Optional[str] = None
+    provenance: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.handoff_id:
+            raise ValueError("SessionHandoff.handoff_id must be non-empty")
+        if not self.from_session_id:
+            raise ValueError("SessionHandoff.from_session_id must be non-empty")
+        if not self.created_at:
+            raise ValueError("SessionHandoff.created_at must be non-empty")
+        if not self.summary:
+            raise ValueError("SessionHandoff.summary must be non-empty")
+        if self.sensitivity not in _SENSITIVITY_LEVELS:
+            raise ValueError(
+                f"SessionHandoff.sensitivity must be one of {_SENSITIVITY_LEVELS}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# LessonCard — a reviewed, reusable lesson derived from traces
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LessonCard:
+    """A reusable lesson derived from traces and approved for reuse.
+
+    Not a raw trace, raw memory, or generic prompt fragment. ``lifecycle_state``
+    gates activation: a lesson should pass through review before it is
+    ``active``.
+    """
+
+    lesson_id: str
+    title: str
+    body: str
+    created_at: str
+    lifecycle_state: str = "draft"
+    scope: Optional[str] = None
+    sensitivity: str = "internal"
+    applicability: List[str] = field(default_factory=list)
+    source_refs: List[str] = field(default_factory=list)
+    expires_at: Optional[str] = None
+    provenance: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.lesson_id:
+            raise ValueError("LessonCard.lesson_id must be non-empty")
+        if not self.title:
+            raise ValueError("LessonCard.title must be non-empty")
+        if not self.body:
+            raise ValueError("LessonCard.body must be non-empty")
+        if not self.created_at:
+            raise ValueError("LessonCard.created_at must be non-empty")
+        if self.lifecycle_state not in _LIFECYCLE_STATES:
+            raise ValueError(
+                f"LessonCard.lifecycle_state must be one of {_LIFECYCLE_STATES}"
+            )
+        if self.sensitivity not in _SENSITIVITY_LEVELS:
+            raise ValueError(
+                f"LessonCard.sensitivity must be one of {_SENSITIVITY_LEVELS}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# SkillCard — a reviewed, reusable procedure derived from traces
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SkillCard:
+    """A reusable procedure/skill derived from traces and approved for reuse.
+
+    Like LessonCard, ``lifecycle_state`` gates activation. ``steps`` and
+    ``preconditions`` describe how and when to apply the skill.
+    """
+
+    skill_id: str
+    name: str
+    description: str
+    created_at: str
+    lifecycle_state: str = "draft"
+    steps: List[str] = field(default_factory=list)
+    preconditions: List[str] = field(default_factory=list)
+    scope: Optional[str] = None
+    sensitivity: str = "internal"
+    source_refs: List[str] = field(default_factory=list)
+    expires_at: Optional[str] = None
+    provenance: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.skill_id:
+            raise ValueError("SkillCard.skill_id must be non-empty")
+        if not self.name:
+            raise ValueError("SkillCard.name must be non-empty")
+        if not self.description:
+            raise ValueError("SkillCard.description must be non-empty")
+        if not self.created_at:
+            raise ValueError("SkillCard.created_at must be non-empty")
+        if self.lifecycle_state not in _LIFECYCLE_STATES:
+            raise ValueError(
+                f"SkillCard.lifecycle_state must be one of {_LIFECYCLE_STATES}"
+            )
+        if self.sensitivity not in _SENSITIVITY_LEVELS:
+            raise ValueError(
+                f"SkillCard.sensitivity must be one of {_SENSITIVITY_LEVELS}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# EvaluationArtifact — statistical / model-evaluation decision report
+# ---------------------------------------------------------------------------
+
+@dataclass
+class EvaluationArtifact:
+    """A statistical / offline model-evaluation report carried with semantics.
+
+    Makes the intended meaning explicit so agents cannot misuse a headline
+    score: value estimates, uncertainty, support diagnostics, warnings, and a
+    decision recommendation. ``support_state`` and ``recommendation_kind``
+    encode that a high-risk evaluation is not deployment evidence.
+    """
+
+    artifact_id: str
+    producer: str
+    created_at: str
+    artifact_type: str = "offline_policy_evaluation"
+    producer_version: Optional[str] = None
+    target_estimand: Optional[str] = None
+    candidate_policy: Optional[str] = None
+    baseline_policy: Optional[str] = None
+    metrics: Dict[str, Any] = field(default_factory=dict)
+    uncertainty: Dict[str, Any] = field(default_factory=dict)
+    support_state: str = "ok"
+    support_diagnostics: Dict[str, Any] = field(default_factory=dict)
+    propensity_diagnostics: Dict[str, Any] = field(default_factory=dict)
+    sensitivity: str = "internal"
+    warnings: List[str] = field(default_factory=list)
+    recommendation: Optional[str] = None
+    recommendation_kind: Optional[str] = None
+    limitations: List[str] = field(default_factory=list)
+    provenance: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    _SUPPORT_STATES = frozenset({"ok", "caution", "high_risk"})
+    _RECOMMENDATION_KINDS = frozenset(
+        {"deploy", "do_not_deploy", "experiment_ready", "needs_more_data"}
+    )
+
+    def __post_init__(self) -> None:
+        if not self.artifact_id:
+            raise ValueError("EvaluationArtifact.artifact_id must be non-empty")
+        if not self.producer:
+            raise ValueError("EvaluationArtifact.producer must be non-empty")
+        if not self.created_at:
+            raise ValueError("EvaluationArtifact.created_at must be non-empty")
+        if not self.artifact_type:
+            raise ValueError("EvaluationArtifact.artifact_type must be non-empty")
+        if self.support_state not in self._SUPPORT_STATES:
+            raise ValueError(
+                f"EvaluationArtifact.support_state must be one of {self._SUPPORT_STATES}"
+            )
+        if (
+            self.recommendation_kind is not None
+            and self.recommendation_kind not in self._RECOMMENDATION_KINDS
+        ):
+            raise ValueError(
+                "EvaluationArtifact.recommendation_kind must be one of "
+                f"{self._RECOMMENDATION_KINDS}"
+            )
+        if self.sensitivity not in _SENSITIVITY_LEVELS:
+            raise ValueError(
+                f"EvaluationArtifact.sensitivity must be one of {_SENSITIVITY_LEVELS}"
+            )
+        # A high-risk evaluation must never recommend deployment: a high-risk
+        # support state means the evidence cannot back a deploy decision.
+        if self.support_state == "high_risk" and self.recommendation_kind == "deploy":
+            raise ValueError(
+                "EvaluationArtifact: recommendation_kind 'deploy' is not permitted "
+                "when support_state is 'high_risk' (a high-risk evaluation is not "
+                "deployment evidence)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# ArtifactSafetyGateRequest — inputs to an artifact safety gate capability
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ArtifactSafetyGateRequest:
+    """Inputs to an optional artifact safety gate run.
+
+    Describes what to check (artifact paths, diff scope, repository root) and
+    how (policy level, output format). Implementation-neutral: it does not
+    name a specific scanner or rule set.
+    """
+
+    request_id: str
+    repository_root: str
+    artifact_paths: List[str] = field(default_factory=list)
+    diff_scope: Optional[str] = None
+    policy_level: str = "standard"
+    output_format: str = "json"
+    capability_id: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.request_id:
+            raise ValueError("ArtifactSafetyGateRequest.request_id must be non-empty")
+        if not self.repository_root:
+            raise ValueError(
+                "ArtifactSafetyGateRequest.repository_root must be non-empty"
+            )
+
+
+# ---------------------------------------------------------------------------
+# ArtifactSafetyReport — output of an artifact safety gate capability
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ArtifactSafetyReport:
+    """Output of an artifact safety gate run.
+
+    ``mode`` distinguishes an advisory check from a blocking gate; ``decision``
+    is the pass/fail verdict. ``findings`` is a list of objects, each carrying
+    a severity, message, optional stable fingerprint, and remediation hint
+    (shape defined in the JSON schema).
+    """
+
+    report_id: str
+    gate_id: str
+    decision: str
+    created_at: str
+    mode: str = "advisory"
+    request_id: Optional[str] = None
+    target_ref: Optional[str] = None
+    summary: Optional[str] = None
+    findings: List[Dict[str, Any]] = field(default_factory=list)
+    provenance: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    _DECISIONS = frozenset({"pass", "fail"})
+    _MODES = frozenset({"advisory", "blocking"})
+
+    def __post_init__(self) -> None:
+        if not self.report_id:
+            raise ValueError("ArtifactSafetyReport.report_id must be non-empty")
+        if not self.gate_id:
+            raise ValueError("ArtifactSafetyReport.gate_id must be non-empty")
+        if not self.created_at:
+            raise ValueError("ArtifactSafetyReport.created_at must be non-empty")
+        if self.decision not in self._DECISIONS:
+            raise ValueError(
+                f"ArtifactSafetyReport.decision must be one of {self._DECISIONS}"
+            )
+        if self.mode not in self._MODES:
+            raise ValueError(
+                f"ArtifactSafetyReport.mode must be one of {self._MODES}"
+            )

--- a/contracts/python/src/weaver_contracts/version.py
+++ b/contracts/python/src/weaver_contracts/version.py
@@ -3,7 +3,7 @@ Contract version constants and compatibility helpers.
 """
 
 # The current contract version. Must match pyproject.toml [project] version.
-CONTRACT_VERSION = "0.4.0"
+CONTRACT_VERSION = "0.5.0"
 
 # The JSON Schema $id version prefix (corresponds to MAJOR version).
 SCHEMA_VERSION_PREFIX = "v0"

--- a/contracts/python/tests/test_extended.py
+++ b/contracts/python/tests/test_extended.py
@@ -8,11 +8,19 @@ from typing import Optional
 import pytest
 
 from weaver_contracts.extended import (
+    ArtifactSafetyGateRequest,
+    ArtifactSafetyReport,
+    EvaluationArtifact,
     ExtendedFrameMetadata,
     ExtendedSelectableItemMetadata,
+    LessonCard,
+    MemoryArtifact,
     RedactionPolicy,
+    ReviewArtifact,
     RiskAssessment,
     SchemaFingerprint,
+    SessionHandoff,
+    SkillCard,
     TelemetryHint,
     UIHint,
 )
@@ -262,3 +270,485 @@ class TestExtendedSelectableItemMetadata:
         data = asdict(metadata)
         json.dumps(data)
         assert data["estimated_duration_ms"] == 500
+
+
+class TestReviewArtifact:
+    def test_valid_from_payload(self):
+        p = load_payload("review_artifact")
+        art = ReviewArtifact(
+            artifact_id=p["artifact_id"],
+            artifact_type=p["artifact_type"],
+            source_project=p["source_project"],
+            created_at=p["created_at"],
+            subject_ref=p.get("subject_ref"),
+            summary=p.get("summary"),
+            evidence_refs=p.get("evidence_refs", []),
+            decision_refs=p.get("decision_refs", []),
+            metadata=p.get("metadata", {}),
+        )
+        assert art.artifact_id == p["artifact_id"]
+        assert art.evidence_refs == p["evidence_refs"]
+
+    def test_empty_artifact_id_raises(self):
+        with pytest.raises(ValueError, match="artifact_id must be non-empty"):
+            ReviewArtifact(
+                artifact_id="",
+                artifact_type="review_note",
+                source_project="agent-kernel",
+                created_at="2026-05-27T08:00:00Z",
+            )
+
+    def test_empty_artifact_type_raises(self):
+        with pytest.raises(ValueError, match="artifact_type must be non-empty"):
+            ReviewArtifact(
+                artifact_id="rev-1",
+                artifact_type="",
+                source_project="agent-kernel",
+                created_at="2026-05-27T08:00:00Z",
+            )
+
+    def test_empty_source_project_raises(self):
+        with pytest.raises(ValueError, match="source_project must be non-empty"):
+            ReviewArtifact(
+                artifact_id="rev-1",
+                artifact_type="review_note",
+                source_project="",
+                created_at="2026-05-27T08:00:00Z",
+            )
+
+    def test_empty_created_at_raises(self):
+        with pytest.raises(ValueError, match="created_at must be non-empty"):
+            ReviewArtifact(
+                artifact_id="rev-1",
+                artifact_type="review_note",
+                source_project="agent-kernel",
+                created_at="",
+            )
+
+    def test_defaults(self):
+        art = ReviewArtifact(
+            artifact_id="rev-1",
+            artifact_type="review_note",
+            source_project="agent-kernel",
+            created_at="2026-05-27T08:00:00Z",
+        )
+        assert art.subject_ref is None
+        assert art.evidence_refs == []
+        assert art.decision_refs == []
+        assert art.metadata == {}
+
+    def test_serialization(self):
+        art = ReviewArtifact(
+            artifact_id="rev-1",
+            artifact_type="safety_report",
+            source_project="vibeguard",
+            created_at="2026-05-27T08:00:00Z",
+            evidence_refs=["trace:x"],
+        )
+        data = asdict(art)
+        json.dumps(data)
+        assert data["evidence_refs"] == ["trace:x"]
+
+
+class TestMemoryArtifact:
+    def _kwargs(self, **overrides):
+        base = dict(
+            memory_id="mem-1",
+            memory_type="preference",
+            content="prefers concise summaries",
+            source="user_feedback",
+            created_at="2026-05-27T08:00:00Z",
+        )
+        base.update(overrides)
+        return base
+
+    def test_valid_from_payload(self):
+        p = load_payload("memory_artifact")
+        mem = MemoryArtifact(
+            memory_id=p["memory_id"],
+            memory_type=p["memory_type"],
+            content=p["content"],
+            source=p["source"],
+            created_at=p["created_at"],
+            updated_at=p.get("updated_at"),
+            scope=p.get("scope"),
+            sensitivity=p.get("sensitivity", "internal"),
+            confidence=p.get("confidence"),
+            expires_at=p.get("expires_at"),
+            dependency_refs=p.get("dependency_refs", []),
+            provenance=p.get("provenance", {}),
+            metadata=p.get("metadata", {}),
+        )
+        assert mem.memory_id == p["memory_id"]
+        assert mem.sensitivity == "internal"
+        assert mem.confidence == p["confidence"]
+
+    def test_empty_content_raises(self):
+        with pytest.raises(ValueError, match="content must be non-empty"):
+            MemoryArtifact(**self._kwargs(content=""))
+
+    def test_empty_source_raises(self):
+        with pytest.raises(ValueError, match="source must be non-empty"):
+            MemoryArtifact(**self._kwargs(source=""))
+
+    def test_invalid_sensitivity_raises(self):
+        with pytest.raises(ValueError, match="sensitivity must be one of"):
+            MemoryArtifact(**self._kwargs(sensitivity="secret"))
+
+    def test_defaults(self):
+        mem = MemoryArtifact(**self._kwargs())
+        assert mem.sensitivity == "internal"
+        assert mem.dependency_refs == []
+        assert mem.provenance == {}
+        assert mem.confidence is None
+
+    def test_serialization(self):
+        mem = MemoryArtifact(**self._kwargs(sensitivity="confidential"))
+        data = asdict(mem)
+        json.dumps(data)
+        assert data["sensitivity"] == "confidential"
+
+
+class TestSessionHandoff:
+    def _kwargs(self, **overrides):
+        base = dict(
+            handoff_id="ho-1",
+            from_session_id="sess-a",
+            created_at="2026-05-27T12:00:00Z",
+            summary="resume work on contracts",
+        )
+        base.update(overrides)
+        return base
+
+    def test_valid_from_payload(self):
+        p = load_payload("session_handoff")
+        ho = SessionHandoff(
+            handoff_id=p["handoff_id"],
+            from_session_id=p["from_session_id"],
+            created_at=p["created_at"],
+            summary=p["summary"],
+            to_session_id=p.get("to_session_id"),
+            sensitivity=p.get("sensitivity", "internal"),
+            open_threads=p.get("open_threads", []),
+            memory_refs=p.get("memory_refs", []),
+            expires_at=p.get("expires_at"),
+            provenance=p.get("provenance", {}),
+            metadata=p.get("metadata", {}),
+        )
+        assert ho.handoff_id == p["handoff_id"]
+        assert ho.memory_refs == p["memory_refs"]
+
+    def test_empty_summary_raises(self):
+        with pytest.raises(ValueError, match="summary must be non-empty"):
+            SessionHandoff(**self._kwargs(summary=""))
+
+    def test_empty_from_session_id_raises(self):
+        with pytest.raises(ValueError, match="from_session_id must be non-empty"):
+            SessionHandoff(**self._kwargs(from_session_id=""))
+
+    def test_invalid_sensitivity_raises(self):
+        with pytest.raises(ValueError, match="sensitivity must be one of"):
+            SessionHandoff(**self._kwargs(sensitivity="topsecret"))
+
+    def test_defaults(self):
+        ho = SessionHandoff(**self._kwargs())
+        assert ho.to_session_id is None
+        assert ho.open_threads == []
+        assert ho.memory_refs == []
+
+    def test_serialization(self):
+        ho = SessionHandoff(**self._kwargs(open_threads=["t1"]))
+        data = asdict(ho)
+        json.dumps(data)
+        assert data["open_threads"] == ["t1"]
+
+
+class TestLessonCard:
+    def _kwargs(self, **overrides):
+        base = dict(
+            lesson_id="lsn-1",
+            title="Always regenerate the index",
+            body="Run the index generator after schema changes.",
+            created_at="2026-05-27T09:00:00Z",
+        )
+        base.update(overrides)
+        return base
+
+    def test_valid_from_payload(self):
+        p = load_payload("lesson_card")
+        card = LessonCard(
+            lesson_id=p["lesson_id"],
+            title=p["title"],
+            body=p["body"],
+            created_at=p["created_at"],
+            lifecycle_state=p.get("lifecycle_state", "draft"),
+            scope=p.get("scope"),
+            sensitivity=p.get("sensitivity", "internal"),
+            applicability=p.get("applicability", []),
+            source_refs=p.get("source_refs", []),
+            expires_at=p.get("expires_at"),
+            provenance=p.get("provenance", {}),
+            metadata=p.get("metadata", {}),
+        )
+        assert card.lesson_id == p["lesson_id"]
+        assert card.lifecycle_state == "active"
+
+    def test_empty_body_raises(self):
+        with pytest.raises(ValueError, match="body must be non-empty"):
+            LessonCard(**self._kwargs(body=""))
+
+    def test_invalid_lifecycle_state_raises(self):
+        with pytest.raises(ValueError, match="lifecycle_state must be one of"):
+            LessonCard(**self._kwargs(lifecycle_state="published"))
+
+    def test_invalid_sensitivity_raises(self):
+        with pytest.raises(ValueError, match="sensitivity must be one of"):
+            LessonCard(**self._kwargs(sensitivity="secret"))
+
+    def test_defaults(self):
+        card = LessonCard(**self._kwargs())
+        assert card.lifecycle_state == "draft"
+        assert card.applicability == []
+        assert card.sensitivity == "internal"
+
+    def test_serialization(self):
+        card = LessonCard(**self._kwargs(lifecycle_state="in_review"))
+        data = asdict(card)
+        json.dumps(data)
+        assert data["lifecycle_state"] == "in_review"
+
+
+class TestSkillCard:
+    def _kwargs(self, **overrides):
+        base = dict(
+            skill_id="skl-1",
+            name="Add a contract",
+            description="How to add an Extended contract.",
+            created_at="2026-05-27T09:30:00Z",
+        )
+        base.update(overrides)
+        return base
+
+    def test_valid_from_payload(self):
+        p = load_payload("skill_card")
+        card = SkillCard(
+            skill_id=p["skill_id"],
+            name=p["name"],
+            description=p["description"],
+            created_at=p["created_at"],
+            lifecycle_state=p.get("lifecycle_state", "draft"),
+            steps=p.get("steps", []),
+            preconditions=p.get("preconditions", []),
+            scope=p.get("scope"),
+            sensitivity=p.get("sensitivity", "internal"),
+            source_refs=p.get("source_refs", []),
+            expires_at=p.get("expires_at"),
+            provenance=p.get("provenance", {}),
+            metadata=p.get("metadata", {}),
+        )
+        assert card.skill_id == p["skill_id"]
+        assert len(card.steps) == len(p["steps"])
+
+    def test_empty_name_raises(self):
+        with pytest.raises(ValueError, match="name must be non-empty"):
+            SkillCard(**self._kwargs(name=""))
+
+    def test_invalid_lifecycle_state_raises(self):
+        with pytest.raises(ValueError, match="lifecycle_state must be one of"):
+            SkillCard(**self._kwargs(lifecycle_state="live"))
+
+    def test_defaults(self):
+        card = SkillCard(**self._kwargs())
+        assert card.lifecycle_state == "draft"
+        assert card.steps == []
+        assert card.preconditions == []
+
+    def test_serialization(self):
+        card = SkillCard(**self._kwargs(steps=["s1", "s2"]))
+        data = asdict(card)
+        json.dumps(data)
+        assert data["steps"] == ["s1", "s2"]
+
+
+class TestEvaluationArtifact:
+    def _kwargs(self, **overrides):
+        base = dict(
+            artifact_id="eval-1",
+            producer="skdr-eval",
+            created_at="2026-05-27T10:00:00Z",
+        )
+        base.update(overrides)
+        return base
+
+    def test_valid_from_payload(self):
+        p = load_payload("evaluation_artifact")
+        art = EvaluationArtifact(
+            artifact_id=p["artifact_id"],
+            producer=p["producer"],
+            created_at=p["created_at"],
+            artifact_type=p.get("artifact_type", "offline_policy_evaluation"),
+            producer_version=p.get("producer_version"),
+            target_estimand=p.get("target_estimand"),
+            candidate_policy=p.get("candidate_policy"),
+            baseline_policy=p.get("baseline_policy"),
+            metrics=p.get("metrics", {}),
+            uncertainty=p.get("uncertainty", {}),
+            support_state=p.get("support_state", "ok"),
+            support_diagnostics=p.get("support_diagnostics", {}),
+            propensity_diagnostics=p.get("propensity_diagnostics", {}),
+            sensitivity=p.get("sensitivity", "internal"),
+            warnings=p.get("warnings", []),
+            recommendation=p.get("recommendation"),
+            recommendation_kind=p.get("recommendation_kind"),
+            limitations=p.get("limitations", []),
+            provenance=p.get("provenance", {}),
+            metadata=p.get("metadata", {}),
+        )
+        assert art.support_state == "caution"
+        assert art.recommendation_kind == "experiment_ready"
+
+    def test_invalid_support_state_raises(self):
+        with pytest.raises(ValueError, match="support_state must be one of"):
+            EvaluationArtifact(**self._kwargs(support_state="unknown"))
+
+    def test_invalid_recommendation_kind_raises(self):
+        with pytest.raises(ValueError, match="recommendation_kind must be one of"):
+            EvaluationArtifact(**self._kwargs(recommendation_kind="ship_it"))
+
+    def test_invalid_sensitivity_raises(self):
+        with pytest.raises(ValueError, match="sensitivity must be one of"):
+            EvaluationArtifact(**self._kwargs(sensitivity="secret"))
+
+    def test_high_risk_cannot_recommend_deploy(self):
+        """#67: a high-risk evaluation must not recommend deployment."""
+        with pytest.raises(ValueError, match="not deployment evidence"):
+            EvaluationArtifact(
+                **self._kwargs(
+                    support_state="high_risk",
+                    recommendation_kind="deploy",
+                )
+            )
+
+    def test_high_risk_allows_non_deploy_recommendation(self):
+        art = EvaluationArtifact(
+            **self._kwargs(
+                support_state="high_risk",
+                recommendation_kind="do_not_deploy",
+            )
+        )
+        assert art.recommendation_kind == "do_not_deploy"
+
+    def test_defaults(self):
+        art = EvaluationArtifact(**self._kwargs())
+        assert art.artifact_type == "offline_policy_evaluation"
+        assert art.support_state == "ok"
+        assert art.recommendation_kind is None
+        assert art.warnings == []
+
+    def test_serialization(self):
+        art = EvaluationArtifact(**self._kwargs(warnings=["limited overlap"]))
+        data = asdict(art)
+        json.dumps(data)
+        assert data["warnings"] == ["limited overlap"]
+
+
+class TestArtifactSafetyGateRequest:
+    def _kwargs(self, **overrides):
+        base = dict(
+            request_id="req-1",
+            repository_root="/workspace/app",
+        )
+        base.update(overrides)
+        return base
+
+    def test_valid_from_payload(self):
+        p = load_payload("artifact_safety_gate_request")
+        req = ArtifactSafetyGateRequest(
+            request_id=p["request_id"],
+            repository_root=p["repository_root"],
+            artifact_paths=p.get("artifact_paths", []),
+            diff_scope=p.get("diff_scope"),
+            policy_level=p.get("policy_level", "standard"),
+            output_format=p.get("output_format", "json"),
+            capability_id=p.get("capability_id"),
+            metadata=p.get("metadata", {}),
+        )
+        assert req.request_id == p["request_id"]
+        assert req.policy_level == "strict"
+
+    def test_empty_request_id_raises(self):
+        with pytest.raises(ValueError, match="request_id must be non-empty"):
+            ArtifactSafetyGateRequest(**self._kwargs(request_id=""))
+
+    def test_empty_repository_root_raises(self):
+        with pytest.raises(ValueError, match="repository_root must be non-empty"):
+            ArtifactSafetyGateRequest(**self._kwargs(repository_root=""))
+
+    def test_defaults(self):
+        req = ArtifactSafetyGateRequest(**self._kwargs())
+        assert req.policy_level == "standard"
+        assert req.output_format == "json"
+        assert req.artifact_paths == []
+
+    def test_serialization(self):
+        req = ArtifactSafetyGateRequest(**self._kwargs(artifact_paths=["a.py"]))
+        data = asdict(req)
+        json.dumps(data)
+        assert data["artifact_paths"] == ["a.py"]
+
+
+class TestArtifactSafetyReport:
+    def _kwargs(self, **overrides):
+        base = dict(
+            report_id="rep-1",
+            gate_id="org.vibeguard.scan",
+            decision="pass",
+            created_at="2026-05-27T10:30:00Z",
+        )
+        base.update(overrides)
+        return base
+
+    def test_valid_from_payload(self):
+        p = load_payload("artifact_safety_report")
+        rep = ArtifactSafetyReport(
+            report_id=p["report_id"],
+            gate_id=p["gate_id"],
+            decision=p["decision"],
+            created_at=p["created_at"],
+            mode=p.get("mode", "advisory"),
+            request_id=p.get("request_id"),
+            target_ref=p.get("target_ref"),
+            summary=p.get("summary"),
+            findings=p.get("findings", []),
+            provenance=p.get("provenance", {}),
+            metadata=p.get("metadata", {}),
+        )
+        assert rep.decision == "fail"
+        assert rep.mode == "blocking"
+        assert rep.findings[0]["severity"] == "high"
+
+    def test_invalid_decision_raises(self):
+        with pytest.raises(ValueError, match="decision must be one of"):
+            ArtifactSafetyReport(**self._kwargs(decision="maybe"))
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError, match="mode must be one of"):
+            ArtifactSafetyReport(**self._kwargs(mode="warn"))
+
+    def test_empty_gate_id_raises(self):
+        with pytest.raises(ValueError, match="gate_id must be non-empty"):
+            ArtifactSafetyReport(**self._kwargs(gate_id=""))
+
+    def test_defaults(self):
+        rep = ArtifactSafetyReport(**self._kwargs())
+        assert rep.mode == "advisory"
+        assert rep.findings == []
+        assert rep.request_id is None
+
+    def test_serialization(self):
+        rep = ArtifactSafetyReport(
+            **self._kwargs(findings=[{"finding_id": "f1", "severity": "low", "message": "m"}])
+        )
+        data = asdict(rep)
+        json.dumps(data)
+        assert data["findings"][0]["finding_id"] == "f1"

--- a/contracts/python/tests/test_extended_schema_alignment.py
+++ b/contracts/python/tests/test_extended_schema_alignment.py
@@ -1,0 +1,139 @@
+"""
+Tests that Extended sample payloads validate against the Extended JSON
+Schemas in contracts/json/extended/.
+
+Mirrors test_json_schema_alignment.py (which covers Core), but targets the
+Extended tier. Each Extended type is listed by its dataclass name so the
+coverage table generator (scripts/generate_coverage_table.py) detects the
+schema-test artifact for that type.
+"""
+
+import json
+import pathlib
+
+import pytest
+
+jsonschema = pytest.importorskip("jsonschema")
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent.parent.parent
+CORE_SCHEMA_DIR = REPO_ROOT / "contracts" / "json"
+EXTENDED_SCHEMA_DIR = CORE_SCHEMA_DIR / "extended"
+PAYLOADS_DIR = REPO_ROOT / "examples" / "sample_payloads"
+
+# (dataclass name, snake_case schema/payload stem). The dataclass names appear
+# here as whole tokens so the coverage generator marks the schema test present:
+# ReviewArtifact, MemoryArtifact, SessionHandoff, LessonCard, SkillCard,
+# EvaluationArtifact, ArtifactSafetyGateRequest, ArtifactSafetyReport.
+EXTENDED_TYPES = [
+    ("ReviewArtifact", "review_artifact"),
+    ("MemoryArtifact", "memory_artifact"),
+    ("SessionHandoff", "session_handoff"),
+    ("LessonCard", "lesson_card"),
+    ("SkillCard", "skill_card"),
+    ("EvaluationArtifact", "evaluation_artifact"),
+    ("ArtifactSafetyGateRequest", "artifact_safety_gate_request"),
+    ("ArtifactSafetyReport", "artifact_safety_report"),
+]
+
+
+def load_extended_schema(stem: str) -> dict:
+    with open(EXTENDED_SCHEMA_DIR / f"{stem}.schema.json") as f:
+        return json.load(f)
+
+
+def load_payload(stem: str) -> dict:
+    with open(PAYLOADS_DIR / f"{stem}.json") as f:
+        return json.load(f)
+
+
+def build_store() -> dict:
+    """URI -> schema for all local schemas (Core + Extended), so $ref
+    resolution works without network access."""
+    store = {}
+    for schema_file in list(CORE_SCHEMA_DIR.glob("*.schema.json")) + list(
+        EXTENDED_SCHEMA_DIR.glob("*.schema.json")
+    ):
+        with open(schema_file) as f:
+            schema = json.load(f)
+        if "$id" in schema:
+            store[schema["$id"]] = schema
+    return store
+
+
+_SCHEMA_STORE = build_store()
+
+
+def validate(payload: dict, schema: dict) -> None:
+    resolver = jsonschema.RefResolver(
+        base_uri=schema.get("$id", ""),
+        referrer=schema,
+        store=_SCHEMA_STORE,
+    )
+    validator_cls = jsonschema.validators.validator_for(schema)
+    validator = validator_cls(
+        schema,
+        resolver=resolver,
+        format_checker=jsonschema.FormatChecker(),
+    )
+    errors = list(validator.iter_errors(payload))
+    if errors:
+        msgs = "\n".join(str(e) for e in errors)
+        raise AssertionError(f"Schema validation failed:\n{msgs}")
+
+
+class TestExtendedSchemaStructure:
+    """Every Extended schema must declare the required metadata fields."""
+
+    @pytest.mark.parametrize(
+        "schema_file", sorted(EXTENDED_SCHEMA_DIR.glob("*.schema.json"))
+    )
+    def test_schema_has_required_metadata(self, schema_file):
+        with open(schema_file) as f:
+            data = json.load(f)
+        for key in ("$id", "title", "description", "required"):
+            assert key in data, f"{schema_file.name} must declare {key}"
+        assert "extended/" in data["$id"], (
+            f"{schema_file.name} $id must live under the extended/ namespace"
+        )
+
+
+class TestExtendedPayloadValidation:
+    """Each Extended sample payload validates against its schema."""
+
+    @pytest.mark.parametrize("class_name,stem", EXTENDED_TYPES)
+    def test_payload_validates(self, class_name, stem):
+        schema = load_extended_schema(stem)
+        payload = load_payload(stem)
+        validate(payload, schema)
+
+
+class TestExtendedNegativeCases:
+    """A few targeted negatives confirm the schemas actually constrain."""
+
+    def test_memory_artifact_missing_required_fails(self):
+        schema = load_extended_schema("memory_artifact")
+        bad = {"memory_id": "m1"}  # missing memory_type/content/source/created_at
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_evaluation_artifact_bad_support_state_fails(self):
+        schema = load_extended_schema("evaluation_artifact")
+        bad = {
+            "artifact_id": "e1",
+            "producer": "skdr-eval",
+            "created_at": "2026-05-27T10:00:00Z",
+            "support_state": "explosive",
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_artifact_safety_report_bad_decision_fails(self):
+        schema = load_extended_schema("artifact_safety_report")
+        bad = {
+            "report_id": "r1",
+            "gate_id": "g1",
+            "decision": "maybe",
+            "created_at": "2026-05-27T10:30:00Z",
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)

--- a/contracts/python/tests/test_extended_schema_alignment.py
+++ b/contracts/python/tests/test_extended_schema_alignment.py
@@ -127,6 +127,20 @@ class TestExtendedNegativeCases:
         with pytest.raises(AssertionError, match="Schema validation failed"):
             validate(bad, schema)
 
+    def test_evaluation_artifact_high_risk_deploy_fails(self):
+        # #67: a high-risk evaluation is not deployment evidence. The schema
+        # must reject this pairing, matching the Python dataclass constraint.
+        schema = load_extended_schema("evaluation_artifact")
+        bad = {
+            "artifact_id": "e1",
+            "producer": "skdr-eval",
+            "created_at": "2026-05-27T10:00:00Z",
+            "support_state": "high_risk",
+            "recommendation_kind": "deploy",
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
     def test_artifact_safety_report_bad_decision_fails(self):
         schema = load_extended_schema("artifact_safety_report")
         bad = {

--- a/docs/ARTIFACT_CONTRACTS.md
+++ b/docs/ARTIFACT_CONTRACTS.md
@@ -166,8 +166,8 @@ agent cannot misuse a headline score. `support_state` (`ok` \| `caution` \|
 machine-readable verdict.
 
 > [!IMPORTANT]
-> A `high_risk` evaluation must never recommend deployment. The Python contract
-> rejects `support_state = "high_risk"` together with
+> A `high_risk` evaluation must never recommend deployment. Both the JSON Schema
+> and the Python contract reject `support_state = "high_risk"` together with
 > `recommendation_kind = "deploy"`: a high-risk evaluation is not deployment
 > evidence.
 

--- a/docs/ARTIFACT_CONTRACTS.md
+++ b/docs/ARTIFACT_CONTRACTS.md
@@ -1,0 +1,243 @@
+# Cross-Project Artifact Contracts
+
+> [!NOTE]
+> This page is **informative**. The artifact types below are **Extended**
+> contracts: optional, not required for spec compliance (invariant I-04).
+> Authority order remains `INVARIANTS.md > BOUNDARIES.md > ARCHITECTURE.md >
+> everything else`. Nothing here redefines an invariant or a normative
+> boundary.
+
+The Weaver stack and its adjacent tools (lessonweaver, skdr-eval, vibeguard)
+exchange several **standalone artifacts** that are neither Core request-path
+contracts nor raw data. This page defines a small, language-neutral vocabulary
+for them so projects interoperate without depending on each other's packages.
+
+All schemas live under
+[`contracts/json/extended/`](../contracts/json/extended/); the Python mirrors
+are in
+[`weaver_contracts.extended`](../contracts/python/src/weaver_contracts/extended.py).
+
+---
+
+## Shared envelope
+
+Every artifact on this page shares a common envelope so producers and
+consumers can treat them uniformly:
+
+| Field | Meaning |
+| ----- | ------- |
+| `*_id` | Non-empty stable identifier. |
+| `created_at` | ISO 8601 (`date-time`) creation timestamp. |
+| `sensitivity` | One of `public` \| `internal` \| `confidential` \| `restricted` (where present). |
+| `provenance` | Optional structured record of how/why the artifact was derived. |
+| `metadata` | Open extension bag; namespace project-specific keys. |
+
+IDs are any non-empty string (`minLength: 1`); UUIDs are not required (see
+`AGENTS.md` → "ID format"). Timestamps are interchange strings, not parsed
+types.
+
+## Taxonomy
+
+These artifacts are deliberately distinct from one another and from Core
+contracts. Pick the narrowest type that fits:
+
+| Type | Is | Is not |
+| ---- | -- | ------ |
+| `ReviewArtifact` | A generic interchange shape for any trace/review record. | A storage system; a Core `TraceEvent`. |
+| `MemoryArtifact` | A durable/semi-durable, reusable memory record. | Transient context, raw tool output, or a trace. |
+| `SessionHandoff` | A compact continuity pack between sessions. | Durable memory (it *references* memory). |
+| `LessonCard` | A reviewed, reusable lesson derived from traces. | A raw trace, raw memory, or prompt fragment. |
+| `SkillCard` | A reviewed, reusable procedure derived from traces. | A flow definition or a Core `Capability`. |
+| `EvaluationArtifact` | A statistical evaluation report with semantics. | Proof of statistical validity; a deploy approval. |
+| `ArtifactSafetyGateRequest` / `ArtifactSafetyReport` | Inputs/outputs of an artifact safety gate. | A specific scanner or rule set. |
+
+---
+
+## ReviewArtifact
+
+The minimal cross-project interchange shape. `artifact_type` is producer-defined
+(for example `context_build`, `execution_record`, `policy_decision`,
+`review_note`, `safety_report`). Evidence and decisions are referenced, not
+inlined.
+
+**Produced/consumed by:** any project; commonly produced by agent-kernel,
+contextweaver, lessonweaver and consumed by review/audit tooling.
+
+<!-- schema: review_artifact -->
+```json
+{
+  "artifact_id": "rev-20260527-001",
+  "artifact_type": "review_note",
+  "source_project": "agent-kernel",
+  "created_at": "2026-05-27T08:00:00Z",
+  "subject_ref": "flow:invoice_reminder_flow@1.2.0",
+  "summary": "Execution completed within policy; no firewall bypass observed.",
+  "evidence_refs": ["trace:evt-20260527-014"],
+  "decision_refs": ["policy:pd-20260527-003"]
+}
+```
+
+## MemoryArtifact
+
+A durable or semi-durable memory record, distinct from transient context, raw
+tool output, and traces. Because memory content may be sensitive, `sensitivity`
+and `provenance` are first-class.
+
+**Produced/consumed by:** contextweaver (memory source), agent-kernel, and
+adjacent memory stores.
+
+<!-- schema: memory_artifact -->
+```json
+{
+  "memory_id": "mem-20260527-001",
+  "memory_type": "repo_convention",
+  "content": "This repo is docs + contracts only; never add runtime logic.",
+  "source": "AGENTS.md",
+  "created_at": "2026-05-27T08:00:00Z",
+  "scope": "repo",
+  "sensitivity": "internal",
+  "confidence": 0.95
+}
+```
+
+## SessionHandoff
+
+A compact continuity pack carried between sessions. It references durable
+memory via `memory_refs` rather than inlining it.
+
+**Produced/consumed by:** the host application / orchestration layer at session
+boundaries.
+
+<!-- schema: session_handoff -->
+```json
+{
+  "handoff_id": "ho-20260527-001",
+  "from_session_id": "sess-20260527-am",
+  "created_at": "2026-05-27T12:00:00Z",
+  "summary": "Implemented Extended artifact contracts; tests green.",
+  "sensitivity": "internal",
+  "open_threads": ["Decide release date for 0.5.0."],
+  "memory_refs": ["mem-20260527-001"]
+}
+```
+
+## LessonCard and SkillCard
+
+Reviewed, reusable knowledge derived from traces. `lifecycle_state`
+(`draft` → `in_review` → `active` → `deprecated`) gates activation: a card
+should pass through review before it is `active`.
+
+**Produced/consumed by:** lessonweaver (producer); any agent that applies
+approved lessons/skills.
+
+<!-- schema: lesson_card -->
+```json
+{
+  "lesson_id": "lsn-20260527-001",
+  "title": "Regenerate generated artifacts before pushing",
+  "body": "After any contracts/json change, regenerate the index and coverage table.",
+  "created_at": "2026-05-27T09:00:00Z",
+  "lifecycle_state": "active",
+  "scope": "repo",
+  "sensitivity": "internal",
+  "applicability": ["changed:contracts/json/**"]
+}
+```
+
+<!-- schema: skill_card -->
+```json
+{
+  "skill_id": "skl-20260527-001",
+  "name": "Add an Extended contract",
+  "description": "End-to-end procedure for adding a new Extended contract type.",
+  "created_at": "2026-05-27T09:30:00Z",
+  "lifecycle_state": "in_review",
+  "steps": ["Add the dataclass.", "Add the JSON schema.", "Add tests."],
+  "preconditions": ["Type is non-universal (Extended, not Core) per I-04."]
+}
+```
+
+## EvaluationArtifact
+
+A statistical / offline evaluation report carried with explicit semantics so an
+agent cannot misuse a headline score. `support_state` (`ok` \| `caution` \|
+`high_risk`) summarizes diagnostic confidence; `recommendation_kind`
+(`deploy` \| `do_not_deploy` \| `experiment_ready` \| `needs_more_data`) is the
+machine-readable verdict.
+
+> [!IMPORTANT]
+> A `high_risk` evaluation must never recommend deployment. The Python contract
+> rejects `support_state = "high_risk"` together with
+> `recommendation_kind = "deploy"`: a high-risk evaluation is not deployment
+> evidence.
+
+**Produced/consumed by:** skdr-eval (producer); contextweaver, ChainWeaver,
+agent-kernel as interpreters/policy gates.
+
+<!-- schema: evaluation_artifact -->
+```json
+{
+  "artifact_id": "eval-20260527-001",
+  "producer": "skdr-eval",
+  "created_at": "2026-05-27T10:00:00Z",
+  "artifact_type": "offline_policy_evaluation",
+  "support_state": "caution",
+  "metrics": {"estimated_value": 0.42},
+  "uncertainty": {"value_ci": [0.31, 0.53]},
+  "warnings": ["Limited overlap; estimate may be unstable."],
+  "recommendation_kind": "experiment_ready"
+}
+```
+
+## ArtifactSafetyGateRequest and ArtifactSafetyReport
+
+An optional, implementation-neutral safety gate over agent-produced artifacts
+(code, config, docs, manifests) before a high-impact action. The request
+describes *what* and *how* to check; the report carries the verdict. `mode`
+(`advisory` vs `blocking`) distinguishes an informational check from a gate
+that must pass.
+
+**Produced/consumed by:** vibeguard or an equivalent gate (producer); the host /
+agent-kernel as the policy gate that acts on the result.
+
+<!-- schema: artifact_safety_gate_request -->
+```json
+{
+  "request_id": "asg-req-20260527-001",
+  "repository_root": "/workspace/app",
+  "artifact_paths": ["src/handlers/payment.py"],
+  "diff_scope": "origin/main...HEAD",
+  "policy_level": "strict",
+  "output_format": "json"
+}
+```
+
+<!-- schema: artifact_safety_report -->
+```json
+{
+  "report_id": "asg-rep-20260527-001",
+  "gate_id": "org.vibeguard.scan_changes",
+  "decision": "fail",
+  "created_at": "2026-05-27T10:30:00Z",
+  "mode": "blocking",
+  "findings": [
+    {
+      "finding_id": "f-001",
+      "severity": "high",
+      "message": "Hardcoded credential detected.",
+      "remediation": "Move the secret to a secret store."
+    }
+  ]
+}
+```
+
+---
+
+## Status and versioning
+
+These types are **Extended**: optional and opt-in. Per `docs/VERSIONING.md`,
+Extended contracts may change (including breaking changes) in a MINOR version.
+They were introduced in contract version `0.5.0`. Full sample payloads live in
+[`examples/sample_payloads/`](../examples/sample_payloads/) and are validated in
+CI against the schemas under
+[`contracts/json/extended/`](../contracts/json/extended/).

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -111,3 +111,77 @@ An immutable audit log entry recording a single significant event in the executi
 The storage backend for raw tool output artifacts referenced by Handles. The HandleStore is an agent-kernel internal component; its implementation is not specified here. What is specified is the Handle contract that references artifacts stored within it.
 
 **Key property:** Artifacts in the HandleStore are accessible only through Handle resolution, which requires authorization.
+
+---
+
+## ReviewArtifact
+
+**(Extended.)** A minimal, language-neutral interchange shape for trace/review records exchanged between projects (context build records, execution records, policy decisions, review notes, safety reports). An interchange shape, not a storage system. See [docs/ARTIFACT_CONTRACTS.md](ARTIFACT_CONTRACTS.md).
+
+**Key fields:** `artifact_id`, `artifact_type`, `source_project`, `created_at`, `evidence_refs`, `decision_refs`.
+
+**Owned by:** any project (cross-project vocabulary).
+
+---
+
+## MemoryArtifact
+
+**(Extended.)** A durable or semi-durable agent memory record, distinct from transient conversation context, raw tool output, and traces. Carries its own sensitivity and provenance.
+
+**Key fields:** `memory_id`, `memory_type`, `content`, `source`, `created_at`, `scope`, `sensitivity`, `confidence`, `expires_at`.
+
+**Owned by:** contextweaver (memory source) and adjacent memory stores; produced/consumed across the stack.
+
+---
+
+## SessionHandoff
+
+**(Extended.)** A compact continuity pack carried between agent sessions. References durable memory via `memory_refs` rather than inlining it.
+
+**Key fields:** `handoff_id`, `from_session_id`, `to_session_id`, `created_at`, `summary`, `open_threads`, `memory_refs`.
+
+**Owned by:** the host application / orchestration layer at session boundaries.
+
+---
+
+## LessonCard
+
+**(Extended.)** A reviewed, reusable lesson derived from traces and approved for reuse. Not a raw trace, raw memory, or prompt fragment. `lifecycle_state` gates activation (review before `active`).
+
+**Key fields:** `lesson_id`, `title`, `body`, `created_at`, `lifecycle_state`, `scope`, `sensitivity`, `applicability`, `source_refs`.
+
+**Owned by:** lessonweaver (produces); any agent applies approved lessons.
+
+---
+
+## SkillCard
+
+**(Extended.)** A reviewed, reusable procedure/skill derived from traces. Like LessonCard, `lifecycle_state` gates activation; `steps` and `preconditions` describe how and when to apply it.
+
+**Key fields:** `skill_id`, `name`, `description`, `created_at`, `lifecycle_state`, `steps`, `preconditions`, `scope`, `sensitivity`, `source_refs`.
+
+**Owned by:** lessonweaver (produces); any agent applies approved skills.
+
+---
+
+## EvaluationArtifact
+
+**(Extended.)** A statistical / offline model-evaluation report carried with explicit semantics so agents cannot misuse a headline score. `support_state` summarizes diagnostic confidence; `recommendation_kind` is the machine-readable verdict.
+
+**Key fields:** `artifact_id`, `producer`, `created_at`, `artifact_type`, `metrics`, `uncertainty`, `support_state`, `warnings`, `recommendation_kind`, `limitations`.
+
+**Owned by:** skdr-eval (produces); contextweaver / ChainWeaver / agent-kernel interpret.
+
+**Invariant (construction-time):** A `high_risk` evaluation must not carry `recommendation_kind = "deploy"` — a high-risk evaluation is not deployment evidence.
+
+---
+
+## ArtifactSafetyGateRequest / ArtifactSafetyReport
+
+**(Extended.)** Inputs and outputs of an optional, implementation-neutral safety gate over agent-produced artifacts (code, config, docs, manifests) before a high-impact action. The report's `mode` distinguishes an advisory check from a blocking gate; `decision` is the pass/fail verdict.
+
+**Key request fields:** `request_id`, `repository_root`, `artifact_paths`, `diff_scope`, `policy_level`, `output_format`.
+
+**Key report fields:** `report_id`, `gate_id`, `decision`, `created_at`, `mode`, `findings` (each with `severity`, `message`, optional `fingerprint`, `remediation`).
+
+**Owned by:** vibeguard or an equivalent gate (produces); the host / agent-kernel acts on the result.

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -22,14 +22,19 @@ After completing all six artifacts, run the local validation checks before submi
 
 ## Extended contract change workflow
 
-Extended contracts do **not** currently have JSON Schemas; the `contracts/json/` directory is Core-only.
-When modifying an Extended contract, complete all of the following in a single PR:
+Extended contracts may define JSON Schemas under `contracts/json/extended/`.
+Newer Extended types ship a schema; the original metadata types remain
+Python-source-of-truth pending their schema retrofit (#46).
+When adding or modifying an Extended contract, complete all of the following in a single PR:
 
 1. **Update the Python dataclass** in `contracts/python/src/weaver_contracts/extended.py`.
-2. **Update or create a sample payload** in `examples/sample_payloads/`.
-3. **Add or update a roundtrip test** in `contracts/python/tests/test_roundtrip_examples.py`.
-4. **Add a CHANGELOG entry** under the appropriate version section.
-5. **Bump the version** in both `contracts/python/src/weaver_contracts/version.py` and `contracts/python/pyproject.toml`.
+2. **Add or update the JSON Schema** under `contracts/json/extended/` (for types that have one).
+3. **Update or create a sample payload** in `examples/sample_payloads/`.
+4. **Add or update a roundtrip test** in `contracts/python/tests/test_extended.py`.
+5. **Add or update a schema-alignment test** in `contracts/python/tests/test_extended_schema_alignment.py` (for types with a schema).
+6. **Add a CHANGELOG entry** under the appropriate version section.
+7. **Bump the version** in both `contracts/python/src/weaver_contracts/version.py` and `contracts/python/pyproject.toml`.
+8. **Regenerate** `contracts/COVERAGE.md` (`scripts/generate_coverage_table.py`) and `well-known/contracts.json` (`scripts/generate_contracts_index.py`); CI checks both with `--check`.
 
 Breaking changes are allowed in MINOR versions for Extended contracts.
 

--- a/examples/sample_payloads/artifact_safety_gate_request.json
+++ b/examples/sample_payloads/artifact_safety_gate_request.json
@@ -1,0 +1,15 @@
+{
+  "request_id": "asg-req-20260527-001",
+  "repository_root": "/workspace/app",
+  "artifact_paths": [
+    "src/handlers/payment.py",
+    ".github/workflows/deploy.yml"
+  ],
+  "diff_scope": "origin/main...HEAD",
+  "policy_level": "strict",
+  "output_format": "json",
+  "capability_id": "org.vibeguard.scan_changes",
+  "metadata": {
+    "trigger": "pre_merge"
+  }
+}

--- a/examples/sample_payloads/artifact_safety_report.json
+++ b/examples/sample_payloads/artifact_safety_report.json
@@ -1,0 +1,31 @@
+{
+  "report_id": "asg-rep-20260527-001",
+  "gate_id": "org.vibeguard.scan_changes",
+  "decision": "fail",
+  "created_at": "2026-05-27T10:30:00Z",
+  "mode": "blocking",
+  "request_id": "asg-req-20260527-001",
+  "target_ref": "origin/main...HEAD",
+  "summary": "1 high-severity finding blocks the merge.",
+  "findings": [
+    {
+      "finding_id": "f-001",
+      "severity": "high",
+      "message": "Hardcoded credential detected in src/handlers/payment.py.",
+      "fingerprint": "sha256:9f2c...e1",
+      "remediation": "Move the secret to an environment variable or secret store."
+    },
+    {
+      "finding_id": "f-002",
+      "severity": "low",
+      "message": "Workflow grants broader permissions than required.",
+      "fingerprint": null,
+      "remediation": "Scope the GITHUB_TOKEN permissions to the minimum needed."
+    }
+  ],
+  "provenance": {
+    "tool": "vibeguard",
+    "ruleset": "default@2026.05"
+  },
+  "metadata": {}
+}

--- a/examples/sample_payloads/evaluation_artifact.json
+++ b/examples/sample_payloads/evaluation_artifact.json
@@ -1,0 +1,42 @@
+{
+  "artifact_id": "eval-20260527-001",
+  "producer": "skdr-eval",
+  "created_at": "2026-05-27T10:00:00Z",
+  "artifact_type": "offline_policy_evaluation",
+  "producer_version": "0.9.2",
+  "target_estimand": "policy_value_under_target_distribution",
+  "candidate_policy": "reminder_policy_v3",
+  "baseline_policy": "reminder_policy_v2",
+  "metrics": {
+    "estimated_value": 0.42,
+    "value_uplift_vs_baseline": 0.05
+  },
+  "uncertainty": {
+    "ci_method": "bootstrap",
+    "ci_level": 0.95,
+    "value_ci": [0.31, 0.53]
+  },
+  "support_state": "caution",
+  "support_diagnostics": {
+    "effective_sample_size": 1840,
+    "overlap": "partial"
+  },
+  "propensity_diagnostics": {
+    "max_importance_weight": 18.4,
+    "clipping_applied": true
+  },
+  "sensitivity": "internal",
+  "warnings": [
+    "High maximum importance weight indicates limited overlap; estimate may be unstable."
+  ],
+  "recommendation": "Run a small online experiment before any rollout; do not deploy on this evidence alone.",
+  "recommendation_kind": "experiment_ready",
+  "limitations": [
+    "Offline estimate only; no online validation performed."
+  ],
+  "provenance": {
+    "dataset": "logged_interactions_2026q1",
+    "run_id": "skdr-run-7781"
+  },
+  "metadata": {}
+}

--- a/examples/sample_payloads/lesson_card.json
+++ b/examples/sample_payloads/lesson_card.json
@@ -1,0 +1,21 @@
+{
+  "lesson_id": "lsn-20260527-001",
+  "title": "Regenerate generated artifacts before pushing",
+  "body": "After any contracts/json change, regenerate well-known/contracts.json and contracts/COVERAGE.md; CI runs both generators with --check and fails on staleness.",
+  "created_at": "2026-05-27T09:00:00Z",
+  "lifecycle_state": "active",
+  "scope": "repo",
+  "sensitivity": "internal",
+  "applicability": [
+    "changed:contracts/json/**",
+    "task:add_contract"
+  ],
+  "source_refs": [
+    "trace:ci-failure-stale-index"
+  ],
+  "expires_at": null,
+  "provenance": {
+    "derived_from": "ci_failure_review"
+  },
+  "metadata": {}
+}

--- a/examples/sample_payloads/memory_artifact.json
+++ b/examples/sample_payloads/memory_artifact.json
@@ -1,0 +1,18 @@
+{
+  "memory_id": "mem-20260527-001",
+  "memory_type": "repo_convention",
+  "content": "This repo is docs + contracts only; never add runtime logic to weaver_contracts.",
+  "source": "AGENTS.md",
+  "created_at": "2026-05-27T08:00:00Z",
+  "updated_at": "2026-05-27T08:05:00Z",
+  "scope": "repo",
+  "sensitivity": "internal",
+  "confidence": 0.95,
+  "expires_at": null,
+  "dependency_refs": [],
+  "provenance": {
+    "derived_from": "doc_ingest",
+    "doc": "AGENTS.md#purpose-and-scope"
+  },
+  "metadata": {}
+}

--- a/examples/sample_payloads/review_artifact.json
+++ b/examples/sample_payloads/review_artifact.json
@@ -1,0 +1,18 @@
+{
+  "artifact_id": "rev-20260527-001",
+  "artifact_type": "review_note",
+  "source_project": "agent-kernel",
+  "created_at": "2026-05-27T08:00:00Z",
+  "subject_ref": "flow:invoice_reminder_flow@1.2.0",
+  "summary": "Execution completed within policy; no firewall bypass observed.",
+  "evidence_refs": [
+    "trace:evt-20260527-014",
+    "frame:frame-20260527-007"
+  ],
+  "decision_refs": [
+    "policy:pd-20260527-003"
+  ],
+  "metadata": {
+    "reviewer": "audit-bot"
+  }
+}

--- a/examples/sample_payloads/session_handoff.json
+++ b/examples/sample_payloads/session_handoff.json
@@ -1,0 +1,20 @@
+{
+  "handoff_id": "ho-20260527-001",
+  "from_session_id": "sess-20260527-am",
+  "created_at": "2026-05-27T12:00:00Z",
+  "summary": "Implemented 5 Extended artifact contracts; tests green; PR description drafted.",
+  "to_session_id": null,
+  "sensitivity": "internal",
+  "open_threads": [
+    "Confirm whether the original 7 Extended types should be retrofitted under #46.",
+    "Decide release date for 0.5.0."
+  ],
+  "memory_refs": [
+    "mem-20260527-001"
+  ],
+  "expires_at": "2026-06-27T12:00:00Z",
+  "provenance": {
+    "derived_from": "session_summary"
+  },
+  "metadata": {}
+}

--- a/examples/sample_payloads/skill_card.json
+++ b/examples/sample_payloads/skill_card.json
@@ -1,0 +1,27 @@
+{
+  "skill_id": "skl-20260527-001",
+  "name": "Add an Extended contract",
+  "description": "End-to-end procedure for adding a new Extended contract type to weaver-spec.",
+  "created_at": "2026-05-27T09:30:00Z",
+  "lifecycle_state": "in_review",
+  "steps": [
+    "Add the dataclass to contracts/python/src/weaver_contracts/extended.py.",
+    "Add the JSON schema under contracts/json/extended/.",
+    "Add a sample payload under examples/sample_payloads/.",
+    "Add roundtrip tests to test_extended.py and schema tests to test_extended_schema_alignment.py.",
+    "Bump version, update CHANGELOG, regenerate COVERAGE.md and well-known/contracts.json."
+  ],
+  "preconditions": [
+    "Type is non-universal (Extended, not Core) per invariant I-04."
+  ],
+  "scope": "repo",
+  "sensitivity": "internal",
+  "source_refs": [
+    "doc:docs/agent-context/workflows.md#extended-contract-change-workflow"
+  ],
+  "expires_at": null,
+  "provenance": {
+    "derived_from": "workflow_doc"
+  },
+  "metadata": {}
+}

--- a/scripts/check_schema_fields.py
+++ b/scripts/check_schema_fields.py
@@ -7,7 +7,8 @@ A spec-compliant schema in this repository must declare ``$id``, ``title``,
 This script enforces that contract from both CI and the pre-commit hook so
 the two stay in sync.
 
-Run with no arguments to scan ``contracts/json/*.schema.json``:
+Run with no arguments to scan ``contracts/json/**/*.schema.json`` (Core at the
+top level and Extended under ``contracts/json/extended/``):
 
     python scripts/check_schema_fields.py
 
@@ -30,7 +31,7 @@ REQUIRED_FIELDS = ("$id", "title", "description", "required")
 
 
 def main() -> int:
-    files = sorted(SCHEMA_DIR.glob("*.schema.json"))
+    files = sorted(SCHEMA_DIR.rglob("*.schema.json"))
     if not files:
         print(f"ERROR: No schema files found under {SCHEMA_DIR}", file=sys.stderr)
         return 1

--- a/well-known/contracts.json
+++ b/well-known/contracts.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "contract_version": "0.4.0",
+  "contract_version": "0.5.0",
   "core": [
     {
       "name": "capability",
@@ -66,5 +66,62 @@
       "sha256": "a388c87ae93d540874ab822cb3686ec89e80703d8ef609dcbd3ebbcd01c7bbd9"
     }
   ],
-  "extended": []
+  "extended": [
+    {
+      "name": "artifact_safety_gate_request",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/artifact_safety_gate_request.schema.json",
+      "path": "contracts/json/extended/artifact_safety_gate_request.schema.json",
+      "sha256": "c923b62b0fbe656761c734c20d3036951d17212c92be6d767b48782e508308ff"
+    },
+    {
+      "name": "artifact_safety_report",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/artifact_safety_report.schema.json",
+      "path": "contracts/json/extended/artifact_safety_report.schema.json",
+      "sha256": "2352e7f2e848500a0b670657fa9716d3b1758e56ffb685876a0f82e2bb64cb49"
+    },
+    {
+      "name": "evaluation_artifact",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/evaluation_artifact.schema.json",
+      "path": "contracts/json/extended/evaluation_artifact.schema.json",
+      "sha256": "87e828ad60b6fe8288bbb1c72acbdb496335d0977f3a3180130925c061a9017c"
+    },
+    {
+      "name": "lesson_card",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/lesson_card.schema.json",
+      "path": "contracts/json/extended/lesson_card.schema.json",
+      "sha256": "922283d72140920f591e7f9ea30621878ba28606c65b078e71ef5459584b9d1a"
+    },
+    {
+      "name": "memory_artifact",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/memory_artifact.schema.json",
+      "path": "contracts/json/extended/memory_artifact.schema.json",
+      "sha256": "5c469d4a3d825be40ac848db79bccef08e5accec5c9cf97318f7f7fa9b174aea"
+    },
+    {
+      "name": "review_artifact",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/review_artifact.schema.json",
+      "path": "contracts/json/extended/review_artifact.schema.json",
+      "sha256": "9ac740c96079862dfe047e60084050279167f44ee5e983e1205070988d059bbe"
+    },
+    {
+      "name": "session_handoff",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/session_handoff.schema.json",
+      "path": "contracts/json/extended/session_handoff.schema.json",
+      "sha256": "09e64fefaa82d7c657840993a1649a356880193e8b3a2efad0c8eb41f5a153c6"
+    },
+    {
+      "name": "skill_card",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/skill_card.schema.json",
+      "path": "contracts/json/extended/skill_card.schema.json",
+      "sha256": "964833d0835a01172686611bdda74757166822d6aed47156c612f7c063c85559"
+    }
+  ]
 }

--- a/well-known/contracts.json
+++ b/well-known/contracts.json
@@ -86,7 +86,7 @@
       "version": "v0",
       "$id": "https://weaver-spec.dev/contracts/v0/extended/evaluation_artifact.schema.json",
       "path": "contracts/json/extended/evaluation_artifact.schema.json",
-      "sha256": "87e828ad60b6fe8288bbb1c72acbdb496335d0977f3a3180130925c061a9017c"
+      "sha256": "11b7a02fd3d13881ccfcc85e22e57cf5292411e23f80993d7956d5c474a6af52"
     },
     {
       "name": "lesson_card",


### PR DESCRIPTION
## Description

Adds eight **Extended** (optional, opt-in) cross-project artifact contracts as one coherent additive sweep, closing five issues triaged as the most coherent group: #65, #56, #64, #67, #63. Each type ships the full Extended artifact set — JSON Schema under `contracts/json/extended/`, sample payload, roundtrip test, schema-alignment test, glossary entry — and is documented in a single consolidated spec page.

**New types**
- `ReviewArtifact` — minimal cross-project trace/review interchange shape (Closes #65)
- `MemoryArtifact` + `SessionHandoff` — durable memory + session continuity (Closes #56)
- `LessonCard` + `SkillCard` — reviewed, reusable knowledge derived from traces (Closes #64)
- `EvaluationArtifact` — statistical/offline-evaluation report with safe semantics (Closes #67)
- `ArtifactSafetyGateRequest` + `ArtifactSafetyReport` — artifact safety gate inputs/outputs (Closes #63)

They share a common envelope (`*_id`, ISO-8601 `created_at`, `sensitivity`, `provenance`, `metadata`) and a documented taxonomy distinguishing memory vs trace vs lesson vs evaluation vs safety-report. `EvaluationArtifact` rejects, at construction time, a `high_risk` support state paired with a `deploy` recommendation (a high-risk evaluation is not deployment evidence — #67's explicit requirement).

## Why

These five issues were identified during triage as the best coherent single-PR group: all are language-neutral, additive, unblocked, and mutually consistency-dependent (defining them separately risks divergent envelopes/taxonomies). Per **I-04** they are Extended, not Core. The `contracts/json/extended/` layout was already pre-wired in the index and coverage generators; this PR populates it for the new types (the original 7 Extended metadata types stay Python-source-of-truth pending #46).

## Type of change

- [x] Docs only (no contract changes) — *partial: also docs*
- [x] Additive contract change (new optional types — non-breaking)
- [ ] Breaking contract change
- [x] CI / tooling change — recursive schema globbing

## Six-artifact checklist

These are **Extended** types, so the Extended workflow applies (schema + dataclass + payload + roundtrip test + schema-alignment test + CHANGELOG + version bump). No Core contracts touched.

- [x] JSON Schema added — `contracts/json/extended/*.schema.json` (8 files)
- [x] Python dataclass added — `weaver_contracts/extended.py` (Core `core.py` **N/A**)
- [x] Sample payload added — `examples/sample_payloads/*.json` (8 files)
- [x] Roundtrip test added — `tests/test_extended.py` (+ new `tests/test_extended_schema_alignment.py`)
- [x] CHANGELOG entry added
- [x] Version bumped — `version.py` + `pyproject.toml` (0.4.0 → 0.5.0, MINOR)

## Deprecations

- [x] N/A (no deprecation in this PR)

## Invariants

- [x] I-01–I-07 verified not violated. These are optional Extended artifacts off the Core request path; no firewall/authorization/audit boundary is changed. No normative `BOUNDARIES.md` table was modified (that would require an ADR); ownership is documented informatively in `docs/ARTIFACT_CONTRACTS.md` and `docs/GLOSSARY.md`.

## Cross-repo impact

- [x] No cross-repo impact — new types are optional and opt-in; no Core contract surface changed. Adjacent tools (lessonweaver, skdr-eval, vibeguard) and siblings may adopt them when ready.

## How verified

Ran the full local gate set:

- `mypy src/` — **Success: no issues found**
- `pytest --cov` — **167 passed**, total coverage **93.32%** (gate: `fail_under = 80`)
- `python scripts/check_schema_fields.py` — **17 schemas OK** (now recursive incl. `extended/`)
- `python scripts/generate_contracts_index.py --check` — **up to date** (regenerated; 0.5.0 + extended entries)
- `python scripts/generate_coverage_table.py --check` — **up to date** (24 types)
- `yamllint -c .yamllint.yml` (issue templates, workflows, configs) — **OK**
- CI walkthrough inline-JSON validator (recursive) — **48 inline payloads validate**, incl. the 7 new examples in `docs/ARTIFACT_CONTRACTS.md`
- markdownlint — new/changed docs **0 errors**

## Mode B scope deltas (documented)

- Establishes `contracts/json/extended/` + `tests/test_extended_schema_alignment.py` for the new types — overlaps groundwork tracked by **#46** (the original 7 Extended types are intentionally left for #46).
- Accuracy edits to `AGENTS.md` ("schemas lead", repo map, doc map) and `docs/agent-context/workflows.md` (Extended workflow) since "Extended has no JSON Schemas" is no longer true.
- Recursive globbing in `scripts/check_schema_fields.py` and the `ci.yml` inline-JSON validator so Extended schemas are covered.

## Risks / caveats

- The shared memory/trace/lesson taxonomy (#56/#64/#65) is defined together here to avoid divergence; field sets are minimal-but-stable with richer data deferred to `metadata`.
- Extended types intentionally use ISO-8601 **string** timestamps (interchange-shape framing), unlike Core dataclasses which use `datetime`.
- Pre-existing note: under the latest `markdownlint` (0.48.0) `AGENTS.md` reports MD060 "table-column-style" on long-standing tables; this is present on `main` too and predates the repo's pinned `markdownlint-cli2` v0.14.0 baseline — not introduced here.

https://claude.ai/code/session_01EURXTGKVgChDWVBksnjayb

---
_Generated by [Claude Code](https://claude.ai/code/session_01EURXTGKVgChDWVBksnjayb)_