### PR TITLE
contracts: v0.6.0 — Extended schema retrofit, JCS signing, OTel mapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ For JSON schema conventions specifically, `contracts/json/README.md` is authorit
 
 JSON Schemas are the language-agnostic source of truth for all **Core** contract definitions. Python Core types must mirror them exactly — same field names, same types, same required/optional status. Zero divergence.
 
-Extended contracts may define JSON Schemas under `contracts/json/extended/`. Where an Extended schema exists, it leads and the Python dataclass in `extended.py` must mirror it (same as Core). The original metadata types (`TelemetryHint`, `SchemaFingerprint`, `RedactionPolicy`, `UIHint`, `RiskAssessment`, `ExtendedFrameMetadata`, `ExtendedSelectableItemMetadata`) remain Python-source-of-truth pending their schema retrofit (#46).
+Extended contracts define JSON Schemas under `contracts/json/extended/`. The Python dataclass in `extended.py` must mirror its schema (same as Core).
 
 ---
 
@@ -138,7 +138,7 @@ Do not merge, collapse, or "simplify" these types without a spec-level ADR.
 
 ## Domain clarifications
 
-**CapabilityToken:** Currently a plain data structure. The word "signed" in the Glossary and schema descriptions is aspirational. Signing is an agent-kernel implementation concern, not enforced in this spec. Do not add signature fields or cryptographic logic here.
+**CapabilityToken:** The Core token remains a plain data structure. As of v0.6.0 the spec defines an Extended detached-signature contract (`CapabilityTokenSignature`, attached under `x_weaver_signature`) per [ADR 001](docs/adr/001-capability-token-signing.md) — the word "signed" is accurate when that extension is present. Signing is opt-in in v0.x; do not add signature fields or cryptographic logic to the Core schema, and do not invent alternative signature shapes — use the Extended contract.
 
 **ID format:** IDs are any non-empty string (`minLength: 1`). UUIDs are not required. Sample payloads use readable slug-style IDs (e.g., `rd-20260308-001`). If any other docs or examples ever conflict with this, treat the JSON Schemas as the authority.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,13 +39,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
     `docs/OTEL_MAPPING.md` (pinned to OTel semconv snapshot `1.30.0`) with
     a CI-validated inline payload, plus a sample payload. Closes #47.
   - Tests: `test_extended.py` gains `TestCapabilityTokenSignature` and
-    `TestOtelTraceMapping` (8 + 9 cases each, including JCS/algorithm
-    registry enforcement, W3C trace/span hex-format checks, and all five
-    OTel span kinds). `test_extended_schema_alignment.py` adds the nine
-    new schemas to its parametrized list plus six new negative cases
-    (unknown signing algorithm, unknown canonicalization, signed
-    CapabilityToken validation, invalid OTel span kind, malformed
-    `trace_id`, missing fingerprint required fields).
+    `TestOtelTraceMapping` (11 + 12 cases each, including JCS/algorithm
+    registry enforcement, the 86-char base64url length constraint on
+    `sig`, W3C-lowercase enforcement on `trace_id` / `span_id` /
+    `parent_span_id`, and all five OTel span kinds).
+    `test_extended_schema_alignment.py` adds the nine new schemas to its
+    parametrized list plus eight new negative cases (unknown signing
+    algorithm, unknown canonicalization, signed CapabilityToken
+    validation, invalid OTel span kind, malformed `trace_id`, uppercase
+    `trace_id`, wrong-length `sig`, missing fingerprint required fields).
 - `compatibility.yaml` — machine-readable manifest of sibling-repository
   compatibility with each weaver-spec contract version (`contextweaver`,
   `agent-kernel`, `ChainWeaver`). Declares per-repo `status`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
     `sig`, W3C-lowercase enforcement on `trace_id` / `span_id` /
     `parent_span_id`, and all five OTel span kinds).
     `test_extended_schema_alignment.py` adds the nine new schemas to its
-    parametrized list plus eight new negative cases (unknown signing
+    parametrized list plus eleven new negative cases (unknown signing
     algorithm, unknown canonicalization, signed CapabilityToken
     validation, invalid OTel span kind, malformed `trace_id`, uppercase
-    `trace_id`, wrong-length `sig`, missing fingerprint required fields).
+    `trace_id`, wrong-length `sig`, `confidence_score` above/below
+    `[0.0, 1.0]`, negative `estimated_duration_ms`, missing fingerprint
+    required fields).
+  - `ExtendedFrameMetadata` and `ExtendedSelectableItemMetadata` gain
+    `__post_init__` range validation so the Python dataclass enforces
+    the same numeric bounds the JSON Schemas document: `confidence_score`
+    must be in `[0.0, 1.0]` (the schema gains explicit `minimum`/`maximum`
+    too) and `estimated_duration_ms` must be `>= 0` (schema's existing
+    `minimum: 0` is now mirrored in Python).
 - `compatibility.yaml` — machine-readable manifest of sibling-repository
   compatibility with each weaver-spec contract version (`contextweaver`,
   `agent-kernel`, `ChainWeaver`). Declares per-repo `status`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,42 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
 
 ### Added
 
+- **v0.6.0 — Extended schema retrofit + signing + OpenTelemetry mapping.**
+  Bumps `CONTRACT_VERSION` and the Python package to `0.6.0` and lands three
+  related issues in one PR.
+  - **JSON Schemas for the seven original Extended metadata types**
+    (`TelemetryHint`, `SchemaFingerprint`, `RedactionPolicy`, `UIHint`,
+    `RiskAssessment`, `ExtendedFrameMetadata`,
+    `ExtendedSelectableItemMetadata`). Their `$id` URIs live under the
+    `extended/` namespace; `ExtendedFrameMetadata` and
+    `ExtendedSelectableItemMetadata` reference their child schemas via
+    `$ref` resolved by the existing local schema store. The
+    Python-source-of-truth carve-out in `AGENTS.md` and
+    `docs/agent-context/workflows.md` is removed. Closes #46.
+  - **`CapabilityTokenSignature` Extended contract** for RFC 8785 JCS
+    canonicalization plus `ed25519` / `es256` detached signatures, attached
+    to a `CapabilityToken` under the namespaced extension key
+    `x_weaver_signature` (Core schema unchanged). New ADR
+    `docs/adr/001-capability-token-signing.md` and verification guide
+    `docs/SIGNING.md`. Two new sample payloads
+    (`capability_token_signature.json`, `capability_token_signed.json`).
+    The `AGENTS.md` "Domain clarifications" entry for `CapabilityToken` is
+    updated to reflect that the word "signed" is accurate when the
+    extension is present. Closes #44.
+  - **`OtelTraceMapping` Extended contract** carrying W3C Trace Context
+    identifiers and OTel GenAI semconv attributes
+    (`gen_ai.operation.name`, `gen_ai.tool.name`, `gen_ai.agent.id`,
+    `gen_ai.agent.name`, `gen_ai.system`). New normative mapping doc
+    `docs/OTEL_MAPPING.md` (pinned to OTel semconv snapshot `1.30.0`) with
+    a CI-validated inline payload, plus a sample payload. Closes #47.
+  - Tests: `test_extended.py` gains `TestCapabilityTokenSignature` and
+    `TestOtelTraceMapping` (8 + 9 cases each, including JCS/algorithm
+    registry enforcement, W3C trace/span hex-format checks, and all five
+    OTel span kinds). `test_extended_schema_alignment.py` adds the nine
+    new schemas to its parametrized list plus six new negative cases
+    (unknown signing algorithm, unknown canonicalization, signed
+    CapabilityToken validation, invalid OTel span kind, malformed
+    `trace_id`, missing fingerprint required fields).
 - `compatibility.yaml` — machine-readable manifest of sibling-repository
   compatibility with each weaver-spec contract version (`contextweaver`,
   `agent-kernel`, `ChainWeaver`). Declares per-repo `status`

--- a/contracts/COVERAGE.md
+++ b/contracts/COVERAGE.md
@@ -17,12 +17,12 @@ CI runs the same script with `--check` and fails if this file is stale.
 
 ## Summary
 
-- Total contract types: **24**
-- JSON Schemas: **17 / 24**
-- Python classes: **24 / 24**
-- Sample payloads: **24 / 24**
-- Roundtrip tests: **24 / 24**
-- Schema validation tests: **11 / 24**
+- Total contract types: **26**
+- JSON Schemas: **26 / 26**
+- Python classes: **26 / 26**
+- Sample payloads: **26 / 26**
+- Roundtrip tests: **26 / 26**
+- Schema validation tests: **20 / 26**
 
 ## Coverage table
 
@@ -37,13 +37,13 @@ CI runs the same script with `--check` and fails if this file is stale.
 | Core | `Frame` | OK | OK | OK | OK | OK |
 | Core | `Handle` | OK | OK | OK | OK | -- |
 | Core | `TraceEvent` | OK | OK | OK | OK | -- |
-| Extended | `TelemetryHint` | -- | OK | OK | OK | -- |
-| Extended | `SchemaFingerprint` | -- | OK | OK | OK | -- |
-| Extended | `RedactionPolicy` | -- | OK | OK | OK | -- |
-| Extended | `UIHint` | -- | OK | OK | OK | -- |
-| Extended | `RiskAssessment` | -- | OK | OK | OK | -- |
-| Extended | `ExtendedFrameMetadata` | -- | OK | OK | OK | -- |
-| Extended | `ExtendedSelectableItemMetadata` | -- | OK | OK | OK | -- |
+| Extended | `TelemetryHint` | OK | OK | OK | OK | OK |
+| Extended | `SchemaFingerprint` | OK | OK | OK | OK | OK |
+| Extended | `RedactionPolicy` | OK | OK | OK | OK | OK |
+| Extended | `UIHint` | OK | OK | OK | OK | OK |
+| Extended | `RiskAssessment` | OK | OK | OK | OK | OK |
+| Extended | `ExtendedFrameMetadata` | OK | OK | OK | OK | OK |
+| Extended | `ExtendedSelectableItemMetadata` | OK | OK | OK | OK | OK |
 | Extended | `ReviewArtifact` | OK | OK | OK | OK | OK |
 | Extended | `MemoryArtifact` | OK | OK | OK | OK | OK |
 | Extended | `SessionHandoff` | OK | OK | OK | OK | OK |
@@ -52,6 +52,8 @@ CI runs the same script with `--check` and fails if this file is stale.
 | Extended | `EvaluationArtifact` | OK | OK | OK | OK | OK |
 | Extended | `ArtifactSafetyGateRequest` | OK | OK | OK | OK | OK |
 | Extended | `ArtifactSafetyReport` | OK | OK | OK | OK | OK |
+| Extended | `CapabilityTokenSignature` | OK | OK | OK | OK | OK |
+| Extended | `OtelTraceMapping` | OK | OK | OK | OK | OK |
 
 ## Legend
 

--- a/contracts/json/README.md
+++ b/contracts/json/README.md
@@ -25,8 +25,31 @@ contracts (not required for spec compliance; see invariant I-04). Their `$id`
 URIs live under the `extended/` namespace, e.g.
 `https://weaver-spec.dev/contracts/v0/extended/memory_artifact.schema.json`.
 Extended schemas follow the same design principles below and are picked up
-automatically by `scripts/generate_contracts_index.py`. See
-[`../../docs/ARTIFACT_CONTRACTS.md`](../../docs/ARTIFACT_CONTRACTS.md) for the
+automatically by `scripts/generate_contracts_index.py`.
+
+Extended schemas currently published:
+
+| Schema | Description |
+| -------- | ------------- |
+| `telemetry_hint.schema.json` | Optional telemetry metadata attached to any event |
+| `schema_fingerprint.schema.json` | Schema version + content hash for compatibility checking |
+| `redaction_policy.schema.json` | Firewall redaction rules applied when producing a Frame |
+| `ui_hint.schema.json` | Optional UI rendering hints for SelectableItems |
+| `risk_assessment.schema.json` | Optional risk metadata for a capability invocation |
+| `extended_frame_metadata.schema.json` | Enriched Frame metadata (telemetry, fingerprint, redaction) |
+| `extended_selectable_item_metadata.schema.json` | UI + risk hints for a SelectableItem |
+| `capability_token_signature.schema.json` | RFC 8785 JCS detached signature for a CapabilityToken (see [docs/SIGNING.md](../../docs/SIGNING.md)) |
+| `otel_trace_mapping.schema.json` | TraceEvent → OpenTelemetry GenAI semantic-convention mapping (see [docs/OTEL_MAPPING.md](../../docs/OTEL_MAPPING.md)) |
+| `review_artifact.schema.json` | Cross-project trace/review interchange envelope |
+| `memory_artifact.schema.json` | Durable / semi-durable agent memory record |
+| `session_handoff.schema.json` | Compact continuity pack between sessions |
+| `lesson_card.schema.json` | Reviewed, reusable lesson derived from traces |
+| `skill_card.schema.json` | Reviewed, reusable procedure derived from traces |
+| `evaluation_artifact.schema.json` | Statistical / model-evaluation decision report |
+| `artifact_safety_gate_request.schema.json` | Inputs to an artifact safety gate capability |
+| `artifact_safety_report.schema.json` | Output of an artifact safety gate run |
+
+See [`../../docs/ARTIFACT_CONTRACTS.md`](../../docs/ARTIFACT_CONTRACTS.md) for the
 cross-project artifact vocabulary.
 
 ## Usage

--- a/contracts/json/extended/capability_token_signature.schema.json
+++ b/contracts/json/extended/capability_token_signature.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/capability_token_signature.schema.json",
+  "title": "CapabilityTokenSignature",
+  "description": "Extended. A detached signature over a JCS-canonicalized (RFC 8785) CapabilityToken payload. Attached to the token under the namespaced extension key `x_weaver_signature`. Verifiers MUST reject signatures whose `alg` or `canonicalization` is not in the published registry. See docs/SIGNING.md and docs/adr/001-capability-token-signing.md.",
+  "type": "object",
+  "required": ["alg", "kid", "sig"],
+  "properties": {
+    "alg": {
+      "type": "string",
+      "enum": ["ed25519", "es256"],
+      "description": "Signature algorithm. Must be one of the algorithms in the published registry (docs/SIGNING.md). Verifiers MUST reject unknown algorithms."
+    },
+    "kid": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Key identifier. Opaque to the spec; resolves against the verifier's keyring."
+    },
+    "sig": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[A-Za-z0-9_-]+$",
+      "description": "Base64url-encoded signature bytes (RFC 4648 §5, no padding). For ed25519 this is 64 bytes (86 base64url chars). For es256 this is the IEEE P1363 concatenated (r||s) form, 64 bytes (86 base64url chars)."
+    },
+    "canonicalization": {
+      "type": "string",
+      "enum": ["JCS"],
+      "description": "Canonicalization scheme applied to the token payload before signing. JCS = JSON Canonicalization Scheme (RFC 8785). The `x_weaver_signature` field itself is excluded from the canonical form before hashing.",
+      "default": "JCS"
+    },
+    "signed_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "Optional ISO 8601 timestamp at which the signature was produced. Informational; verification does not depend on it."
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/capability_token_signature.schema.json
+++ b/contracts/json/extended/capability_token_signature.schema.json
@@ -18,9 +18,8 @@
     },
     "sig": {
       "type": "string",
-      "minLength": 1,
-      "pattern": "^[A-Za-z0-9_-]+$",
-      "description": "Base64url-encoded signature bytes (RFC 4648 §5, no padding). For ed25519 this is 64 bytes (86 base64url chars). For es256 this is the IEEE P1363 concatenated (r||s) form, 64 bytes (86 base64url chars)."
+      "pattern": "^[A-Za-z0-9_-]{86}$",
+      "description": "Base64url-encoded signature bytes (RFC 4648 §5, no padding). For ed25519 this is 64 bytes (86 base64url chars). For es256 this is the IEEE P1363 concatenated (r||s) form, 64 bytes (86 base64url chars). The schema enforces the 86-char length; verifiers MUST still decode and validate cryptographically per docs/SIGNING.md."
     },
     "canonicalization": {
       "type": "string",

--- a/contracts/json/extended/extended_frame_metadata.schema.json
+++ b/contracts/json/extended/extended_frame_metadata.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/extended_frame_metadata.schema.json",
+  "title": "ExtendedFrameMetadata",
+  "description": "Extended. Optional enriched metadata for a Frame, beyond the Core contract: redaction policy, telemetry hint, schema fingerprint, confidence score, and source capability version.",
+  "type": "object",
+  "required": [],
+  "properties": {
+    "redaction_policy": {
+      "anyOf": [
+        { "$ref": "https://weaver-spec.dev/contracts/v0/extended/redaction_policy.schema.json" },
+        { "type": "null" }
+      ],
+      "description": "Optional embedded RedactionPolicy describing how the Frame was redacted."
+    },
+    "telemetry": {
+      "anyOf": [
+        { "$ref": "https://weaver-spec.dev/contracts/v0/extended/telemetry_hint.schema.json" },
+        { "type": "null" }
+      ],
+      "description": "Optional TelemetryHint for observability enrichment."
+    },
+    "schema_fingerprint": {
+      "anyOf": [
+        { "$ref": "https://weaver-spec.dev/contracts/v0/extended/schema_fingerprint.schema.json" },
+        { "type": "null" }
+      ],
+      "description": "Optional SchemaFingerprint identifying the schema the Frame's body validates against."
+    },
+    "confidence_score": {
+      "type": ["number", "null"],
+      "description": "Optional confidence score in [0.0, 1.0] for the upstream capability's result."
+    },
+    "source_capability_version": {
+      "type": ["string", "null"],
+      "description": "Optional version of the capability that produced the Frame."
+    },
+    "extra": {
+      "type": "object",
+      "description": "Implementation-specific extension bag. Namespace project-specific keys to avoid collisions.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/extended_frame_metadata.schema.json
+++ b/contracts/json/extended/extended_frame_metadata.schema.json
@@ -29,6 +29,8 @@
     },
     "confidence_score": {
       "type": ["number", "null"],
+      "minimum": 0.0,
+      "maximum": 1.0,
       "description": "Optional confidence score in [0.0, 1.0] for the upstream capability's result."
     },
     "source_capability_version": {

--- a/contracts/json/extended/extended_selectable_item_metadata.schema.json
+++ b/contracts/json/extended/extended_selectable_item_metadata.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/extended_selectable_item_metadata.schema.json",
+  "title": "ExtendedSelectableItemMetadata",
+  "description": "Extended. Optional UI and risk hints for a SelectableItem: a UI hint, a risk assessment, an estimated duration, and a confirmation requirement.",
+  "type": "object",
+  "required": [],
+  "properties": {
+    "ui_hint": {
+      "anyOf": [
+        { "$ref": "https://weaver-spec.dev/contracts/v0/extended/ui_hint.schema.json" },
+        { "type": "null" }
+      ],
+      "description": "Optional UIHint guiding how the item should be rendered."
+    },
+    "risk_assessment": {
+      "anyOf": [
+        { "$ref": "https://weaver-spec.dev/contracts/v0/extended/risk_assessment.schema.json" },
+        { "type": "null" }
+      ],
+      "description": "Optional RiskAssessment for the selectable item."
+    },
+    "estimated_duration_ms": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Optional estimated execution duration in milliseconds."
+    },
+    "requires_confirmation": {
+      "type": "boolean",
+      "description": "If true, the UI must obtain explicit user confirmation before invoking the item.",
+      "default": false
+    },
+    "extra": {
+      "type": "object",
+      "description": "Implementation-specific extension bag. Namespace project-specific keys to avoid collisions.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/otel_trace_mapping.schema.json
+++ b/contracts/json/extended/otel_trace_mapping.schema.json
@@ -9,13 +9,13 @@
     "trace_id": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^[0-9a-fA-F]{32}$",
+      "pattern": "^[0-9a-f]{32}$",
       "description": "OTel trace identifier. 32 lowercase hex characters per the W3C Trace Context (https://www.w3.org/TR/trace-context/#trace-id)."
     },
     "span_id": {
       "type": "string",
       "minLength": 1,
-      "pattern": "^[0-9a-fA-F]{16}$",
+      "pattern": "^[0-9a-f]{16}$",
       "description": "OTel span identifier. 16 lowercase hex characters per the W3C Trace Context (https://www.w3.org/TR/trace-context/#parent-id)."
     },
     "span_kind": {
@@ -45,7 +45,7 @@
     },
     "parent_span_id": {
       "type": ["string", "null"],
-      "pattern": "^[0-9a-fA-F]{16}$",
+      "pattern": "^[0-9a-f]{16}$",
       "description": "Optional parent span ID for nested operations. Same format as span_id."
     },
     "semconv_version": {

--- a/contracts/json/extended/otel_trace_mapping.schema.json
+++ b/contracts/json/extended/otel_trace_mapping.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/otel_trace_mapping.schema.json",
+  "title": "OtelTraceMapping",
+  "description": "Extended. Mapping of a Weaver TraceEvent onto an OpenTelemetry span — carries the OTel trace/span identifiers and the GenAI semantic-convention attributes that downstream observability tools consume. The full field-by-field mapping is documented in docs/OTEL_MAPPING.md, pinned to the OTel semconv snapshot referenced there.",
+  "type": "object",
+  "required": ["trace_id", "span_id", "span_kind"],
+  "properties": {
+    "trace_id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[0-9a-fA-F]{32}$",
+      "description": "OTel trace identifier. 32 lowercase hex characters per the W3C Trace Context (https://www.w3.org/TR/trace-context/#trace-id)."
+    },
+    "span_id": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[0-9a-fA-F]{16}$",
+      "description": "OTel span identifier. 16 lowercase hex characters per the W3C Trace Context (https://www.w3.org/TR/trace-context/#parent-id)."
+    },
+    "span_kind": {
+      "type": "string",
+      "enum": ["INTERNAL", "CLIENT", "SERVER", "PRODUCER", "CONSUMER"],
+      "description": "OTel SpanKind. See https://opentelemetry.io/docs/specs/otel/trace/api/#spankind."
+    },
+    "gen_ai_operation_name": {
+      "type": ["string", "null"],
+      "description": "Value for the OTel attribute `gen_ai.operation.name` (e.g. `chat`, `text_completion`, `embeddings`, `agent.invoke_agent`, `execute_tool`). See https://opentelemetry.io/docs/specs/semconv/gen-ai/."
+    },
+    "gen_ai_agent_id": {
+      "type": ["string", "null"],
+      "description": "Value for the OTel attribute `gen_ai.agent.id`. Stable identifier of the agent or capability owner."
+    },
+    "gen_ai_agent_name": {
+      "type": ["string", "null"],
+      "description": "Value for the OTel attribute `gen_ai.agent.name`. Human-readable name of the agent."
+    },
+    "gen_ai_tool_name": {
+      "type": ["string", "null"],
+      "description": "Value for the OTel attribute `gen_ai.tool.name`. Derived from TraceEvent.capability_id by the mapping in docs/OTEL_MAPPING.md."
+    },
+    "gen_ai_system": {
+      "type": ["string", "null"],
+      "description": "Value for the OTel attribute `gen_ai.system`. Identifies the AI system that produced the event (e.g. `anthropic`, `openai`, `weaver`)."
+    },
+    "parent_span_id": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-fA-F]{16}$",
+      "description": "Optional parent span ID for nested operations. Same format as span_id."
+    },
+    "semconv_version": {
+      "type": ["string", "null"],
+      "description": "OTel semantic-conventions snapshot the producer mapped against. Mirrors the `semconv_version` value pinned at the top of docs/OTEL_MAPPING.md."
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/redaction_policy.schema.json
+++ b/contracts/json/extended/redaction_policy.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/redaction_policy.schema.json",
+  "title": "RedactionPolicy",
+  "description": "Extended. Describes the redaction rules applied by the firewall when producing a Frame. Identifies which fields were redacted or truncated and whether PII was detected.",
+  "type": "object",
+  "required": ["policy_id"],
+  "properties": {
+    "policy_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable identifier of the redaction policy that produced this record."
+    },
+    "redacted_fields": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Field paths whose values were redacted (removed or masked)."
+    },
+    "truncated_fields": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Field paths whose values were truncated to a length bound."
+    },
+    "redaction_reason": {
+      "type": ["string", "null"],
+      "description": "Short human-readable reason the policy was applied."
+    },
+    "pii_detected": {
+      "type": "boolean",
+      "description": "True if any PII-class data was detected in the payload.",
+      "default": false
+    },
+    "pii_types": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Categories of PII that were detected (e.g., person_name, credential)."
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/risk_assessment.schema.json
+++ b/contracts/json/extended/risk_assessment.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/risk_assessment.schema.json",
+  "title": "RiskAssessment",
+  "description": "Extended. Optional risk metadata for a capability invocation. Encodes the assessed risk level, reasons, whether human approval is required, and any mitigations in place.",
+  "type": "object",
+  "required": [],
+  "properties": {
+    "risk_level": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"],
+      "description": "Assessed risk class. Mirrors RiskAssessment._VALID_LEVELS in extended.py.",
+      "default": "low"
+    },
+    "risk_reasons": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Short human-readable reasons that produced this risk level."
+    },
+    "requires_human_approval": {
+      "type": "boolean",
+      "description": "If true, execution should not proceed without approval by the principal named in approval_principal.",
+      "default": false
+    },
+    "approval_principal": {
+      "type": ["string", "null"],
+      "description": "Optional identifier of the principal expected to approve."
+    },
+    "mitigations": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Mitigations in place that reduce the risk (e.g., sandboxed execution, dry-run available)."
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/schema_fingerprint.schema.json
+++ b/contracts/json/extended/schema_fingerprint.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/schema_fingerprint.schema.json",
+  "title": "SchemaFingerprint",
+  "description": "Extended. Records the schema version and content hash for a contract payload, enabling schema-evolution and compatibility checking across producers and consumers.",
+  "type": "object",
+  "required": ["schema_id", "schema_version"],
+  "properties": {
+    "schema_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The $id URI of the schema this fingerprint refers to."
+    },
+    "schema_version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Semver version of the schema, matching CONTRACT_VERSION at the time of emission."
+    },
+    "content_hash": {
+      "type": ["string", "null"],
+      "description": "Optional content hash of the payload (e.g., SHA-256 hex of canonical JSON)."
+    },
+    "hash_algorithm": {
+      "type": "string",
+      "description": "Hash algorithm used to compute content_hash. Defaults to sha256.",
+      "default": "sha256"
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/telemetry_hint.schema.json
+++ b/contracts/json/extended/telemetry_hint.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/telemetry_hint.schema.json",
+  "title": "TelemetryHint",
+  "description": "Extended. Optional telemetry metadata that can be attached to any event or contract for observability enrichment. All fields are optional; an empty object is valid.",
+  "type": "object",
+  "required": [],
+  "properties": {
+    "trace_id": {
+      "type": ["string", "null"],
+      "description": "Optional distributed-trace identifier. Free-form; commonly a W3C traceparent trace-id or vendor-specific string."
+    },
+    "span_id": {
+      "type": ["string", "null"],
+      "description": "Optional span identifier within the trace."
+    },
+    "baggage": {
+      "type": "object",
+      "description": "Optional key/value baggage propagated alongside the trace. Values must be strings.",
+      "additionalProperties": { "type": "string" }
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/ui_hint.schema.json
+++ b/contracts/json/extended/ui_hint.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/ui_hint.schema.json",
+  "title": "UIHint",
+  "description": "Extended. Optional rendering hints for UI layers that display ChoiceCards or SelectableItems. All fields are optional; an empty object is valid.",
+  "type": "object",
+  "required": [],
+  "properties": {
+    "icon": {
+      "type": ["string", "null"],
+      "description": "Optional icon identifier (vocabulary is implementation-defined)."
+    },
+    "color": {
+      "type": ["string", "null"],
+      "description": "Optional color identifier or token."
+    },
+    "priority": {
+      "type": ["integer", "null"],
+      "description": "Optional sort/priority order for rendering. Higher means more prominent."
+    },
+    "group": {
+      "type": ["string", "null"],
+      "description": "Optional group identifier for clustering related items in the UI."
+    },
+    "disabled": {
+      "type": "boolean",
+      "description": "If true, the UI should render the item as disabled.",
+      "default": false
+    },
+    "tooltip": {
+      "type": ["string", "null"],
+      "description": "Optional tooltip / hover text."
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/python/pyproject.toml
+++ b/contracts/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "weaver_contracts"
-version = "0.5.0"
+version = "0.6.0"
 description = "Minimal Python contracts for the Weaver Stack (contextweaver, agent-kernel, ChainWeaver)"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/contracts/python/src/weaver_contracts/extended.py
+++ b/contracts/python/src/weaver_contracts/extended.py
@@ -518,3 +518,120 @@ class ArtifactSafetyReport:
             raise ValueError(
                 f"ArtifactSafetyReport.mode must be one of {self._MODES}"
             )
+
+
+# ===========================================================================
+# Cryptographic and observability bindings
+#
+# CapabilityTokenSignature (#44) defines a detached signature over a
+# JCS-canonicalized CapabilityToken payload; the signature attaches to the
+# Core token under the namespaced extension key `x_weaver_signature` so Core
+# stays unchanged. OtelTraceMapping (#47) carries the OTel identifiers and
+# GenAI semantic-convention attributes that a Weaver TraceEvent maps to.
+# Field-by-field documentation:
+#   - docs/SIGNING.md and docs/adr/001-capability-token-signing.md
+#   - docs/OTEL_MAPPING.md
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# CapabilityTokenSignature — RFC 8785 JCS detached signature for tokens
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CapabilityTokenSignature:
+    """Detached signature over a JCS-canonicalized CapabilityToken payload.
+
+    Attached to a CapabilityToken under the namespaced extension key
+    ``x_weaver_signature``. Verifiers MUST reject signatures whose ``alg`` or
+    ``canonicalization`` is not in the published registry. See
+    ``docs/SIGNING.md`` for verification pseudocode and ``docs/adr/001-capability-token-signing.md``
+    for the design decision.
+    """
+
+    alg: str
+    kid: str
+    sig: str
+    canonicalization: str = "JCS"
+    signed_at: Optional[str] = None
+
+    _VALID_ALGS = frozenset({"ed25519", "es256"})
+    _VALID_CANONICALIZATIONS = frozenset({"JCS"})
+
+    def __post_init__(self) -> None:
+        if self.alg not in self._VALID_ALGS:
+            raise ValueError(
+                f"CapabilityTokenSignature.alg must be one of {self._VALID_ALGS}"
+            )
+        if not self.kid:
+            raise ValueError("CapabilityTokenSignature.kid must be non-empty")
+        if not self.sig:
+            raise ValueError("CapabilityTokenSignature.sig must be non-empty")
+        if self.canonicalization not in self._VALID_CANONICALIZATIONS:
+            raise ValueError(
+                "CapabilityTokenSignature.canonicalization must be one of "
+                f"{self._VALID_CANONICALIZATIONS}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# OtelTraceMapping — TraceEvent → OpenTelemetry GenAI span attributes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class OtelTraceMapping:
+    """Mapping of a Weaver TraceEvent onto an OpenTelemetry span.
+
+    Carries the OTel trace/span identifiers and the GenAI semantic-convention
+    attributes downstream observability tools consume (e.g. Datadog,
+    Honeycomb, New Relic). The full field-by-field mapping lives in
+    ``docs/OTEL_MAPPING.md``, pinned to a specific OTel semconv snapshot.
+    """
+
+    trace_id: str
+    span_id: str
+    span_kind: str
+    gen_ai_operation_name: Optional[str] = None
+    gen_ai_agent_id: Optional[str] = None
+    gen_ai_agent_name: Optional[str] = None
+    gen_ai_tool_name: Optional[str] = None
+    gen_ai_system: Optional[str] = None
+    parent_span_id: Optional[str] = None
+    semconv_version: Optional[str] = None
+
+    _VALID_SPAN_KINDS = frozenset(
+        {"INTERNAL", "CLIENT", "SERVER", "PRODUCER", "CONSUMER"}
+    )
+    _TRACE_ID_LEN = 32  # 16 bytes hex per W3C Trace Context
+    _SPAN_ID_LEN = 16  # 8 bytes hex per W3C Trace Context
+
+    def __post_init__(self) -> None:
+        if not self.trace_id:
+            raise ValueError("OtelTraceMapping.trace_id must be non-empty")
+        if len(self.trace_id) != self._TRACE_ID_LEN or not all(
+            c in "0123456789abcdefABCDEF" for c in self.trace_id
+        ):
+            raise ValueError(
+                "OtelTraceMapping.trace_id must be 32 hex characters "
+                "(W3C Trace Context)"
+            )
+        if not self.span_id:
+            raise ValueError("OtelTraceMapping.span_id must be non-empty")
+        if len(self.span_id) != self._SPAN_ID_LEN or not all(
+            c in "0123456789abcdefABCDEF" for c in self.span_id
+        ):
+            raise ValueError(
+                "OtelTraceMapping.span_id must be 16 hex characters "
+                "(W3C Trace Context)"
+            )
+        if self.span_kind not in self._VALID_SPAN_KINDS:
+            raise ValueError(
+                f"OtelTraceMapping.span_kind must be one of {self._VALID_SPAN_KINDS}"
+            )
+        if self.parent_span_id is not None and (
+            len(self.parent_span_id) != self._SPAN_ID_LEN
+            or not all(c in "0123456789abcdefABCDEF" for c in self.parent_span_id)
+        ):
+            raise ValueError(
+                "OtelTraceMapping.parent_span_id must be 16 hex characters"
+            )

--- a/contracts/python/src/weaver_contracts/extended.py
+++ b/contracts/python/src/weaver_contracts/extended.py
@@ -557,6 +557,13 @@ class CapabilityTokenSignature:
 
     _VALID_ALGS = frozenset({"ed25519", "es256"})
     _VALID_CANONICALIZATIONS = frozenset({"JCS"})
+    # Both registered algorithms produce 64-byte raw signatures (ed25519 RFC 8032
+    # raw, or es256 IEEE P1363 r||s), which encode to exactly 86 base64url chars
+    # without padding. See docs/SIGNING.md for the algorithm registry.
+    _SIG_BASE64URL_LEN = 86
+    _SIG_BASE64URL_ALPHABET = frozenset(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    )
 
     def __post_init__(self) -> None:
         if self.alg not in self._VALID_ALGS:
@@ -567,6 +574,14 @@ class CapabilityTokenSignature:
             raise ValueError("CapabilityTokenSignature.kid must be non-empty")
         if not self.sig:
             raise ValueError("CapabilityTokenSignature.sig must be non-empty")
+        if (
+            len(self.sig) != self._SIG_BASE64URL_LEN
+            or not all(c in self._SIG_BASE64URL_ALPHABET for c in self.sig)
+        ):
+            raise ValueError(
+                "CapabilityTokenSignature.sig must be 86 base64url characters "
+                "(64 raw bytes, RFC 4648 §5 no padding); see docs/SIGNING.md"
+            )
         if self.canonicalization not in self._VALID_CANONICALIZATIONS:
             raise ValueError(
                 "CapabilityTokenSignature.canonicalization must be one of "
@@ -608,20 +623,22 @@ class OtelTraceMapping:
     def __post_init__(self) -> None:
         if not self.trace_id:
             raise ValueError("OtelTraceMapping.trace_id must be non-empty")
+        # W3C Trace Context requires lowercase hex; producers must normalize
+        # before constructing this object (https://www.w3.org/TR/trace-context/#trace-id).
         if len(self.trace_id) != self._TRACE_ID_LEN or not all(
-            c in "0123456789abcdefABCDEF" for c in self.trace_id
+            c in "0123456789abcdef" for c in self.trace_id
         ):
             raise ValueError(
-                "OtelTraceMapping.trace_id must be 32 hex characters "
+                "OtelTraceMapping.trace_id must be 32 lowercase hex characters "
                 "(W3C Trace Context)"
             )
         if not self.span_id:
             raise ValueError("OtelTraceMapping.span_id must be non-empty")
         if len(self.span_id) != self._SPAN_ID_LEN or not all(
-            c in "0123456789abcdefABCDEF" for c in self.span_id
+            c in "0123456789abcdef" for c in self.span_id
         ):
             raise ValueError(
-                "OtelTraceMapping.span_id must be 16 hex characters "
+                "OtelTraceMapping.span_id must be 16 lowercase hex characters "
                 "(W3C Trace Context)"
             )
         if self.span_kind not in self._VALID_SPAN_KINDS:
@@ -630,8 +647,8 @@ class OtelTraceMapping:
             )
         if self.parent_span_id is not None and (
             len(self.parent_span_id) != self._SPAN_ID_LEN
-            or not all(c in "0123456789abcdefABCDEF" for c in self.parent_span_id)
+            or not all(c in "0123456789abcdef" for c in self.parent_span_id)
         ):
             raise ValueError(
-                "OtelTraceMapping.parent_span_id must be 16 hex characters"
+                "OtelTraceMapping.parent_span_id must be 16 lowercase hex characters"
             )

--- a/contracts/python/src/weaver_contracts/extended.py
+++ b/contracts/python/src/weaver_contracts/extended.py
@@ -122,6 +122,12 @@ class ExtendedFrameMetadata:
     source_capability_version: Optional[str] = None
     extra: Dict[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        if self.confidence_score is not None and not 0.0 <= self.confidence_score <= 1.0:
+            raise ValueError(
+                "ExtendedFrameMetadata.confidence_score must be in [0.0, 1.0]"
+            )
+
 
 # ---------------------------------------------------------------------------
 # ExtendedSelectableItemMetadata — UI and risk hints for a SelectableItem
@@ -136,6 +142,12 @@ class ExtendedSelectableItemMetadata:
     estimated_duration_ms: Optional[int] = None
     requires_confirmation: bool = False
     extra: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.estimated_duration_ms is not None and self.estimated_duration_ms < 0:
+            raise ValueError(
+                "ExtendedSelectableItemMetadata.estimated_duration_ms must be >= 0"
+            )
 
 
 # ===========================================================================

--- a/contracts/python/src/weaver_contracts/version.py
+++ b/contracts/python/src/weaver_contracts/version.py
@@ -3,7 +3,7 @@ Contract version constants and compatibility helpers.
 """
 
 # The current contract version. Must match pyproject.toml [project] version.
-CONTRACT_VERSION = "0.5.0"
+CONTRACT_VERSION = "0.6.0"
 
 # The JSON Schema $id version prefix (corresponds to MAJOR version).
 SCHEMA_VERSION_PREFIX = "v0"

--- a/contracts/python/tests/test_extended.py
+++ b/contracts/python/tests/test_extended.py
@@ -757,11 +757,17 @@ class TestArtifactSafetyReport:
 
 
 class TestCapabilityTokenSignature:
+    # 86-char base64url placeholder (64 raw bytes encoded RFC 4648 §5 no padding).
+    # Illustrative only — never produced by a real keyring.
+    _ILLUSTRATIVE_SIG = (
+        "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-Pw"
+    )
+
     def _kwargs(self, **overrides):
         base = dict(
             alg="ed25519",
             kid="agent-kernel-2026-05-key-01",
-            sig="MEUCIQDxQ7w4_4Tq3rH9aJZQz9wHvN9p2lYkM7Z5oXrLg8b7nQ",
+            sig=self._ILLUSTRATIVE_SIG,
         )
         base.update(overrides)
         return base
@@ -789,6 +795,20 @@ class TestCapabilityTokenSignature:
     def test_empty_sig_raises(self):
         with pytest.raises(ValueError, match="sig must be non-empty"):
             CapabilityTokenSignature(**self._kwargs(sig=""))
+
+    def test_short_sig_raises(self):
+        with pytest.raises(ValueError, match="sig must be 86 base64url"):
+            CapabilityTokenSignature(**self._kwargs(sig="A" * 85))
+
+    def test_long_sig_raises(self):
+        with pytest.raises(ValueError, match="sig must be 86 base64url"):
+            CapabilityTokenSignature(**self._kwargs(sig="A" * 87))
+
+    def test_non_base64url_sig_raises(self):
+        # '+' and '/' belong to standard base64 — base64url forbids them.
+        bad = "A" * 84 + "+/"
+        with pytest.raises(ValueError, match="sig must be 86 base64url"):
+            CapabilityTokenSignature(**self._kwargs(sig=bad))
 
     def test_unknown_canonicalization_raises(self):
         with pytest.raises(ValueError, match="canonicalization must be one of"):
@@ -843,17 +863,35 @@ class TestOtelTraceMapping:
         assert m.gen_ai_tool_name == "org.myapp.search_docs"
 
     def test_short_trace_id_raises(self):
-        with pytest.raises(ValueError, match="trace_id must be 32 hex"):
+        with pytest.raises(ValueError, match="trace_id must be 32 lowercase hex"):
             OtelTraceMapping(**self._kwargs(trace_id="deadbeef"))
 
     def test_short_span_id_raises(self):
-        with pytest.raises(ValueError, match="span_id must be 16 hex"):
+        with pytest.raises(ValueError, match="span_id must be 16 lowercase hex"):
             OtelTraceMapping(**self._kwargs(span_id="dead"))
 
     def test_non_hex_trace_id_raises(self):
-        with pytest.raises(ValueError, match="trace_id must be 32 hex"):
+        with pytest.raises(ValueError, match="trace_id must be 32 lowercase hex"):
             OtelTraceMapping(
                 **self._kwargs(trace_id="z" * 32)  # 32 chars, not hex
+            )
+
+    def test_uppercase_trace_id_raises(self):
+        # W3C Trace Context requires lowercase hex; uppercase is non-conformant
+        # even though the chars are hex-valid.
+        with pytest.raises(ValueError, match="trace_id must be 32 lowercase hex"):
+            OtelTraceMapping(
+                **self._kwargs(trace_id="4BF92F3577B34DA6A3CE929D0E0E4736")
+            )
+
+    def test_uppercase_span_id_raises(self):
+        with pytest.raises(ValueError, match="span_id must be 16 lowercase hex"):
+            OtelTraceMapping(**self._kwargs(span_id="00F067AA0BA902B7"))
+
+    def test_uppercase_parent_span_id_raises(self):
+        with pytest.raises(ValueError, match="parent_span_id must be 16 lowercase hex"):
+            OtelTraceMapping(
+                **self._kwargs(parent_span_id="B9C7C989F97918E1")
             )
 
     def test_invalid_span_kind_raises(self):
@@ -861,7 +899,7 @@ class TestOtelTraceMapping:
             OtelTraceMapping(**self._kwargs(span_kind="DOWNSTREAM"))
 
     def test_invalid_parent_span_id_raises(self):
-        with pytest.raises(ValueError, match="parent_span_id must be 16 hex"):
+        with pytest.raises(ValueError, match="parent_span_id must be 16 lowercase hex"):
             OtelTraceMapping(**self._kwargs(parent_span_id="z" * 16))
 
     def test_defaults_omit_optional(self):

--- a/contracts/python/tests/test_extended.py
+++ b/contracts/python/tests/test_extended.py
@@ -10,11 +10,13 @@ import pytest
 from weaver_contracts.extended import (
     ArtifactSafetyGateRequest,
     ArtifactSafetyReport,
+    CapabilityTokenSignature,
     EvaluationArtifact,
     ExtendedFrameMetadata,
     ExtendedSelectableItemMetadata,
     LessonCard,
     MemoryArtifact,
+    OtelTraceMapping,
     RedactionPolicy,
     ReviewArtifact,
     RiskAssessment,
@@ -752,3 +754,129 @@ class TestArtifactSafetyReport:
         data = asdict(rep)
         json.dumps(data)
         assert data["findings"][0]["finding_id"] == "f1"
+
+
+class TestCapabilityTokenSignature:
+    def _kwargs(self, **overrides):
+        base = dict(
+            alg="ed25519",
+            kid="agent-kernel-2026-05-key-01",
+            sig="MEUCIQDxQ7w4_4Tq3rH9aJZQz9wHvN9p2lYkM7Z5oXrLg8b7nQ",
+        )
+        base.update(overrides)
+        return base
+
+    def test_valid_from_payload(self):
+        p = load_payload("capability_token_signature")
+        sig = CapabilityTokenSignature(
+            alg=p["alg"],
+            kid=p["kid"],
+            sig=p["sig"],
+            canonicalization=p.get("canonicalization", "JCS"),
+            signed_at=p.get("signed_at"),
+        )
+        assert sig.alg == "ed25519"
+        assert sig.canonicalization == "JCS"
+
+    def test_unknown_alg_raises(self):
+        with pytest.raises(ValueError, match="alg must be one of"):
+            CapabilityTokenSignature(**self._kwargs(alg="rsa-pkcs1"))
+
+    def test_empty_kid_raises(self):
+        with pytest.raises(ValueError, match="kid must be non-empty"):
+            CapabilityTokenSignature(**self._kwargs(kid=""))
+
+    def test_empty_sig_raises(self):
+        with pytest.raises(ValueError, match="sig must be non-empty"):
+            CapabilityTokenSignature(**self._kwargs(sig=""))
+
+    def test_unknown_canonicalization_raises(self):
+        with pytest.raises(ValueError, match="canonicalization must be one of"):
+            CapabilityTokenSignature(
+                **self._kwargs(canonicalization="sorted-keys")
+            )
+
+    def test_defaults(self):
+        sig = CapabilityTokenSignature(**self._kwargs())
+        assert sig.canonicalization == "JCS"
+        assert sig.signed_at is None
+
+    def test_es256_accepted(self):
+        sig = CapabilityTokenSignature(**self._kwargs(alg="es256"))
+        assert sig.alg == "es256"
+
+    def test_serialization(self):
+        sig = CapabilityTokenSignature(
+            **self._kwargs(signed_at="2026-05-28T08:00:00Z")
+        )
+        data = asdict(sig)
+        json.dumps(data)
+        assert data["signed_at"] == "2026-05-28T08:00:00Z"
+
+
+class TestOtelTraceMapping:
+    def _kwargs(self, **overrides):
+        base = dict(
+            trace_id="4bf92f3577b34da6a3ce929d0e0e4736",
+            span_id="00f067aa0ba902b7",
+            span_kind="INTERNAL",
+        )
+        base.update(overrides)
+        return base
+
+    def test_valid_from_payload(self):
+        p = load_payload("otel_trace_mapping")
+        m = OtelTraceMapping(
+            trace_id=p["trace_id"],
+            span_id=p["span_id"],
+            span_kind=p["span_kind"],
+            gen_ai_operation_name=p.get("gen_ai_operation_name"),
+            gen_ai_agent_id=p.get("gen_ai_agent_id"),
+            gen_ai_agent_name=p.get("gen_ai_agent_name"),
+            gen_ai_tool_name=p.get("gen_ai_tool_name"),
+            gen_ai_system=p.get("gen_ai_system"),
+            parent_span_id=p.get("parent_span_id"),
+            semconv_version=p.get("semconv_version"),
+        )
+        assert m.span_kind == "INTERNAL"
+        assert m.gen_ai_operation_name == "execute_tool"
+        assert m.gen_ai_tool_name == "org.myapp.search_docs"
+
+    def test_short_trace_id_raises(self):
+        with pytest.raises(ValueError, match="trace_id must be 32 hex"):
+            OtelTraceMapping(**self._kwargs(trace_id="deadbeef"))
+
+    def test_short_span_id_raises(self):
+        with pytest.raises(ValueError, match="span_id must be 16 hex"):
+            OtelTraceMapping(**self._kwargs(span_id="dead"))
+
+    def test_non_hex_trace_id_raises(self):
+        with pytest.raises(ValueError, match="trace_id must be 32 hex"):
+            OtelTraceMapping(
+                **self._kwargs(trace_id="z" * 32)  # 32 chars, not hex
+            )
+
+    def test_invalid_span_kind_raises(self):
+        with pytest.raises(ValueError, match="span_kind must be one of"):
+            OtelTraceMapping(**self._kwargs(span_kind="DOWNSTREAM"))
+
+    def test_invalid_parent_span_id_raises(self):
+        with pytest.raises(ValueError, match="parent_span_id must be 16 hex"):
+            OtelTraceMapping(**self._kwargs(parent_span_id="z" * 16))
+
+    def test_defaults_omit_optional(self):
+        m = OtelTraceMapping(**self._kwargs())
+        assert m.gen_ai_operation_name is None
+        assert m.parent_span_id is None
+        assert m.semconv_version is None
+
+    def test_all_span_kinds_accepted(self):
+        for kind in ("INTERNAL", "CLIENT", "SERVER", "PRODUCER", "CONSUMER"):
+            m = OtelTraceMapping(**self._kwargs(span_kind=kind))
+            assert m.span_kind == kind
+
+    def test_serialization(self):
+        m = OtelTraceMapping(**self._kwargs(gen_ai_system="weaver"))
+        data = asdict(m)
+        json.dumps(data)
+        assert data["gen_ai_system"] == "weaver"

--- a/contracts/python/tests/test_extended.py
+++ b/contracts/python/tests/test_extended.py
@@ -240,6 +240,19 @@ class TestExtendedFrameMetadata:
         json.dumps(data)
         assert data["telemetry"]["trace_id"] == "trace-3"
 
+    def test_confidence_score_boundaries_accepted(self):
+        # Inclusive boundaries — 0.0 and 1.0 are valid.
+        ExtendedFrameMetadata(confidence_score=0.0)
+        ExtendedFrameMetadata(confidence_score=1.0)
+
+    def test_confidence_score_below_range_raises(self):
+        with pytest.raises(ValueError, match=r"confidence_score must be in \[0\.0, 1\.0\]"):
+            ExtendedFrameMetadata(confidence_score=-0.01)
+
+    def test_confidence_score_above_range_raises(self):
+        with pytest.raises(ValueError, match=r"confidence_score must be in \[0\.0, 1\.0\]"):
+            ExtendedFrameMetadata(confidence_score=1.01)
+
 
 class TestExtendedSelectableItemMetadata:
     def test_valid_from_payload(self):
@@ -272,6 +285,17 @@ class TestExtendedSelectableItemMetadata:
         data = asdict(metadata)
         json.dumps(data)
         assert data["estimated_duration_ms"] == 500
+
+    def test_estimated_duration_ms_zero_accepted(self):
+        # Boundary — zero is valid (instant operation).
+        ExtendedSelectableItemMetadata(estimated_duration_ms=0)
+
+    def test_negative_estimated_duration_ms_raises(self):
+        with pytest.raises(
+            ValueError,
+            match="estimated_duration_ms must be >= 0",
+        ):
+            ExtendedSelectableItemMetadata(estimated_duration_ms=-1)
 
 
 class TestReviewArtifact:

--- a/contracts/python/tests/test_extended_schema_alignment.py
+++ b/contracts/python/tests/test_extended_schema_alignment.py
@@ -244,6 +244,23 @@ class TestExtendedNegativeCases:
         with pytest.raises(AssertionError, match="Schema validation failed"):
             validate(bad, schema)
 
+    def test_extended_frame_metadata_confidence_score_above_range_fails(self):
+        # Description claims [0.0, 1.0]; schema must enforce both bounds.
+        schema = load_extended_schema("extended_frame_metadata")
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate({"confidence_score": 1.5}, schema)
+
+    def test_extended_frame_metadata_confidence_score_below_range_fails(self):
+        schema = load_extended_schema("extended_frame_metadata")
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate({"confidence_score": -0.1}, schema)
+
+    def test_extended_selectable_item_negative_duration_fails(self):
+        # Schema declares `minimum: 0` on estimated_duration_ms.
+        schema = load_extended_schema("extended_selectable_item_metadata")
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate({"estimated_duration_ms": -1}, schema)
+
     def test_capability_token_signature_wrong_length_sig_fails(self):
         # docs/SIGNING.md fixes both registered algorithms at 64 raw bytes,
         # which is 86 base64url chars without padding. Anything else (DER-

--- a/contracts/python/tests/test_extended_schema_alignment.py
+++ b/contracts/python/tests/test_extended_schema_alignment.py
@@ -22,9 +22,19 @@ PAYLOADS_DIR = REPO_ROOT / "examples" / "sample_payloads"
 
 # (dataclass name, snake_case schema/payload stem). The dataclass names appear
 # here as whole tokens so the coverage generator marks the schema test present:
+# TelemetryHint, SchemaFingerprint, RedactionPolicy, UIHint, RiskAssessment,
+# ExtendedFrameMetadata, ExtendedSelectableItemMetadata,
 # ReviewArtifact, MemoryArtifact, SessionHandoff, LessonCard, SkillCard,
-# EvaluationArtifact, ArtifactSafetyGateRequest, ArtifactSafetyReport.
+# EvaluationArtifact, ArtifactSafetyGateRequest, ArtifactSafetyReport,
+# CapabilityTokenSignature, OtelTraceMapping.
 EXTENDED_TYPES = [
+    ("TelemetryHint", "telemetry_hint"),
+    ("SchemaFingerprint", "schema_fingerprint"),
+    ("RedactionPolicy", "redaction_policy"),
+    ("UIHint", "ui_hint"),
+    ("RiskAssessment", "risk_assessment"),
+    ("ExtendedFrameMetadata", "extended_frame_metadata"),
+    ("ExtendedSelectableItemMetadata", "extended_selectable_item_metadata"),
     ("ReviewArtifact", "review_artifact"),
     ("MemoryArtifact", "memory_artifact"),
     ("SessionHandoff", "session_handoff"),
@@ -33,6 +43,8 @@ EXTENDED_TYPES = [
     ("EvaluationArtifact", "evaluation_artifact"),
     ("ArtifactSafetyGateRequest", "artifact_safety_gate_request"),
     ("ArtifactSafetyReport", "artifact_safety_report"),
+    ("CapabilityTokenSignature", "capability_token_signature"),
+    ("OtelTraceMapping", "otel_trace_mapping"),
 ]
 
 
@@ -148,6 +160,74 @@ class TestExtendedNegativeCases:
             "gate_id": "g1",
             "decision": "maybe",
             "created_at": "2026-05-27T10:30:00Z",
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_risk_assessment_invalid_level_fails(self):
+        schema = load_extended_schema("risk_assessment")
+        bad = {"risk_level": "extreme"}
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_schema_fingerprint_missing_required_fails(self):
+        schema = load_extended_schema("schema_fingerprint")
+        bad = {"schema_version": "0.6.0"}  # missing schema_id
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_capability_token_signature_unknown_alg_fails(self):
+        # #44: verifiers MUST reject signatures whose alg is not in the
+        # registry. The schema enforces this with an enum constraint.
+        schema = load_extended_schema("capability_token_signature")
+        bad = {"alg": "rsa-pkcs1", "kid": "k1", "sig": "abc"}
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_capability_token_signature_unknown_canonicalization_fails(self):
+        # #44: canonicalization must be JCS (RFC 8785); other forms are not
+        # in the registry and must be rejected.
+        schema = load_extended_schema("capability_token_signature")
+        bad = {
+            "alg": "ed25519",
+            "kid": "k1",
+            "sig": "abc",
+            "canonicalization": "sorted-keys",
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_capability_token_signed_payload_validates(self):
+        # The signed CapabilityToken sample carries `x_weaver_signature` as
+        # a namespaced extension; the Core schema accepts extra properties
+        # so a signed token must remain valid against capability_token.
+        with open(CORE_SCHEMA_DIR / "capability_token.schema.json") as f:
+            schema = json.load(f)
+        payload = load_payload("capability_token_signed")
+        validate(payload, schema)
+
+        # The embedded signature itself must validate against the Extended
+        # signature schema.
+        sig_schema = load_extended_schema("capability_token_signature")
+        validate(payload["x_weaver_signature"], sig_schema)
+
+    def test_otel_trace_mapping_bad_span_kind_fails(self):
+        schema = load_extended_schema("otel_trace_mapping")
+        bad = {
+            "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+            "span_id": "00f067aa0ba902b7",
+            "span_kind": "DOWNSTREAM",  # not a SpanKind
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_otel_trace_mapping_bad_trace_id_length_fails(self):
+        # W3C Trace Context: trace_id is exactly 32 hex chars.
+        schema = load_extended_schema("otel_trace_mapping")
+        bad = {
+            "trace_id": "deadbeef",  # too short
+            "span_id": "00f067aa0ba902b7",
+            "span_kind": "INTERNAL",
         }
         with pytest.raises(AssertionError, match="Schema validation failed"):
             validate(bad, schema)

--- a/contracts/python/tests/test_extended_schema_alignment.py
+++ b/contracts/python/tests/test_extended_schema_alignment.py
@@ -231,3 +231,29 @@ class TestExtendedNegativeCases:
         }
         with pytest.raises(AssertionError, match="Schema validation failed"):
             validate(bad, schema)
+
+    def test_otel_trace_mapping_uppercase_trace_id_fails(self):
+        # W3C Trace Context requires lowercase hex; the schema pattern must
+        # reject uppercase even though chars are hex-valid.
+        schema = load_extended_schema("otel_trace_mapping")
+        bad = {
+            "trace_id": "4BF92F3577B34DA6A3CE929D0E0E4736",
+            "span_id": "00f067aa0ba902b7",
+            "span_kind": "INTERNAL",
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_capability_token_signature_wrong_length_sig_fails(self):
+        # docs/SIGNING.md fixes both registered algorithms at 64 raw bytes,
+        # which is 86 base64url chars without padding. Anything else (DER-
+        # encoded ECDSA, RSA, truncated, etc.) is structurally invalid and
+        # the schema pattern must reject it before crypto verification runs.
+        schema = load_extended_schema("capability_token_signature")
+        bad = {
+            "alg": "ed25519",
+            "kid": "k1",
+            "sig": "A" * 50,  # base64url alphabet, wrong length
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)

--- a/docs/OTEL_MAPPING.md
+++ b/docs/OTEL_MAPPING.md
@@ -1,0 +1,128 @@
+# TraceEvent → OpenTelemetry GenAI semantic conventions mapping
+
+> [!IMPORTANT]
+> This document is the normative mapping from Weaver `TraceEvent` fields onto
+> [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/).
+> Sibling repos that emit OTel spans MUST follow this mapping so telemetry
+> remains interoperable across vendors (Datadog, Honeycomb, New Relic, and
+> any other backend that consumes OTel GenAI semconv). Tracked in issue #47.
+
+The Extended contract `OtelTraceMapping`
+(`contracts/json/extended/otel_trace_mapping.schema.json`,
+`weaver_contracts.extended.OtelTraceMapping`) carries the OTel identifiers
+and GenAI attributes for a single TraceEvent. Producers attach an
+`OtelTraceMapping` to each `TraceEvent` they emit (under their own metadata
+extension key, since `TraceEvent.metadata` is `additionalProperties: true`).
+
+---
+
+## Pinned semconv snapshot
+
+| Field | Value |
+| ----- | ----- |
+| `semconv_version` | `1.30.0` |
+| Snapshot URL | <https://opentelemetry.io/docs/specs/semconv/gen-ai/> |
+| Anchor pages | [GenAI spans](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/), [Agent spans](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/) |
+
+Producers SHOULD set `OtelTraceMapping.semconv_version` to the snapshot they
+mapped against; verifiers can use the value to detect drift.
+
+---
+
+## Field-by-field mapping
+
+The table below lists every `TraceEvent` field and the OTel attribute or span
+shape it maps onto. "No mapping" means the Weaver-only field carries
+information OTel GenAI semconv does not currently define an attribute for —
+attach it under `gen_ai.weaver.*` or leave it out.
+
+| TraceEvent field | OTel attribute / span shape | Notes |
+| ---------------- | --------------------------- | ----- |
+| `event_id` | `gen_ai.weaver.event_id` (custom) | OTel has no first-class event identifier separate from span ID; expose for cross-linking back to Weaver traces. |
+| `event_type` | `gen_ai.operation.name` (mapped via §"Event type → operation name") | See translation table below. |
+| `timestamp` | Span `start_time` (and `end_time` for completion events) | RFC 3339 / ISO 8601 input, OTel uses Unix nanos internally. |
+| `capability_id` | `gen_ai.tool.name` | Direct mapping; Weaver `capability_id` *is* the tool name. |
+| `principal` | `gen_ai.agent.id` | Weaver principal identifies the agent or service invoking the capability. |
+| `decision_id` | `gen_ai.weaver.policy_decision_id` (custom) | No OTel semconv attribute for policy/authz decisions yet. |
+| `frame_id` | `gen_ai.weaver.frame_id` (custom) | Frame is a Weaver concept. |
+| `handle_id` | `gen_ai.weaver.handle_id` (custom) | Handle is a Weaver concept. |
+| `outcome` | `error.type` (when `failure`) + span `status_code` (`OK` / `ERROR`) | OTel span status replaces an explicit success/failure attribute. |
+| `error_message` | `exception.message` (when present) | Recorded as a span event per [OTel exceptions semconv](https://opentelemetry.io/docs/specs/semconv/exceptions/). |
+| `metadata` | passthrough | Implementation-specific. Namespace any custom keys under `gen_ai.weaver.*` or your own producer namespace. |
+
+---
+
+## Event type → `gen_ai.operation.name`
+
+| Weaver `event_type` | `gen_ai.operation.name` | OTel `span_kind` |
+| ------------------- | ----------------------- | ---------------- |
+| `capability_authorized` | `agent.invoke_agent` | `INTERNAL` |
+| `capability_denied` | `agent.invoke_agent` | `INTERNAL` (span status = `ERROR`, `error.type = "policy_denied"`) |
+| `capability_executed` | `execute_tool` | `INTERNAL` (or `CLIENT` if the capability calls out of process) |
+| `firewall_applied` | `agent.invoke_agent` | `INTERNAL` |
+| `handle_created` | `agent.invoke_agent` | `INTERNAL` |
+| `handle_resolved` | `agent.invoke_agent` | `INTERNAL` |
+| `token_issued` | `agent.invoke_agent` | `INTERNAL` |
+| `token_invalidated` | `agent.invoke_agent` | `INTERNAL` |
+| `flow_started` | `agent.invoke_agent` | `INTERNAL` |
+| `flow_step_started` | `execute_tool` | `INTERNAL` |
+| `flow_step_completed` | `execute_tool` | `INTERNAL` |
+| `flow_completed` | `agent.invoke_agent` | `INTERNAL` |
+| `flow_failed` | `agent.invoke_agent` | `INTERNAL` (span status = `ERROR`) |
+
+OTel GenAI semconv reserves `agent.invoke_agent` for agent-control events and
+`execute_tool` for the actual tool invocation; the table above keeps that
+separation.
+
+---
+
+## OtelTraceMapping field reference
+
+| Field | Source / formula | Example |
+| ----- | ---------------- | ------- |
+| `trace_id` | W3C Trace Context `trace-id` (32 hex chars). Producers SHOULD propagate from the inbound `traceparent` header. | `4bf92f3577b34da6a3ce929d0e0e4736` |
+| `span_id` | W3C Trace Context `span-id` (16 hex chars), unique per span. | `00f067aa0ba902b7` |
+| `span_kind` | Per the table above. | `INTERNAL` |
+| `gen_ai_operation_name` | Per the event-type table above. | `execute_tool` |
+| `gen_ai_agent_id` | `TraceEvent.principal` | `agent-kernel-prod-1` |
+| `gen_ai_agent_name` | Stable display name of the agent. | `agent-kernel` |
+| `gen_ai_tool_name` | `TraceEvent.capability_id` | `org.myapp.search_docs` |
+| `gen_ai_system` | Producer-defined; `weaver` for native Weaver events. | `weaver` |
+| `parent_span_id` | The OTel span ID of the parent operation, if any. | `b9c7c989f97918e1` |
+| `semconv_version` | Snapshot referenced above. | `1.30.0` |
+
+---
+
+## Inline example
+
+<!-- schema: otel_trace_mapping -->
+```json
+{
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "span_id": "00f067aa0ba902b7",
+  "span_kind": "INTERNAL",
+  "gen_ai_operation_name": "execute_tool",
+  "gen_ai_agent_id": "agent-kernel-prod-1",
+  "gen_ai_agent_name": "agent-kernel",
+  "gen_ai_tool_name": "org.myapp.search_docs",
+  "gen_ai_system": "weaver",
+  "parent_span_id": "b9c7c989f97918e1",
+  "semconv_version": "1.30.0"
+}
+```
+
+This example accompanies the
+`capability_executed` TraceEvent fired when the `org.myapp.search_docs`
+capability completes; the OTel collector receiving it would create one
+`INTERNAL` span named `execute_tool` with `gen_ai.tool.name = org.myapp.search_docs`.
+
+---
+
+## Related
+
+- Extended schema: `contracts/json/extended/otel_trace_mapping.schema.json`
+- Extended dataclass: `weaver_contracts.extended.OtelTraceMapping`
+- Sample payload: `examples/sample_payloads/otel_trace_mapping.json`
+- Issue #47 — original proposal.
+- OTel GenAI semconv index: <https://opentelemetry.io/docs/specs/semconv/gen-ai/>
+- OTel Agent spans: <https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/>

--- a/docs/OTEL_MAPPING.md
+++ b/docs/OTEL_MAPPING.md
@@ -80,15 +80,15 @@ separation.
 
 | Field | Source / formula | Example |
 | ----- | ---------------- | ------- |
-| `trace_id` | W3C Trace Context `trace-id` (32 hex chars). Producers SHOULD propagate from the inbound `traceparent` header. | `4bf92f3577b34da6a3ce929d0e0e4736` |
-| `span_id` | W3C Trace Context `span-id` (16 hex chars), unique per span. | `00f067aa0ba902b7` |
+| `trace_id` | W3C Trace Context `trace-id` (32 lowercase hex chars). Producers SHOULD propagate from the inbound `traceparent` header. | `4bf92f3577b34da6a3ce929d0e0e4736` |
+| `span_id` | W3C Trace Context `span-id` (16 lowercase hex chars), unique per span. | `00f067aa0ba902b7` |
 | `span_kind` | Per the table above. | `INTERNAL` |
 | `gen_ai_operation_name` | Per the event-type table above. | `execute_tool` |
 | `gen_ai_agent_id` | `TraceEvent.principal` | `agent-kernel-prod-1` |
 | `gen_ai_agent_name` | Stable display name of the agent. | `agent-kernel` |
 | `gen_ai_tool_name` | `TraceEvent.capability_id` | `org.myapp.search_docs` |
 | `gen_ai_system` | Producer-defined; `weaver` for native Weaver events. | `weaver` |
-| `parent_span_id` | The OTel span ID of the parent operation, if any. | `b9c7c989f97918e1` |
+| `parent_span_id` | The OTel span ID of the parent operation, if any (16 lowercase hex chars). | `b9c7c989f97918e1` |
 | `semconv_version` | Snapshot referenced above. | `1.30.0` |
 
 ---

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -1,0 +1,139 @@
+# Signing CapabilityTokens
+
+> [!IMPORTANT]
+> This document is normative for the Extended contract
+> `CapabilityTokenSignature`. The canonicalization rule and algorithm
+> registry below are mandatory for any producer or verifier claiming
+> compliance with weaver-spec token signing. See
+> [ADR 001](adr/001-capability-token-signing.md) for the design decision.
+
+CapabilityToken signing is **Extended** in v0.x: tokens without a signature
+remain valid, and routing/orchestration layers must pass the signature
+extension through unchanged. Promotion to Core is tracked under issue #48
+sub-ADR 005.
+
+---
+
+## Canonicalization
+
+The payload to be signed is the CapabilityToken JSON object with the
+`x_weaver_signature` field **removed**, then canonicalized via
+[RFC 8785 JSON Canonicalization Scheme (JCS)](https://www.rfc-editor.org/rfc/rfc8785).
+
+JCS guarantees:
+
+- UTF-8 output.
+- Member keys sorted by code point.
+- Numbers serialized per ES6 `Number.prototype.toString` (no trailing zeros,
+  shortest unambiguous form).
+- I-JSON restrictions applied.
+
+Ad-hoc `json.dumps(sort_keys=True)` is **not** equivalent — it does not
+normalize numbers, escape sequences, or insignificant whitespace consistently.
+Use a real JCS implementation (Python: [jcs](https://pypi.org/project/jcs/);
+JavaScript: [canonicalize](https://www.npmjs.com/package/canonicalize); reference
+test vectors: <https://github.com/cyberphone/json-canonicalization>).
+
+---
+
+## Algorithm registry
+
+The `alg` field of `CapabilityTokenSignature` MUST be one of the values below.
+Verifiers MUST reject unknown algorithms.
+
+| `alg` | Public-key algorithm | Signature encoding | Signature size |
+| ----- | -------------------- | ------------------ | -------------- |
+| `ed25519` | Ed25519 ([RFC 8032](https://www.rfc-editor.org/rfc/rfc8032)) | Raw 64-byte signature, base64url (no padding) | 64 bytes / 86 base64url chars |
+| `es256` | ECDSA over NIST P-256 with SHA-256 | IEEE P1363 concatenated `r\|\|s`, 64 bytes, base64url (no padding) | 64 bytes / 86 base64url chars |
+
+Adding a new algorithm to this registry is an additive change (MINOR bump);
+removing one is breaking.
+
+`canonicalization` MUST be `JCS`. Other canonicalization schemes are not in
+the registry and must be rejected.
+
+---
+
+## Producing a signature
+
+```text
+input:  token (a CapabilityToken JSON object), alg, kid, private_key
+output: token_with_signature
+
+1. work = deep_copy(token)
+2. delete work["x_weaver_signature"]      # signing input excludes the signature
+3. canonical_bytes = jcs.canonicalize(work)
+4. signature_bytes = sign(alg, private_key, canonical_bytes)
+5. token["x_weaver_signature"] = {
+     "alg": alg,
+     "kid": kid,
+     "sig": base64url_no_pad(signature_bytes),
+     "canonicalization": "JCS",
+     "signed_at": now_iso8601()       # optional, informational
+   }
+6. return token
+```
+
+---
+
+## Verifying a signature
+
+```text
+input:  token, keyring (kid -> public_key)
+output: bool
+
+1. signature = token.get("x_weaver_signature")
+2. if signature is None:                     return False  # unsigned
+3. if signature["alg"]    not in REGISTRY:   return False  # unknown alg
+4. if signature["canonicalization"] != "JCS": return False  # wrong canonical
+5. public_key = keyring.get(signature["kid"])
+6. if public_key is None:                    return False  # unknown key
+7. work = deep_copy(token)
+8. delete work["x_weaver_signature"]
+9. canonical_bytes = jcs.canonicalize(work)
+10. signature_bytes = base64url_decode_no_pad(signature["sig"])
+11. return verify(signature["alg"], public_key, canonical_bytes, signature_bytes)
+```
+
+A verifier that returns `True` MAY then apply additional invariant checks
+(I-06 scope non-empty, `expires_at` in the future, etc.) — these are
+independent of signature verification.
+
+---
+
+## Test vectors
+
+To produce repeatable interop test vectors, regenerate from the sample payload
+`examples/sample_payloads/capability_token_signed.json` after stripping
+`x_weaver_signature` and running the chosen JCS implementation. The JCS
+reference repository (linked above) ships vectors that exercise every
+canonicalization edge case (number formatting, surrogate pairs, etc.); sibling
+repos should run those vectors as part of their interop suite.
+
+The sample payload's `sig` value is illustrative only — it was not produced
+from a real key pair. Replace it with a vector from your own keyring during
+adoption.
+
+---
+
+## What is out of scope
+
+- **Key management.** Issuing `kid` values, rotating keys, distributing
+  public keys to verifiers — each adopter manages these. Recommended: short
+  rotation windows aligned with token expiry, public-key distribution via
+  a JWKS-style endpoint.
+- **Revocation.** Signed tokens remain valid until `expires_at`. Use
+  `single_use: true` for one-shot tokens; rely on revocation lists or short
+  expiries for the rest.
+- **Encryption.** Signing is integrity + authentication, not confidentiality.
+  Tokens MUST NOT contain secrets in cleartext.
+
+---
+
+## Related
+
+- ADR 001: [adr/001-capability-token-signing.md](adr/001-capability-token-signing.md)
+- Extended schema: `contracts/json/extended/capability_token_signature.schema.json`
+- Extended dataclass: `weaver_contracts.extended.CapabilityTokenSignature`
+- Issue #44 — original proposal.
+- Issue #48 sub-ADR 005 — promotion to Core in v1.0.0.

--- a/docs/adr/001-capability-token-signing.md
+++ b/docs/adr/001-capability-token-signing.md
@@ -1,0 +1,110 @@
+# ADR 001: CapabilityToken canonical form (RFC 8785 JCS) and signing spec — Extended-first
+
+**Status:** accepted
+
+---
+
+## Context
+
+`docs/INVARIANTS.md` and the schema description for `CapabilityToken` describe
+the token as "signed", but no field, no algorithm registry, and no verification
+rule existed in the spec — the word was aspirational (see `AGENTS.md` →
+"Forbidden behaviors" #5 and "Domain clarifications" → CapabilityToken).
+Sibling-repo authorization teams cannot ship tamper-evident tokens without a
+concrete spec covering:
+
+1. A deterministic canonical form for the token payload.
+2. A signature object with explicit algorithm, key identifier, and signature
+   bytes.
+3. Verification rules that downstream consumers (contextweaver, ChainWeaver,
+   third-party auditors) follow identically.
+
+Tracked in issue #44.
+
+## Decision
+
+Define token signing as an **Extended** contract first; promote to Core only in
+v1.0.0 once all three siblings adopt it and interop tests are green
+(see issue #48, sub-ADR 005).
+
+1. **Canonicalization.** The payload to be signed is the CapabilityToken JSON
+   object with the `x_weaver_signature` field removed, then canonicalized via
+   [RFC 8785 JSON Canonicalization Scheme (JCS)](https://www.rfc-editor.org/rfc/rfc8785).
+2. **Algorithm registry.** Initial algorithms: `ed25519` and `es256` (both
+   produce 64-byte signatures). The registry lives in `docs/SIGNING.md`.
+   Verifiers MUST reject unknown algorithms.
+3. **Signature object.** A new Extended contract `CapabilityTokenSignature`
+   carries `alg`, `kid`, `sig`, `canonicalization`, and an optional
+   informational `signed_at`. Its JSON Schema is
+   `contracts/json/extended/capability_token_signature.schema.json`.
+4. **Attachment.** The signature is attached to a `CapabilityToken` under the
+   namespaced extension key `x_weaver_signature`. Core schemas are unchanged.
+   Tokens without `x_weaver_signature` remain valid in v0.x (signing is opt-in).
+5. **Verification flow:** documented step-by-step with test vectors in
+   `docs/SIGNING.md`. Verifiers strip `x_weaver_signature`, JCS-canonicalize the
+   remaining object, then verify `sig` against `kid` using `alg`.
+
+## Consequences
+
+**Easier:**
+
+- `agent-kernel` and downstream auditors can ship tamper-evident tokens and
+  detect MITM tampering.
+- The word "signed" in glossary/schema descriptions becomes accurate when
+  `x_weaver_signature` is present.
+- Sibling repos that only pass tokens through (contextweaver, ChainWeaver) do
+  not need to verify — they preserve the extension unchanged.
+
+**Harder:**
+
+- Producers and verifiers must use a real JCS implementation; ad-hoc
+  `json.dumps(sort_keys=True)` is **not** sufficient (it does not normalize
+  numbers or string escapes per I-JSON).
+- Key management (issuing `kid` values, rotating keys) is out of scope for the
+  spec; each adopter manages it.
+
+## Affected Contracts
+
+| Contract | Change type | Description |
+| ---------- | ------------- | ------------- |
+| `extended/capability_token_signature.schema.json` | new schema | Detached-signature shape |
+| `weaver_contracts.extended.CapabilityTokenSignature` | new dataclass | Mirrors the schema |
+| `examples/sample_payloads/capability_token_signature.json` | new payload | Standalone signature sample |
+| `examples/sample_payloads/capability_token_signed.json` | new payload | CapabilityToken with `x_weaver_signature` attached |
+| `capability_token.schema.json` | unchanged | `additionalProperties: true` already accepts the `x_weaver_signature` extension |
+
+## Migration Path
+
+- **agent-kernel:** implement issuance + verification per `docs/SIGNING.md`.
+  Begin issuing signed tokens once a `kid` registry is configured.
+- **contextweaver / ChainWeaver:** pass `x_weaver_signature` through unchanged.
+  No validation required.
+- **Existing unsigned tokens:** remain valid for v0.x. v1.0.0 may promote
+  signing to Core (deferred to issue #48 ADR 005).
+
+## Cross-Repo Impact
+
+| Repository | Impact | Coordination required? |
+| ------------ | -------- | ------------------------ |
+| contextweaver | Passthrough only; do not strip `x_weaver_signature`. | no |
+| agent-kernel | Implement issuance + verification. | yes — issuance and key-management plan |
+| ChainWeaver | Passthrough only. | no |
+
+## Alternatives considered
+
+- **JOSE/JWS.** Heavy; binary base64 wrapping breaks the JSON-native model and
+  doubles payload size. Rejected.
+- **COSE.** Designed for CBOR; mismatch for JSON-native contracts. Rejected.
+- **`json.dumps(sort_keys=True)` ad-hoc.** Does not normalize numbers, does not
+  restrict to I-JSON; spec would silently break across language runtimes.
+  Rejected.
+- **JCS (RFC 8785).** Explicit interop guarantees, reference implementation +
+  test vectors at <https://github.com/cyberphone/json-canonicalization>.
+  **Selected.**
+
+## References
+
+- RFC 8785 — JSON Canonicalization Scheme (JCS): <https://www.rfc-editor.org/rfc/rfc8785>
+- JCS reference implementation + test vectors: <https://github.com/cyberphone/json-canonicalization>
+- Issue #44 — original proposal.
+- Issue #48 sub-ADR 005 — promotion to Core in v1.0.0.

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -22,16 +22,18 @@ After completing all six artifacts, run the local validation checks before submi
 
 ## Extended contract change workflow
 
-Extended contracts may define JSON Schemas under `contracts/json/extended/`.
-Newer Extended types ship a schema; the original metadata types remain
-Python-source-of-truth pending their schema retrofit (#46).
+Extended contracts define JSON Schemas under `contracts/json/extended/`.
+Every Extended type ships the full eight-artifact set; the original metadata
+types (`TelemetryHint`, `SchemaFingerprint`, `RedactionPolicy`, `UIHint`,
+`RiskAssessment`, `ExtendedFrameMetadata`, `ExtendedSelectableItemMetadata`)
+were retrofitted with schemas in v0.6.0 (#46).
 When adding or modifying an Extended contract, complete all of the following in a single PR:
 
 1. **Update the Python dataclass** in `contracts/python/src/weaver_contracts/extended.py`.
-2. **Add or update the JSON Schema** under `contracts/json/extended/` (for types that have one).
+2. **Add or update the JSON Schema** under `contracts/json/extended/`.
 3. **Update or create a sample payload** in `examples/sample_payloads/`.
 4. **Add or update a roundtrip test** in `contracts/python/tests/test_extended.py`.
-5. **Add or update a schema-alignment test** in `contracts/python/tests/test_extended_schema_alignment.py` (for types with a schema).
+5. **Add or update a schema-alignment test** in `contracts/python/tests/test_extended_schema_alignment.py`.
 6. **Add a CHANGELOG entry** under the appropriate version section.
 7. **Bump the version** in both `contracts/python/src/weaver_contracts/version.py` and `contracts/python/pyproject.toml`.
 8. **Regenerate** `contracts/COVERAGE.md` (`scripts/generate_coverage_table.py`) and `well-known/contracts.json` (`scripts/generate_contracts_index.py`); CI checks both with `--check`.

--- a/examples/sample_payloads/capability_token_signature.json
+++ b/examples/sample_payloads/capability_token_signature.json
@@ -1,7 +1,7 @@
 {
   "alg": "ed25519",
   "kid": "agent-kernel-2026-05-key-01",
-  "sig": "MEUCIQDxQ7w4_4Tq3rH9aJZQz9wHvN9p2lYkM7Z5oXrLg8b7nQIgZ8u3oXNl6sR4yKqJ0fY7m2bH8nQrL4kPzM5o9XaB7tY",
+  "sig": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0-Pw",
   "canonicalization": "JCS",
   "signed_at": "2026-05-28T08:00:00Z"
 }

--- a/examples/sample_payloads/capability_token_signature.json
+++ b/examples/sample_payloads/capability_token_signature.json
@@ -1,0 +1,7 @@
+{
+  "alg": "ed25519",
+  "kid": "agent-kernel-2026-05-key-01",
+  "sig": "MEUCIQDxQ7w4_4Tq3rH9aJZQz9wHvN9p2lYkM7Z5oXrLg8b7nQIgZ8u3oXNl6sR4yKqJ0fY7m2bH8nQrL4kPzM5o9XaB7tY",
+  "canonicalization": "JCS",
+  "signed_at": "2026-05-28T08:00:00Z"
+}

--- a/examples/sample_payloads/capability_token_signed.json
+++ b/examples/sample_payloads/capability_token_signed.json
@@ -1,0 +1,23 @@
+{
+  "token_id": "tok-20260528-signed-001",
+  "principal": "agent-session-7f3a",
+  "scope": [
+    "org.myapp.search_docs",
+    "org.myapp.fetch_doc_page"
+  ],
+  "issued_at": "2026-05-28T08:00:00Z",
+  "expires_at": "2026-05-28T09:00:00Z",
+  "single_use": false,
+  "issuer": "agent-kernel-prod-1",
+  "metadata": {
+    "session_id": "sess-20260528-xyz",
+    "request_id": "req-20260528-001"
+  },
+  "x_weaver_signature": {
+    "alg": "ed25519",
+    "kid": "agent-kernel-2026-05-key-01",
+    "sig": "MEUCIQDxQ7w4_4Tq3rH9aJZQz9wHvN9p2lYkM7Z5oXrLg8b7nQIgZ8u3oXNl6sR4yKqJ0fY7m2bH8nQrL4kPzM5o9XaB7tY",
+    "canonicalization": "JCS",
+    "signed_at": "2026-05-28T08:00:00Z"
+  }
+}

--- a/examples/sample_payloads/capability_token_signed.json
+++ b/examples/sample_payloads/capability_token_signed.json
@@ -16,7 +16,7 @@
   "x_weaver_signature": {
     "alg": "ed25519",
     "kid": "agent-kernel-2026-05-key-01",
-    "sig": "MEUCIQDxQ7w4_4Tq3rH9aJZQz9wHvN9p2lYkM7Z5oXrLg8b7nQIgZ8u3oXNl6sR4yKqJ0fY7m2bH8nQrL4kPzM5o9XaB7tY",
+    "sig": "CxIZICcuNTxDSlFYX2ZtdHuCiZCXnqWss7rByM_W3eTr8vkABw4VHCMqMTg_Rk1UW2JpcHd-hYyTmqGor7a9xA",
     "canonicalization": "JCS",
     "signed_at": "2026-05-28T08:00:00Z"
   }

--- a/examples/sample_payloads/otel_trace_mapping.json
+++ b/examples/sample_payloads/otel_trace_mapping.json
@@ -1,0 +1,12 @@
+{
+  "trace_id": "4bf92f3577b34da6a3ce929d0e0e4736",
+  "span_id": "00f067aa0ba902b7",
+  "span_kind": "INTERNAL",
+  "gen_ai_operation_name": "execute_tool",
+  "gen_ai_agent_id": "agent-kernel-prod-1",
+  "gen_ai_agent_name": "agent-kernel",
+  "gen_ai_tool_name": "org.myapp.search_docs",
+  "gen_ai_system": "weaver",
+  "parent_span_id": "b9c7c989f97918e1",
+  "semconv_version": "1.30.0"
+}

--- a/well-known/contracts.json
+++ b/well-known/contracts.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "contract_version": "0.5.0",
+  "contract_version": "0.6.0",
   "core": [
     {
       "name": "capability",
@@ -82,11 +82,32 @@
       "sha256": "2352e7f2e848500a0b670657fa9716d3b1758e56ffb685876a0f82e2bb64cb49"
     },
     {
+      "name": "capability_token_signature",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/capability_token_signature.schema.json",
+      "path": "contracts/json/extended/capability_token_signature.schema.json",
+      "sha256": "70e9492cc4a6cecedccccaba34d9c355e9fb740451d4ea50570ae9449af6399b"
+    },
+    {
       "name": "evaluation_artifact",
       "version": "v0",
       "$id": "https://weaver-spec.dev/contracts/v0/extended/evaluation_artifact.schema.json",
       "path": "contracts/json/extended/evaluation_artifact.schema.json",
       "sha256": "11b7a02fd3d13881ccfcc85e22e57cf5292411e23f80993d7956d5c474a6af52"
+    },
+    {
+      "name": "extended_frame_metadata",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/extended_frame_metadata.schema.json",
+      "path": "contracts/json/extended/extended_frame_metadata.schema.json",
+      "sha256": "67f18a8030ffa37ab9df07898814e65925c714bd30edda29481e8808c65ec3ca"
+    },
+    {
+      "name": "extended_selectable_item_metadata",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/extended_selectable_item_metadata.schema.json",
+      "path": "contracts/json/extended/extended_selectable_item_metadata.schema.json",
+      "sha256": "86c42335dcb1d5fe2935978ab766be97e727ee4d85c39fe448b13f2117165841"
     },
     {
       "name": "lesson_card",
@@ -103,11 +124,39 @@
       "sha256": "5c469d4a3d825be40ac848db79bccef08e5accec5c9cf97318f7f7fa9b174aea"
     },
     {
+      "name": "otel_trace_mapping",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/otel_trace_mapping.schema.json",
+      "path": "contracts/json/extended/otel_trace_mapping.schema.json",
+      "sha256": "5bbb1083ba706826979e3e141c6a4b59ee3435e36e844f3e9f9ad1b290c7475d"
+    },
+    {
+      "name": "redaction_policy",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/redaction_policy.schema.json",
+      "path": "contracts/json/extended/redaction_policy.schema.json",
+      "sha256": "6adca8aaf365ebbb5d95e6a28d04e4e337ccd2d95036db43d62c55b31f29b0c3"
+    },
+    {
       "name": "review_artifact",
       "version": "v0",
       "$id": "https://weaver-spec.dev/contracts/v0/extended/review_artifact.schema.json",
       "path": "contracts/json/extended/review_artifact.schema.json",
       "sha256": "9ac740c96079862dfe047e60084050279167f44ee5e983e1205070988d059bbe"
+    },
+    {
+      "name": "risk_assessment",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/risk_assessment.schema.json",
+      "path": "contracts/json/extended/risk_assessment.schema.json",
+      "sha256": "a42717f80f37070bd24dd97c9a7486901416bab488b90fdc5e7e61990c5cc061"
+    },
+    {
+      "name": "schema_fingerprint",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/schema_fingerprint.schema.json",
+      "path": "contracts/json/extended/schema_fingerprint.schema.json",
+      "sha256": "fa76eedf784941986431697e00a9c9d504911f56c5adf6fbbeb42cc8f4216271"
     },
     {
       "name": "session_handoff",
@@ -122,6 +171,20 @@
       "$id": "https://weaver-spec.dev/contracts/v0/extended/skill_card.schema.json",
       "path": "contracts/json/extended/skill_card.schema.json",
       "sha256": "964833d0835a01172686611bdda74757166822d6aed47156c612f7c063c85559"
+    },
+    {
+      "name": "telemetry_hint",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/telemetry_hint.schema.json",
+      "path": "contracts/json/extended/telemetry_hint.schema.json",
+      "sha256": "84e31eb6f441a2f79b2ab65b1f487af73da6473ba6b3c2434f1d51813ce3c33c"
+    },
+    {
+      "name": "ui_hint",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/ui_hint.schema.json",
+      "path": "contracts/json/extended/ui_hint.schema.json",
+      "sha256": "2f487617ddae026f16b7cac1de3e1b9d4eb489eefc025adc229d5fe29ac12b78"
     }
   ]
 }

--- a/well-known/contracts.json
+++ b/well-known/contracts.json
@@ -86,7 +86,7 @@
       "version": "v0",
       "$id": "https://weaver-spec.dev/contracts/v0/extended/capability_token_signature.schema.json",
       "path": "contracts/json/extended/capability_token_signature.schema.json",
-      "sha256": "70e9492cc4a6cecedccccaba34d9c355e9fb740451d4ea50570ae9449af6399b"
+      "sha256": "0b214fa8fa77bc0859584acd68e767f239716e4e43c3d782cec063517b2e7f92"
     },
     {
       "name": "evaluation_artifact",
@@ -128,7 +128,7 @@
       "version": "v0",
       "$id": "https://weaver-spec.dev/contracts/v0/extended/otel_trace_mapping.schema.json",
       "path": "contracts/json/extended/otel_trace_mapping.schema.json",
-      "sha256": "5bbb1083ba706826979e3e141c6a4b59ee3435e36e844f3e9f9ad1b290c7475d"
+      "sha256": "e885ce38b247d08c8014d0c37b2bf1743eedd2b6214a761eaf7c681dd27cdace"
     },
     {
       "name": "redaction_policy",

--- a/well-known/contracts.json
+++ b/well-known/contracts.json
@@ -100,7 +100,7 @@
       "version": "v0",
       "$id": "https://weaver-spec.dev/contracts/v0/extended/extended_frame_metadata.schema.json",
       "path": "contracts/json/extended/extended_frame_metadata.schema.json",
-      "sha256": "67f18a8030ffa37ab9df07898814e65925c714bd30edda29481e8808c65ec3ca"
+      "sha256": "02915e1b0cb20432685e451ee3d09f86085ad26605db5310ae3fc6e6fd5a8b0e"
     },
     {
       "name": "extended_selectable_item_metadata",


### PR DESCRIPTION
## Description

Bundles three M2 Extended-schema-lead issues into a single MINOR bump (`0.5.0` → `0.6.0`). All three share the same code area (`contracts/json/extended/`, `extended.py`, sample payloads, alignment tests) and the same eight-step Extended workflow, so the version bump, CHANGELOG entry, coverage table, and contracts index are amortised across all three.

- **Closes #46** — Adds JSON Schemas for the seven original Extended metadata types (`TelemetryHint`, `SchemaFingerprint`, `RedactionPolicy`, `UIHint`, `RiskAssessment`, `ExtendedFrameMetadata`, `ExtendedSelectableItemMetadata`). The Python-source-of-truth carve-out in `AGENTS.md` and `docs/agent-context/workflows.md` is removed. Coverage table reaches 26 / 26 on JSON Schemas and 20 / 26 on schema-validation tests.
- **Closes #44** — Adds `CapabilityTokenSignature` (RFC 8785 JCS + `ed25519`/`es256`) attached to a `CapabilityToken` under the namespaced extension key `x_weaver_signature`. Core schema unchanged. New `docs/adr/001-capability-token-signing.md` and verification guide `docs/SIGNING.md`. `AGENTS.md` "Domain clarifications" entry for `CapabilityToken` is updated so the word "signed" is grounded in a real Extended contract.
- **Closes #47** — Adds `OtelTraceMapping` (W3C Trace Context IDs + OTel GenAI semconv attributes). New `docs/OTEL_MAPPING.md` pins the OTel semconv snapshot to `1.30.0`, maps every `TraceEvent` field, and carries a CI-validated inline payload.

## What changed

**Schemas** (`contracts/json/extended/`, 9 new files):

- `telemetry_hint`, `schema_fingerprint`, `redaction_policy`, `ui_hint`, `risk_assessment`, `extended_frame_metadata`, `extended_selectable_item_metadata` (#46).
- `capability_token_signature` (#44) — enforces alg ∈ {ed25519, es256}, canonicalization ∈ {JCS}, base64url `sig`.
- `otel_trace_mapping` (#47) — enforces W3C hex format for `trace_id` (32 chars) and `span_id` (16 chars), `span_kind` enum.

**Dataclasses** (`extended.py`): add `CapabilityTokenSignature` and `OtelTraceMapping`, both with `__post_init__` validation mirroring the schema constraints (W3C hex checks, algorithm/canonicalization registry, span-kind enum).

**Sample payloads:** `capability_token_signature.json`, `capability_token_signed.json` (full Core `CapabilityToken` with `x_weaver_signature` attached, validates against the Core schema unchanged), `otel_trace_mapping.json`.

**Tests:**

- `test_extended.py` — `TestCapabilityTokenSignature` (8 cases) and `TestOtelTraceMapping` (9 cases, incl. all 5 span kinds, malformed trace/span IDs, non-hex chars).
- `test_extended_schema_alignment.py` — adds the 9 new schemas to the parametrized list, plus 6 new negative cases (unknown signing alg, unknown canonicalization, full signed-token validation against Core schema, invalid OTel span kind, malformed `trace_id`, missing fingerprint required fields).

**Docs:** new `docs/adr/001-capability-token-signing.md`, `docs/SIGNING.md`, `docs/OTEL_MAPPING.md`; `contracts/json/README.md` lists every Extended schema; `AGENTS.md` carve-outs removed; `docs/agent-context/workflows.md` Extended workflow simplified to "every Extended type ships the full eight-artifact set".

**Generated:** `contracts/COVERAGE.md` and `well-known/contracts.json` regenerated (CI-verified by `--check`).

---

## Type of change

- [ ] Docs only (no contract changes)
- [x] Additive contract change (new optional field or new type — non-breaking)
- [ ] Breaking contract change (requires ADR — see [CONTRIBUTING.md](CONTRIBUTING.md))
- [ ] CI / tooling change

> Note: ADR 001 (`docs/adr/001-capability-token-signing.md`) is included because #44 is labeled `adr`, but the change itself is additive (Extended-only, opt-in). Core schemas are not modified.

---

## Six-artifact checklist

This PR touches Extended contracts only — the eight-step Extended workflow applies (`docs/agent-context/workflows.md`). Core boxes are N/A.

- [ ] JSON Schema updated (`contracts/json/`) — N/A (Core unchanged)
- [ ] Python dataclass updated (`contracts/python/src/weaver_contracts/core.py`) — N/A
- [ ] Sample payload updated (`examples/sample_payloads/`) — see Extended payloads above
- [ ] Roundtrip test updated (`contracts/python/tests/test_roundtrip_examples.py`) — N/A (Extended tests live in `test_extended.py` / `test_extended_schema_alignment.py`)
- [x] CHANGELOG entry added (`CHANGELOG.md`)
- [x] Version bumped (`version.py` + `pyproject.toml`) — 0.5.0 → 0.6.0

---

## Deprecations

- [x] `docs/DEPRECATIONS.md` updated — N/A (no deprecation in this PR)

---

## Invariants

- [x] I have verified that invariants I-01 through I-07 in `docs/INVARIANTS.md` are not violated by this change. The new Extended contracts are additive metadata; they do not touch Frame/Handle semantics, do not weaken `CapabilityToken` scope constraints, and do not add fields to Core schemas.

---

## Cross-repo impact

- [ ] **contextweaver** — passthrough only; must not strip `x_weaver_signature` from tokens it relays; may emit `OtelTraceMapping` for routing-side TraceEvents.
- [x] **agent-kernel** — needs coordinated update — may issue + verify `CapabilityTokenSignature` per `docs/SIGNING.md`; may emit `OtelTraceMapping` per `docs/OTEL_MAPPING.md`. Both are opt-in in v0.x.
- [ ] **ChainWeaver** — passthrough only; may emit `OtelTraceMapping` for flow lifecycle events.
- [ ] No cross-repo impact

---

## How verified

Local commands run (from `contracts/python/` for pytest/mypy, from repo root for the rest):

```
python3 -m pytest --cov --cov-report=term-missing
  → 210 passed, coverage 93.54% (floor 80%)
python3 -m mypy src/
  → Success: no issues found in 4 source files
python3 scripts/check_schema_fields.py
  → Validated 26 schema(s)
python3 scripts/generate_contracts_index.py --check
  → OK: well-known/contracts.json is up to date.
python3 scripts/generate_coverage_table.py --check
  → OK: contracts/COVERAGE.md is up to date.
yamllint -c .yamllint.yml .github/ISSUE_TEMPLATE/ .github/workflows/ .yamllint.yml .pre-commit-config.yaml compatibility.yaml
  → clean
markdownlint README.md CONTRIBUTING.md CHANGELOG.md CHARTER.md 'docs/**/*.md' 'contracts/**/*.md' 'examples/**/*.md' '.github/**/*.md'
  → clean
(walkthrough-payload validator from .github/workflows/ci.yml, replicated locally)
  → Validated 49 inline payload(s); all pass schema validation
```

---

## Risks / caveats

- **Sample signature `sig` value is illustrative**, not produced from a real key pair. Adopters must replace it with a vector from their own keyring. `docs/SIGNING.md` calls this out and points to the JCS reference repository for real interop vectors.
- **OTel semconv 1.30.0 is pinned**; future snapshots may rename `gen_ai.tool.name` / `gen_ai.agent.id`. The mapping doc carries the snapshot version explicitly so drift is detectable.
- **`additionalProperties: true` is preserved** on every new schema (matches the rest of the repo) — adopters can extend without breaking validation.

## Process

See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contribution process, including the ADR process for breaking changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCcV9CduJ8n8SgGy1fkdnP)_