### PR TITLE
contracts: add selection↔execution boundary Extended contracts (#61, #66)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,7 @@ For mixed changes, use the prefix for the most impactful change. Mention the sec
 | [docs/SCHEMA_HOSTING.md](docs/SCHEMA_HOSTING.md) | `$id` URL pattern, immutability rule, content-addressed index |
 | [docs/DOCS_CONVENTIONS.md](docs/DOCS_CONVENTIONS.md) | Markup convention for normative requirements vs informative notes vs examples |
 | [docs/ARTIFACT_CONTRACTS.md](docs/ARTIFACT_CONTRACTS.md) | Cross-project Extended artifact vocabulary (memory, session handoff, lesson/skill cards, evaluation, safety gate) |
+| [docs/EXECUTION_BOUNDARY.md](docs/EXECUTION_BOUNDARY.md) | Selection ↔ execution boundary Extended contracts (ExecutionCandidate, CompiledFlow, ExecutionRoutingDecision, ExecutionFeedback) |
 | [docs/ECOSYSTEM.md](docs/ECOSYSTEM.md) | Derived ecosystem boundary map (owns/consumes/emits per project, end-to-end lifecycle); points to BOUNDARIES.md/LIFECYCLE.md as canonical |
 | [docs/agent-context/architecture.md](docs/agent-context/architecture.md) | Pointers to canonical architecture and boundary docs |
 | [docs/agent-context/workflows.md](docs/agent-context/workflows.md) | Authoritative commands, change sequences, documentation governance |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,41 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
 
 ### Added
 
+- **Selection ↔ execution boundary Extended contracts.** Four new
+  implementation-neutral Extended contracts describing the boundary between
+  selecting a unit of work and executing it, so static routers, the
+  `contextweaver` ChoiceCard layer, and feedback-aware external routers can all
+  describe a selection the same way instead of each integration inventing its
+  own router-to-executor payload.
+  - **`ExecutionCandidate`** — something selectable for execution; `candidate_type`
+    is a fixed enum (`tool` / `flow` / `capability` / `agent` / `workflow`).
+  - **`CompiledFlow`** — a compiled flow (e.g. a ChainWeaver flow) exposed as a
+    routable, executable item. References (does not inline) its input/output
+    schemas, lists internal `tool_dependencies`, and carries derived
+    `sensitivity` / `side_effects`. `requires_authorization` defaults to `true`:
+    a pre-compiled flow does not bypass the kernel authorization path
+    (invariant I-07). It attaches to an `ExecutionCandidate` (when
+    `candidate_type` is `flow`) via `$ref`.
+  - **`ExecutionRoutingDecision`** — a router's **advisory** recommendation of an
+    `ExecutionCandidate`. Named distinctly from the Core `RoutingDecision` (the
+    `contextweaver` ChoiceCard wrapper, kept separate per AGENTS.md "Design
+    decisions not to reopen"). It does not grant execution rights; the
+    execution/policy layer still records a `PolicyDecision` and emits a
+    `TraceEvent` (invariant I-02). `confidence` is standardized to `[0.0, 1.0]`.
+  - **`ExecutionFeedback`** — the observed outcome of executing a candidate,
+    correlated by `decision_id` / `candidate_id` and preserving the execution
+    runtime's `trace_ref`. `quality_score` is standardized to `[0.0, 1.0]`.
+    Consuming feedback is optional, keeping deterministic routers deterministic.
+  - JSON Schemas under `contracts/json/extended/`, Python dataclasses in
+    `extended.py` (with `__post_init__` range/enum validation mirroring the
+    schemas), four sample payloads (including a `contextweaver` → ChainWeaver
+    routing example and an external-router → ChainWeaver → feedback example),
+    roundtrip tests in `test_extended.py`, schema-alignment + negative tests in
+    `test_extended_schema_alignment.py`, and the normative
+    `docs/EXECUTION_BOUNDARY.md`. `contracts/COVERAGE.md` and
+    `well-known/contracts.json` regenerated. These are additive Extended
+    contracts (no Core change), folded into the unreleased `0.6.0` set.
+    Closes #61. Closes #66.
 - **v0.6.0 — Extended schema retrofit + signing + OpenTelemetry mapping.**
   Bumps `CONTRACT_VERSION` and the Python package to `0.6.0` and lands three
   related issues in one PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
   describe a selection the same way instead of each integration inventing its
   own router-to-executor payload.
   - **`ExecutionCandidate`** — something selectable for execution; `candidate_type`
-    is a fixed enum (`tool` / `flow` / `capability` / `agent` / `workflow`).
+    is a fixed enum (`tool` / `flow` / `capability` / `agent` / `workflow`). A
+    `compiled_flow` detail is only valid when `candidate_type` is `flow`
+    (enforced in both the JSON Schema and the Python dataclass).
   - **`CompiledFlow`** — a compiled flow (e.g. a ChainWeaver flow) exposed as a
     routable, executable item. References (does not inline) its input/output
     schemas, lists internal `tool_dependencies`, and carries derived

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This repo is the contract layer for all of the above. You do not need to adopt e
 | End-to-end lifecycle | [docs/LIFECYCLE.md](docs/LIFECYCLE.md) |
 | Cross-repo integration map | [docs/INTEGRATION_MAP.md](docs/INTEGRATION_MAP.md) |
 | Cross-project artifact contracts | [docs/ARTIFACT_CONTRACTS.md](docs/ARTIFACT_CONTRACTS.md) |
+| Selection ↔ execution boundary | [docs/EXECUTION_BOUNDARY.md](docs/EXECUTION_BOUNDARY.md) |
 | Term definitions | [docs/GLOSSARY.md](docs/GLOSSARY.md) |
 | Sequence diagrams | [docs/SEQUENCE_DIAGRAMS.md](docs/SEQUENCE_DIAGRAMS.md) |
 | Versioning rules | [docs/VERSIONING.md](docs/VERSIONING.md) |

--- a/contracts/COVERAGE.md
+++ b/contracts/COVERAGE.md
@@ -17,12 +17,12 @@ CI runs the same script with `--check` and fails if this file is stale.
 
 ## Summary
 
-- Total contract types: **26**
-- JSON Schemas: **26 / 26**
-- Python classes: **26 / 26**
-- Sample payloads: **26 / 26**
-- Roundtrip tests: **26 / 26**
-- Schema validation tests: **20 / 26**
+- Total contract types: **30**
+- JSON Schemas: **30 / 30**
+- Python classes: **30 / 30**
+- Sample payloads: **30 / 30**
+- Roundtrip tests: **30 / 30**
+- Schema validation tests: **24 / 30**
 
 ## Coverage table
 
@@ -54,6 +54,10 @@ CI runs the same script with `--check` and fails if this file is stale.
 | Extended | `ArtifactSafetyReport` | OK | OK | OK | OK | OK |
 | Extended | `CapabilityTokenSignature` | OK | OK | OK | OK | OK |
 | Extended | `OtelTraceMapping` | OK | OK | OK | OK | OK |
+| Extended | `CompiledFlow` | OK | OK | OK | OK | OK |
+| Extended | `ExecutionCandidate` | OK | OK | OK | OK | OK |
+| Extended | `ExecutionRoutingDecision` | OK | OK | OK | OK | OK |
+| Extended | `ExecutionFeedback` | OK | OK | OK | OK | OK |
 
 ## Legend
 

--- a/contracts/json/extended/compiled_flow.schema.json
+++ b/contracts/json/extended/compiled_flow.schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/compiled_flow.schema.json",
+  "title": "CompiledFlow",
+  "description": "Extended. A compiled flow (e.g. a ChainWeaver flow) exposed as a Weaver ecosystem item that can be routed to and executed like a capability. References (does not inline) its input/output schemas, lists the capability IDs it depends on internally, and carries sensitivity/side-effect metadata derived from those tools. A pre-compiled flow does not bypass execution authorization: a flow step that invokes a tool still goes through the kernel authorization/audit path (invariant I-07). See docs/EXECUTION_BOUNDARY.md.",
+  "type": "object",
+  "required": ["flow_id"],
+  "properties": {
+    "flow_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable identifier for the compiled flow."
+    },
+    "name": {
+      "type": ["string", "null"],
+      "description": "Optional human-readable name."
+    },
+    "version": {
+      "type": ["string", "null"],
+      "description": "Optional flow version (useful for versioned ChainWeaver flows)."
+    },
+    "description": {
+      "type": ["string", "null"],
+      "description": "Optional short description of what the flow does."
+    },
+    "input_schema_ref": {
+      "type": ["string", "null"],
+      "description": "Optional reference (URI or registry key) to the flow's input schema. The schema is referenced, not inlined, to avoid context bloat."
+    },
+    "output_schema_ref": {
+      "type": ["string", "null"],
+      "description": "Optional reference (URI or registry key) to the flow's output schema."
+    },
+    "tool_dependencies": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Capability IDs the flow invokes internally. Used to derive sensitivity and side-effect metadata and to plan authorization."
+    },
+    "sensitivity": {
+      "type": ["string", "null"],
+      "enum": ["public", "internal", "confidential", "restricted", null],
+      "description": "Optional sensitivity level, typically derived from the most sensitive tool the flow depends on. One of the shared artifact sensitivity levels."
+    },
+    "side_effects": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional side-effect markers derived from the flow's tools (e.g. `external_email`, `data_write`). Free-form; namespace project-specific values."
+    },
+    "requires_authorization": {
+      "type": "boolean",
+      "description": "Whether executing this flow requires authorization through the execution/policy layer. Defaults to true; a pre-compiled flow does not bypass the kernel authorization path (invariant I-07)."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Implementation-specific extension bag. Namespace project-specific keys to avoid collisions.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/compiled_flow.schema.json
+++ b/contracts/json/extended/compiled_flow.schema.json
@@ -48,6 +48,7 @@
     },
     "requires_authorization": {
       "type": "boolean",
+      "default": true,
       "description": "Whether executing this flow requires authorization through the execution/policy layer. Defaults to true; a pre-compiled flow does not bypass the kernel authorization path (invariant I-07)."
     },
     "metadata": {

--- a/contracts/json/extended/execution_candidate.schema.json
+++ b/contracts/json/extended/execution_candidate.schema.json
@@ -33,12 +33,23 @@
         { "$ref": "https://weaver-spec.dev/contracts/v0/extended/compiled_flow.schema.json" },
         { "type": "null" }
       ],
-      "description": "Optional CompiledFlow detail, present when candidate_type is `flow`."
+      "description": "Optional CompiledFlow detail. Only valid when candidate_type is `flow`."
     },
     "metadata": {
       "type": "object",
       "description": "Implementation-specific extension bag. Namespace project-specific keys to avoid collisions.",
       "additionalProperties": true
+    }
+  },
+  "if": {
+    "required": ["compiled_flow"],
+    "properties": {
+      "compiled_flow": { "type": "object" }
+    }
+  },
+  "then": {
+    "properties": {
+      "candidate_type": { "const": "flow" }
     }
   },
   "additionalProperties": true

--- a/contracts/json/extended/execution_candidate.schema.json
+++ b/contracts/json/extended/execution_candidate.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/execution_candidate.schema.json",
+  "title": "ExecutionCandidate",
+  "description": "Extended. Something that can be selected for execution: a tool, flow, capability, agent, or workflow. Implementation-neutral identifier-plus-metadata shape used by the selection ↔ execution boundary contracts. When candidate_type is `flow` the candidate may carry a `compiled_flow` detail. See docs/EXECUTION_BOUNDARY.md.",
+  "type": "object",
+  "required": ["candidate_id", "candidate_type"],
+  "properties": {
+    "candidate_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable identifier for the selected item."
+    },
+    "candidate_type": {
+      "type": "string",
+      "enum": ["tool", "flow", "capability", "agent", "workflow"],
+      "description": "The kind of item selected. A runtime is not required to support every kind."
+    },
+    "name": {
+      "type": ["string", "null"],
+      "description": "Optional human-readable name."
+    },
+    "version": {
+      "type": ["string", "null"],
+      "description": "Optional version, useful for versioned flows and tools."
+    },
+    "description": {
+      "type": ["string", "null"],
+      "description": "Optional short description."
+    },
+    "compiled_flow": {
+      "anyOf": [
+        { "$ref": "https://weaver-spec.dev/contracts/v0/extended/compiled_flow.schema.json" },
+        { "type": "null" }
+      ],
+      "description": "Optional CompiledFlow detail, present when candidate_type is `flow`."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Implementation-specific extension bag. Namespace project-specific keys to avoid collisions.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/execution_feedback.schema.json
+++ b/contracts/json/extended/execution_feedback.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/execution_feedback.schema.json",
+  "title": "ExecutionFeedback",
+  "description": "Extended. The observed outcome of executing (or attempting to execute) a selected candidate. Links back to the originating decision and candidate so a router or evaluator can correlate recommendation, execution, and result. Sending feedback is optional — a deterministic router need not consume it. See docs/EXECUTION_BOUNDARY.md.",
+  "type": "object",
+  "required": ["decision_id", "candidate_id", "success", "timestamp"],
+  "properties": {
+    "decision_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Links feedback to the originating ExecutionRoutingDecision."
+    },
+    "candidate_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Links feedback to the selected ExecutionCandidate."
+    },
+    "success": {
+      "type": "boolean",
+      "description": "Whether execution completed successfully."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when the feedback was created."
+    },
+    "latency_ms": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Optional execution latency in milliseconds."
+    },
+    "cost": {
+      "type": "object",
+      "description": "Optional structured cost payload (e.g. tokens or USD saved/spent).",
+      "additionalProperties": true
+    },
+    "quality_score": {
+      "type": ["number", "null"],
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "description": "Optional caller/evaluator/user-provided quality signal in [0.0, 1.0]."
+    },
+    "error_type": {
+      "type": ["string", "null"],
+      "description": "Optional normalized error class when success is false."
+    },
+    "error_message": {
+      "type": ["string", "null"],
+      "description": "Optional short error message."
+    },
+    "trace_ref": {
+      "type": ["string", "null"],
+      "description": "Reference to the execution trace, e.g. a ChainWeaver `chainweaver:trace_id:abc123`."
+    },
+    "execution_summary": {
+      "type": "object",
+      "description": "Optional compact summary of the execution result.",
+      "additionalProperties": true
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Implementation-specific extension bag. Namespace project-specific keys to avoid collisions.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/execution_routing_decision.schema.json
+++ b/contracts/json/extended/execution_routing_decision.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/execution_routing_decision.schema.json",
+  "title": "ExecutionRoutingDecision",
+  "description": "Extended. A router's advisory recommendation of an ExecutionCandidate, implementation-neutral with respect to the routing algorithm. Advisory by default: it does NOT grant execution rights — the execution/policy layer still records a PolicyDecision and emits a TraceEvent before running the candidate (invariants I-02, I-07). Distinct from the Core RoutingDecision (the contextweaver ChoiceCard wrapper). See docs/EXECUTION_BOUNDARY.md.",
+  "type": "object",
+  "required": ["decision_id", "candidate"],
+  "properties": {
+    "decision_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable ID correlating this decision with downstream execution traces and ExecutionFeedback."
+    },
+    "candidate": {
+      "$ref": "https://weaver-spec.dev/contracts/v0/extended/execution_candidate.schema.json",
+      "description": "The selected ExecutionCandidate."
+    },
+    "confidence": {
+      "type": ["number", "null"],
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "description": "Optional confidence score in [0.0, 1.0]."
+    },
+    "reason_codes": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Machine-readable reasons for the decision (e.g. `capability_match`, `low_latency`)."
+    },
+    "reason": {
+      "type": ["string", "null"],
+      "description": "Optional human-readable explanation."
+    },
+    "fallback_candidates": {
+      "type": "array",
+      "items": {
+        "$ref": "https://weaver-spec.dev/contracts/v0/extended/execution_candidate.schema.json"
+      },
+      "description": "Ordered list of alternative candidates the runtime may fall back to."
+    },
+    "constraints": {
+      "type": "object",
+      "description": "Relevant constraints used by the router, such as cost, latency, policy, or user context.",
+      "additionalProperties": true
+    },
+    "policy_context_ref": {
+      "type": ["string", "null"],
+      "description": "Optional reference to the policy/auth context the router considered. Advisory only — does not grant authorization."
+    },
+    "trace_ref": {
+      "type": ["string", "null"],
+      "description": "Optional reference to router-side trace/observability data, e.g. `router:trace:abc123`."
+    },
+    "created_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "Optional ISO 8601 timestamp of when the decision was produced."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Implementation-specific extension bag. Namespace project-specific keys to avoid collisions.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/execution_routing_decision.schema.json
+++ b/contracts/json/extended/execution_routing_decision.schema.json
@@ -12,7 +12,9 @@
       "description": "Stable ID correlating this decision with downstream execution traces and ExecutionFeedback."
     },
     "candidate": {
-      "$ref": "https://weaver-spec.dev/contracts/v0/extended/execution_candidate.schema.json",
+      "allOf": [
+        { "$ref": "https://weaver-spec.dev/contracts/v0/extended/execution_candidate.schema.json" }
+      ],
       "description": "The selected ExecutionCandidate."
     },
     "confidence": {

--- a/contracts/python/src/weaver_contracts/extended.py
+++ b/contracts/python/src/weaver_contracts/extended.py
@@ -664,3 +664,182 @@ class OtelTraceMapping:
             raise ValueError(
                 "OtelTraceMapping.parent_span_id must be 16 lowercase hex characters"
             )
+
+
+# ===========================================================================
+# Selection ↔ execution boundary contracts
+#
+# These contracts describe the boundary between *selecting* a unit of work and
+# *executing* it, without prescribing a routing algorithm or execution engine
+# (#61). They are implementation-neutral: a static router, a contextweaver
+# ChoiceCard layer, or a learned/feedback-aware external router can all produce
+# an ExecutionRoutingDecision; agent-kernel, ChainWeaver, or any compatible
+# runtime can consume it.
+#
+# Naming: the generic decision type is ExecutionRoutingDecision, NOT
+# RoutingDecision. The Core RoutingDecision (core.py) is the contextweaver
+# ChoiceCard wrapper and is deliberately separate (see AGENTS.md "Design
+# decisions not to reopen"); reusing the name would conflate the two.
+#
+# CompiledFlow (#66) is the candidate detail for a compiled ChainWeaver flow.
+# It is referenced by ExecutionCandidate when candidate_type == "flow".
+#
+# Authorization boundary: an ExecutionRoutingDecision is advisory. It does NOT
+# grant execution rights. Authorization, policy enforcement, audit logging, and
+# firewalling remain with the execution/policy layer (agent-kernel or another
+# Weaver-compatible runtime), per invariants I-02 and I-07. See
+# docs/EXECUTION_BOUNDARY.md for the full boundary description and examples.
+# ===========================================================================
+
+# Candidate kinds an external router may select for execution. Fixed set: a
+# runtime is not required to support every kind (see docs/EXECUTION_BOUNDARY.md).
+_CANDIDATE_TYPES = frozenset({"tool", "flow", "capability", "agent", "workflow"})
+
+
+# ---------------------------------------------------------------------------
+# CompiledFlow — a compiled ChainWeaver flow exposed as a selectable item
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CompiledFlow:
+    """A compiled flow (e.g. a ChainWeaver flow) exposed as a Weaver ecosystem
+    item that can be routed to and executed like a capability.
+
+    Implementation-neutral: it references (does not inline) its input/output
+    schemas, lists the capability IDs it depends on internally, and carries
+    sensitivity/side-effect metadata derived from those tools. ``requires_authorization``
+    defaults to ``True`` because a flow step that invokes a tool must still go
+    through the kernel authorization/audit path (invariant I-07); the flow being
+    pre-compiled does not bypass execution authorization.
+    """
+
+    flow_id: str
+    name: Optional[str] = None
+    version: Optional[str] = None
+    description: Optional[str] = None
+    input_schema_ref: Optional[str] = None
+    output_schema_ref: Optional[str] = None
+    tool_dependencies: List[str] = field(default_factory=list)
+    sensitivity: Optional[str] = None
+    side_effects: List[str] = field(default_factory=list)
+    requires_authorization: bool = True
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.flow_id:
+            raise ValueError("CompiledFlow.flow_id must be non-empty")
+        if self.sensitivity is not None and self.sensitivity not in _SENSITIVITY_LEVELS:
+            raise ValueError(
+                f"CompiledFlow.sensitivity must be one of {_SENSITIVITY_LEVELS}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# ExecutionCandidate — something a router can select for execution
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ExecutionCandidate:
+    """Something that can be selected for execution: a tool, flow, capability,
+    agent, or workflow.
+
+    When ``candidate_type == "flow"`` the candidate may carry a ``compiled_flow``
+    detail (#66); for other kinds the candidate is identified by ``candidate_id``
+    plus optional ``version`` and the runtime resolves it. ``metadata`` carries
+    implementation-specific fields (namespace project-specific keys).
+    """
+
+    candidate_id: str
+    candidate_type: str
+    name: Optional[str] = None
+    version: Optional[str] = None
+    description: Optional[str] = None
+    compiled_flow: Optional[CompiledFlow] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.candidate_id:
+            raise ValueError("ExecutionCandidate.candidate_id must be non-empty")
+        if self.candidate_type not in _CANDIDATE_TYPES:
+            raise ValueError(
+                f"ExecutionCandidate.candidate_type must be one of {_CANDIDATE_TYPES}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# ExecutionRoutingDecision — a router's advisory recommendation
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ExecutionRoutingDecision:
+    """A router's recommendation of an ExecutionCandidate.
+
+    Advisory by default: it does NOT grant execution rights. The execution/policy
+    layer (agent-kernel or another compatible runtime) still decides whether the
+    caller may run the selected candidate, records a PolicyDecision, and emits a
+    TraceEvent (invariants I-02, I-07). ``decision_id`` correlates this decision
+    with downstream execution traces and ExecutionFeedback. Distinct from the
+    Core ``RoutingDecision`` (the contextweaver ChoiceCard wrapper).
+    """
+
+    decision_id: str
+    candidate: ExecutionCandidate
+    confidence: Optional[float] = None
+    reason_codes: List[str] = field(default_factory=list)
+    reason: Optional[str] = None
+    fallback_candidates: List[ExecutionCandidate] = field(default_factory=list)
+    constraints: Dict[str, Any] = field(default_factory=dict)
+    policy_context_ref: Optional[str] = None
+    trace_ref: Optional[str] = None
+    created_at: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.decision_id:
+            raise ValueError("ExecutionRoutingDecision.decision_id must be non-empty")
+        if self.confidence is not None and not 0.0 <= self.confidence <= 1.0:
+            raise ValueError(
+                "ExecutionRoutingDecision.confidence must be in [0.0, 1.0]"
+            )
+
+
+# ---------------------------------------------------------------------------
+# ExecutionFeedback — the observed outcome of executing a candidate
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ExecutionFeedback:
+    """The observed outcome of executing (or attempting to execute) a candidate.
+
+    Links back to the originating decision via ``decision_id`` and to the
+    selected item via ``candidate_id`` so a router or evaluator can correlate
+    recommendation, execution, and result. ``trace_ref`` preserves the execution
+    runtime's trace identifier (e.g. a ChainWeaver ``trace_id``) for end-to-end
+    correlation. Sending feedback is optional: a deterministic router need not
+    consume it (see docs/EXECUTION_BOUNDARY.md).
+    """
+
+    decision_id: str
+    candidate_id: str
+    success: bool
+    timestamp: str
+    latency_ms: Optional[int] = None
+    cost: Dict[str, Any] = field(default_factory=dict)
+    quality_score: Optional[float] = None
+    error_type: Optional[str] = None
+    error_message: Optional[str] = None
+    trace_ref: Optional[str] = None
+    execution_summary: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.decision_id:
+            raise ValueError("ExecutionFeedback.decision_id must be non-empty")
+        if not self.candidate_id:
+            raise ValueError("ExecutionFeedback.candidate_id must be non-empty")
+        if not self.timestamp:
+            raise ValueError("ExecutionFeedback.timestamp must be non-empty")
+        if self.latency_ms is not None and self.latency_ms < 0:
+            raise ValueError("ExecutionFeedback.latency_ms must be >= 0")
+        if self.quality_score is not None and not 0.0 <= self.quality_score <= 1.0:
+            raise ValueError("ExecutionFeedback.quality_score must be in [0.0, 1.0]")

--- a/contracts/python/src/weaver_contracts/extended.py
+++ b/contracts/python/src/weaver_contracts/extended.py
@@ -743,10 +743,11 @@ class ExecutionCandidate:
     """Something that can be selected for execution: a tool, flow, capability,
     agent, or workflow.
 
-    When ``candidate_type == "flow"`` the candidate may carry a ``compiled_flow``
-    detail (#66); for other kinds the candidate is identified by ``candidate_id``
-    plus optional ``version`` and the runtime resolves it. ``metadata`` carries
-    implementation-specific fields (namespace project-specific keys).
+    A ``compiled_flow`` detail (#66) is only valid when
+    ``candidate_type == "flow"``; for other kinds the candidate is identified by
+    ``candidate_id`` plus optional ``version`` and the runtime resolves it.
+    ``metadata`` carries implementation-specific fields (namespace
+    project-specific keys).
     """
 
     candidate_id: str
@@ -763,6 +764,11 @@ class ExecutionCandidate:
         if self.candidate_type not in _CANDIDATE_TYPES:
             raise ValueError(
                 f"ExecutionCandidate.candidate_type must be one of {_CANDIDATE_TYPES}"
+            )
+        if self.compiled_flow is not None and self.candidate_type != "flow":
+            raise ValueError(
+                "ExecutionCandidate.compiled_flow is only valid when "
+                'candidate_type == "flow"'
             )
 
 

--- a/contracts/python/tests/test_extended.py
+++ b/contracts/python/tests/test_extended.py
@@ -11,7 +11,11 @@ from weaver_contracts.extended import (
     ArtifactSafetyGateRequest,
     ArtifactSafetyReport,
     CapabilityTokenSignature,
+    CompiledFlow,
     EvaluationArtifact,
+    ExecutionCandidate,
+    ExecutionFeedback,
+    ExecutionRoutingDecision,
     ExtendedFrameMetadata,
     ExtendedSelectableItemMetadata,
     LessonCard,
@@ -942,3 +946,204 @@ class TestOtelTraceMapping:
         data = asdict(m)
         json.dumps(data)
         assert data["gen_ai_system"] == "weaver"
+
+
+# ---------------------------------------------------------------------------
+# Selection ↔ execution boundary contracts (#61, #66)
+# ---------------------------------------------------------------------------
+
+
+class TestCompiledFlow:
+    def test_valid_from_payload(self):
+        p = load_payload("compiled_flow")
+        flow = CompiledFlow(
+            flow_id=p["flow_id"],
+            name=p.get("name"),
+            version=p.get("version"),
+            description=p.get("description"),
+            input_schema_ref=p.get("input_schema_ref"),
+            output_schema_ref=p.get("output_schema_ref"),
+            tool_dependencies=p.get("tool_dependencies", []),
+            sensitivity=p.get("sensitivity"),
+            side_effects=p.get("side_effects", []),
+            requires_authorization=p.get("requires_authorization", True),
+            metadata=p.get("metadata", {}),
+        )
+        assert flow.flow_id == "invoice_reminder_flow"
+        assert flow.requires_authorization is True
+        assert "org.email.send_reminder" in flow.tool_dependencies
+
+    def test_defaults(self):
+        flow = CompiledFlow(flow_id="f1")
+        assert flow.requires_authorization is True
+        assert flow.tool_dependencies == []
+        assert flow.sensitivity is None
+
+    def test_empty_flow_id_raises(self):
+        with pytest.raises(ValueError, match="flow_id must be non-empty"):
+            CompiledFlow(flow_id="")
+
+    def test_invalid_sensitivity_raises(self):
+        with pytest.raises(ValueError, match="sensitivity must be one of"):
+            CompiledFlow(flow_id="f1", sensitivity="top-secret")
+
+    def test_serialization(self):
+        flow = CompiledFlow(flow_id="f1", side_effects=["data_write"])
+        data = asdict(flow)
+        json.dumps(data)
+        assert data["side_effects"] == ["data_write"]
+
+
+class TestExecutionCandidate:
+    def test_valid_from_payload(self):
+        p = load_payload("execution_candidate")
+        cf = p.get("compiled_flow")
+        candidate = ExecutionCandidate(
+            candidate_id=p["candidate_id"],
+            candidate_type=p["candidate_type"],
+            name=p.get("name"),
+            version=p.get("version"),
+            description=p.get("description"),
+            compiled_flow=CompiledFlow(
+                flow_id=cf["flow_id"],
+                name=cf.get("name"),
+                version=cf.get("version"),
+                description=cf.get("description"),
+                tool_dependencies=cf.get("tool_dependencies", []),
+                sensitivity=cf.get("sensitivity"),
+                side_effects=cf.get("side_effects", []),
+                requires_authorization=cf.get("requires_authorization", True),
+            )
+            if cf is not None
+            else None,
+            metadata=p.get("metadata", {}),
+        )
+        assert candidate.candidate_type == "flow"
+        assert candidate.compiled_flow is not None
+        assert candidate.compiled_flow.flow_id == "invoice_reminder_flow"
+
+    def test_minimal_non_flow_candidate(self):
+        candidate = ExecutionCandidate(
+            candidate_id="send_invoice_reminder", candidate_type="tool"
+        )
+        assert candidate.compiled_flow is None
+
+    def test_empty_candidate_id_raises(self):
+        with pytest.raises(ValueError, match="candidate_id must be non-empty"):
+            ExecutionCandidate(candidate_id="", candidate_type="tool")
+
+    def test_invalid_candidate_type_raises(self):
+        with pytest.raises(ValueError, match="candidate_type must be one of"):
+            ExecutionCandidate(candidate_id="c1", candidate_type="macro")
+
+
+class TestExecutionRoutingDecision:
+    def _candidate(self) -> ExecutionCandidate:
+        return ExecutionCandidate(candidate_id="c1", candidate_type="flow")
+
+    def test_valid_from_payload(self):
+        p = load_payload("execution_routing_decision")
+        c = p["candidate"]
+        decision = ExecutionRoutingDecision(
+            decision_id=p["decision_id"],
+            candidate=ExecutionCandidate(
+                candidate_id=c["candidate_id"],
+                candidate_type=c["candidate_type"],
+                name=c.get("name"),
+                version=c.get("version"),
+            ),
+            confidence=p.get("confidence"),
+            reason_codes=p.get("reason_codes", []),
+            reason=p.get("reason"),
+            fallback_candidates=[
+                ExecutionCandidate(
+                    candidate_id=fc["candidate_id"],
+                    candidate_type=fc["candidate_type"],
+                    name=fc.get("name"),
+                )
+                for fc in p.get("fallback_candidates", [])
+            ],
+            constraints=p.get("constraints", {}),
+            policy_context_ref=p.get("policy_context_ref"),
+            trace_ref=p.get("trace_ref"),
+            created_at=p.get("created_at"),
+            metadata=p.get("metadata", {}),
+        )
+        assert decision.decision_id == "dec_123"
+        assert decision.candidate.candidate_id == "invoice_reminder_flow"
+        assert decision.confidence == 0.86
+        assert len(decision.fallback_candidates) == 1
+
+    def test_empty_decision_id_raises(self):
+        with pytest.raises(ValueError, match="decision_id must be non-empty"):
+            ExecutionRoutingDecision(decision_id="", candidate=self._candidate())
+
+    def test_confidence_above_range_raises(self):
+        with pytest.raises(ValueError, match="confidence must be in"):
+            ExecutionRoutingDecision(
+                decision_id="d1", candidate=self._candidate(), confidence=1.5
+            )
+
+    def test_confidence_below_range_raises(self):
+        with pytest.raises(ValueError, match="confidence must be in"):
+            ExecutionRoutingDecision(
+                decision_id="d1", candidate=self._candidate(), confidence=-0.1
+            )
+
+
+class TestExecutionFeedback:
+    def _kwargs(self, **overrides):
+        base = dict(
+            decision_id="dec_123",
+            candidate_id="invoice_reminder_flow",
+            success=True,
+            timestamp="2026-05-25T08:00:00Z",
+        )
+        base.update(overrides)
+        return base
+
+    def test_valid_from_payload(self):
+        p = load_payload("execution_feedback")
+        fb = ExecutionFeedback(
+            decision_id=p["decision_id"],
+            candidate_id=p["candidate_id"],
+            success=p["success"],
+            timestamp=p["timestamp"],
+            latency_ms=p.get("latency_ms"),
+            cost=p.get("cost", {}),
+            quality_score=p.get("quality_score"),
+            error_type=p.get("error_type"),
+            error_message=p.get("error_message"),
+            trace_ref=p.get("trace_ref"),
+            execution_summary=p.get("execution_summary", {}),
+            metadata=p.get("metadata", {}),
+        )
+        assert fb.success is True
+        assert fb.latency_ms == 842
+        assert fb.trace_ref == "chainweaver:trace_id:abc123"
+
+    def test_empty_decision_id_raises(self):
+        with pytest.raises(ValueError, match="decision_id must be non-empty"):
+            ExecutionFeedback(**self._kwargs(decision_id=""))
+
+    def test_empty_candidate_id_raises(self):
+        with pytest.raises(ValueError, match="candidate_id must be non-empty"):
+            ExecutionFeedback(**self._kwargs(candidate_id=""))
+
+    def test_empty_timestamp_raises(self):
+        with pytest.raises(ValueError, match="timestamp must be non-empty"):
+            ExecutionFeedback(**self._kwargs(timestamp=""))
+
+    def test_negative_latency_raises(self):
+        with pytest.raises(ValueError, match="latency_ms must be >= 0"):
+            ExecutionFeedback(**self._kwargs(latency_ms=-1))
+
+    def test_quality_score_out_of_range_raises(self):
+        with pytest.raises(ValueError, match="quality_score must be in"):
+            ExecutionFeedback(**self._kwargs(quality_score=1.1))
+
+    def test_serialization(self):
+        fb = ExecutionFeedback(**self._kwargs(success=False, error_type="timeout"))
+        data = asdict(fb)
+        json.dumps(data)
+        assert data["error_type"] == "timeout"

--- a/contracts/python/tests/test_extended.py
+++ b/contracts/python/tests/test_extended.py
@@ -1036,6 +1036,14 @@ class TestExecutionCandidate:
         with pytest.raises(ValueError, match="candidate_type must be one of"):
             ExecutionCandidate(candidate_id="c1", candidate_type="macro")
 
+    def test_compiled_flow_on_non_flow_candidate_raises(self):
+        with pytest.raises(ValueError, match="compiled_flow is only valid"):
+            ExecutionCandidate(
+                candidate_id="c1",
+                candidate_type="tool",
+                compiled_flow=CompiledFlow(flow_id="f1"),
+            )
+
 
 class TestExecutionRoutingDecision:
     def _candidate(self) -> ExecutionCandidate:

--- a/contracts/python/tests/test_extended_schema_alignment.py
+++ b/contracts/python/tests/test_extended_schema_alignment.py
@@ -307,6 +307,17 @@ class TestExtendedNegativeCases:
         payload = load_payload("execution_candidate")
         validate(payload, schema)
 
+    def test_execution_candidate_compiled_flow_on_non_flow_fails(self):
+        # compiled_flow is only valid when candidate_type == "flow" (if/then).
+        schema = load_extended_schema("execution_candidate")
+        bad = {
+            "candidate_id": "c1",
+            "candidate_type": "tool",
+            "compiled_flow": {"flow_id": "f1"},
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
     def test_execution_routing_decision_missing_candidate_fails(self):
         # candidate is required; a decision without one is invalid.
         schema = load_extended_schema("execution_routing_decision")

--- a/contracts/python/tests/test_extended_schema_alignment.py
+++ b/contracts/python/tests/test_extended_schema_alignment.py
@@ -26,7 +26,8 @@ PAYLOADS_DIR = REPO_ROOT / "examples" / "sample_payloads"
 # ExtendedFrameMetadata, ExtendedSelectableItemMetadata,
 # ReviewArtifact, MemoryArtifact, SessionHandoff, LessonCard, SkillCard,
 # EvaluationArtifact, ArtifactSafetyGateRequest, ArtifactSafetyReport,
-# CapabilityTokenSignature, OtelTraceMapping.
+# CapabilityTokenSignature, OtelTraceMapping, CompiledFlow,
+# ExecutionCandidate, ExecutionRoutingDecision, ExecutionFeedback.
 EXTENDED_TYPES = [
     ("TelemetryHint", "telemetry_hint"),
     ("SchemaFingerprint", "schema_fingerprint"),
@@ -45,6 +46,10 @@ EXTENDED_TYPES = [
     ("ArtifactSafetyReport", "artifact_safety_report"),
     ("CapabilityTokenSignature", "capability_token_signature"),
     ("OtelTraceMapping", "otel_trace_mapping"),
+    ("CompiledFlow", "compiled_flow"),
+    ("ExecutionCandidate", "execution_candidate"),
+    ("ExecutionRoutingDecision", "execution_routing_decision"),
+    ("ExecutionFeedback", "execution_feedback"),
 ]
 
 
@@ -271,6 +276,69 @@ class TestExtendedNegativeCases:
             "alg": "ed25519",
             "kid": "k1",
             "sig": "A" * 50,  # base64url alphabet, wrong length
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_compiled_flow_missing_required_fails(self):
+        # #66: flow_id is the only required field.
+        schema = load_extended_schema("compiled_flow")
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate({"name": "no id"}, schema)
+
+    def test_compiled_flow_invalid_sensitivity_fails(self):
+        # sensitivity must be one of the shared artifact sensitivity levels.
+        schema = load_extended_schema("compiled_flow")
+        bad = {"flow_id": "f1", "sensitivity": "top-secret"}
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_execution_candidate_invalid_type_fails(self):
+        # #61 open question 1 settled: candidate_type is a fixed enum.
+        schema = load_extended_schema("execution_candidate")
+        bad = {"candidate_id": "c1", "candidate_type": "macro"}
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_execution_candidate_with_compiled_flow_validates(self):
+        # candidate_type=flow may embed a CompiledFlow via $ref; this must
+        # resolve against the local schema store and validate.
+        schema = load_extended_schema("execution_candidate")
+        payload = load_payload("execution_candidate")
+        validate(payload, schema)
+
+    def test_execution_routing_decision_missing_candidate_fails(self):
+        # candidate is required; a decision without one is invalid.
+        schema = load_extended_schema("execution_routing_decision")
+        bad = {"decision_id": "dec_1"}
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_execution_routing_decision_confidence_above_range_fails(self):
+        # #61 open question 2 settled: confidence is standardized to [0.0, 1.0].
+        schema = load_extended_schema("execution_routing_decision")
+        bad = {
+            "decision_id": "dec_1",
+            "candidate": {"candidate_id": "c1", "candidate_type": "tool"},
+            "confidence": 1.5,
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_execution_feedback_missing_required_fails(self):
+        schema = load_extended_schema("execution_feedback")
+        bad = {"decision_id": "dec_1", "candidate_id": "c1"}  # no success/timestamp
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_execution_feedback_negative_latency_fails(self):
+        schema = load_extended_schema("execution_feedback")
+        bad = {
+            "decision_id": "dec_1",
+            "candidate_id": "c1",
+            "success": True,
+            "timestamp": "2026-05-25T08:00:00Z",
+            "latency_ms": -1,
         }
         with pytest.raises(AssertionError, match="Schema validation failed"):
             validate(bad, schema)

--- a/docs/EXECUTION_BOUNDARY.md
+++ b/docs/EXECUTION_BOUNDARY.md
@@ -1,0 +1,167 @@
+# Selection ↔ Execution Boundary
+
+This page defines the implementation-neutral contracts for the boundary between
+*selecting* a unit of work and *executing* it: `ExecutionCandidate`,
+`ExecutionRoutingDecision`, `ExecutionFeedback`, and the `CompiledFlow` detail.
+All four are **Extended** contracts (optional; not required for spec
+compliance). Their JSON Schemas live under
+[`contracts/json/extended/`](../contracts/json/extended/) and their Python
+mirrors in [`weaver_contracts.extended`](../contracts/python/src/weaver_contracts/extended.py).
+
+> [!NOTE]
+> These contracts exist so that a static router, the `contextweaver` ChoiceCard
+> layer, and a learned/feedback-aware external router can all describe a
+> selection the same way, instead of each integration inventing its own
+> router-to-executor payload. They were motivated by the ChainWeaver routing
+> discussion but are deliberately generic (issues #61 and #66).
+
+---
+
+## Why a separate `ExecutionRoutingDecision`
+
+The Core [`RoutingDecision`](../contracts/json/routing_decision.schema.json) is
+the `contextweaver` artifact that wraps one or more `ChoiceCard`s with selection
+state. It is intentionally kept separate from the generic decision type defined
+here — see the "Design decisions not to reopen" table in
+[`AGENTS.md`](../AGENTS.md). To avoid conflating the two, the generic,
+runtime-neutral decision is named **`ExecutionRoutingDecision`**.
+
+---
+
+## The contracts
+
+### `ExecutionCandidate`
+
+Something that can be selected for execution. `candidate_type` is a fixed enum:
+`tool`, `flow`, `capability`, `agent`, `workflow`. A runtime is not required to
+support every kind. When `candidate_type` is `flow`, the candidate may carry a
+`compiled_flow` detail.
+
+### `CompiledFlow`
+
+A compiled flow (e.g. a ChainWeaver flow) exposed as an item that can be routed
+to and executed like a capability. It **references** (does not inline) its
+input/output schemas, lists the capability IDs it depends on internally
+(`tool_dependencies`), and carries `sensitivity` and `side_effects` metadata
+typically derived from those tools.
+
+> [!IMPORTANT]
+> A `CompiledFlow` being pre-compiled does not bypass execution authorization. A
+> flow step that invokes a tool MUST still delegate to the execution layer's
+> authorization and audit path (invariant
+> [I-07](INVARIANTS.md#i-07-chainweaver-delegates-execution-to-the-kernel)).
+> `requires_authorization` defaults to `true`.
+
+### `ExecutionRoutingDecision`
+
+A router's recommendation of an `ExecutionCandidate`, with optional
+`confidence` (standardized to `[0.0, 1.0]`), machine-readable `reason_codes`,
+ordered `fallback_candidates`, router-side `constraints`, and references for
+policy context and tracing. `decision_id` correlates the decision with
+downstream execution traces and feedback.
+
+> [!IMPORTANT]
+> An `ExecutionRoutingDecision` is **advisory**. It MUST NOT be treated as a
+> grant of execution rights. Before the selected candidate runs, the
+> execution/policy layer (agent-kernel or another Weaver-compatible runtime)
+> still validates a `CapabilityToken`, records a `PolicyDecision`, and emits a
+> `TraceEvent` (invariant
+> [I-02](INVARIANTS.md#i-02-every-execution-is-authorized-and-auditable)).
+> `policy_context_ref` is a reference the router considered, not an
+> authorization.
+
+### `ExecutionFeedback`
+
+The observed outcome of executing (or attempting to execute) the selected
+candidate. It links back via `decision_id` and `candidate_id`, carries
+`success`, optional `latency_ms`, `cost`, `quality_score` (also `[0.0, 1.0]`),
+error fields, and a `trace_ref` that preserves the execution runtime's trace
+identifier for end-to-end correlation.
+
+> [!NOTE]
+> Sending feedback is optional. A deterministic router need not consume it;
+> `contextweaver` stays deterministic by default and may ignore feedback. A
+> feedback-aware external router can use it to score future decisions.
+
+---
+
+## Example: `contextweaver` → ChainWeaver flow selection
+
+**Example:** a routing decision selecting a compiled ChainWeaver flow. See
+[`examples/sample_payloads/execution_routing_decision.json`](../examples/sample_payloads/execution_routing_decision.json).
+
+```json
+{
+  "decision_id": "dec_123",
+  "candidate": {
+    "candidate_id": "invoice_reminder_flow",
+    "candidate_type": "flow",
+    "version": "1.2.0",
+    "compiled_flow": {
+      "flow_id": "invoice_reminder_flow",
+      "version": "1.2.0",
+      "tool_dependencies": [
+        "org.billing.list_unpaid_invoices",
+        "org.email.send_reminder"
+      ],
+      "sensitivity": "confidential",
+      "side_effects": ["external_email", "data_read"],
+      "requires_authorization": true
+    }
+  },
+  "confidence": 0.86,
+  "reason_codes": ["capability_match", "low_latency", "historical_success"]
+}
+```
+
+---
+
+## Example: external router → ChainWeaver → feedback
+
+The contracts support this pattern without making the external router a
+ChainWeaver dependency:
+
+```text
+user task
+  → external router produces an ExecutionRoutingDecision
+  → host application validates policy/auth (PolicyDecision + TraceEvent)
+  → ChainWeaver resolves the selected flow
+  → ChainWeaver executes the deterministic flow
+  → the execution trace is converted into ExecutionFeedback
+  → feedback is sent back to the router or stored for evaluation
+```
+
+**Example:** feedback preserving the ChainWeaver trace id. See
+[`examples/sample_payloads/execution_feedback.json`](../examples/sample_payloads/execution_feedback.json).
+
+```json
+{
+  "decision_id": "dec_123",
+  "candidate_id": "invoice_reminder_flow",
+  "success": true,
+  "timestamp": "2026-05-25T08:00:00Z",
+  "latency_ms": 842,
+  "quality_score": 0.9,
+  "trace_ref": "chainweaver:trace_id:abc123"
+}
+```
+
+---
+
+## Non-goals
+
+These contracts do not define a routing algorithm, do not require learned
+routing or an online decision service, do not make ChainWeaver depend on any
+router, do not make `contextweaver` depend on feedback by default, and do not
+let a routing decision bypass authorization, policy, or audit layers.
+
+---
+
+## Related
+
+- [docs/INVARIANTS.md](INVARIANTS.md) — I-02 (authorized + auditable execution),
+  I-07 (ChainWeaver delegates execution).
+- [docs/BOUNDARIES.md](BOUNDARIES.md) — responsibility boundaries and artifact
+  ownership across the routing and execution layers.
+- [docs/ARTIFACT_CONTRACTS.md](ARTIFACT_CONTRACTS.md) — the broader Extended
+  artifact vocabulary.

--- a/examples/sample_payloads/compiled_flow.json
+++ b/examples/sample_payloads/compiled_flow.json
@@ -1,0 +1,18 @@
+{
+  "flow_id": "invoice_reminder_flow",
+  "name": "Invoice reminder flow",
+  "version": "1.2.0",
+  "description": "Find unpaid invoices and send reminder emails.",
+  "input_schema_ref": "https://weaver-spec.dev/examples/schemas/invoice_reminder_input.json",
+  "output_schema_ref": "https://weaver-spec.dev/examples/schemas/invoice_reminder_output.json",
+  "tool_dependencies": [
+    "org.billing.list_unpaid_invoices",
+    "org.email.send_reminder"
+  ],
+  "sensitivity": "confidential",
+  "side_effects": ["external_email", "data_read"],
+  "requires_authorization": true,
+  "metadata": {
+    "runtime": "chainweaver"
+  }
+}

--- a/examples/sample_payloads/execution_candidate.json
+++ b/examples/sample_payloads/execution_candidate.json
@@ -1,0 +1,23 @@
+{
+  "candidate_id": "invoice_reminder_flow",
+  "candidate_type": "flow",
+  "name": "Invoice reminder flow",
+  "version": "1.2.0",
+  "description": "Find unpaid invoices and send reminder emails.",
+  "compiled_flow": {
+    "flow_id": "invoice_reminder_flow",
+    "name": "Invoice reminder flow",
+    "version": "1.2.0",
+    "description": "Find unpaid invoices and send reminder emails.",
+    "tool_dependencies": [
+      "org.billing.list_unpaid_invoices",
+      "org.email.send_reminder"
+    ],
+    "sensitivity": "confidential",
+    "side_effects": ["external_email", "data_read"],
+    "requires_authorization": true
+  },
+  "metadata": {
+    "runtime": "chainweaver"
+  }
+}

--- a/examples/sample_payloads/execution_feedback.json
+++ b/examples/sample_payloads/execution_feedback.json
@@ -1,0 +1,18 @@
+{
+  "decision_id": "dec_123",
+  "candidate_id": "invoice_reminder_flow",
+  "success": true,
+  "timestamp": "2026-05-25T08:00:00Z",
+  "latency_ms": 842,
+  "cost": {
+    "estimated_tokens_saved": 1200,
+    "estimated_cost_saved_usd": 0.02
+  },
+  "quality_score": 0.9,
+  "trace_ref": "chainweaver:trace_id:abc123",
+  "execution_summary": {
+    "flow_name": "invoice_reminder_flow",
+    "step_count": 4
+  },
+  "metadata": {}
+}

--- a/examples/sample_payloads/execution_routing_decision.json
+++ b/examples/sample_payloads/execution_routing_decision.json
@@ -1,0 +1,38 @@
+{
+  "decision_id": "dec_123",
+  "candidate": {
+    "candidate_id": "invoice_reminder_flow",
+    "candidate_type": "flow",
+    "name": "Invoice reminder flow",
+    "version": "1.2.0",
+    "compiled_flow": {
+      "flow_id": "invoice_reminder_flow",
+      "version": "1.2.0",
+      "tool_dependencies": [
+        "org.billing.list_unpaid_invoices",
+        "org.email.send_reminder"
+      ],
+      "sensitivity": "confidential",
+      "side_effects": ["external_email", "data_read"],
+      "requires_authorization": true
+    }
+  },
+  "confidence": 0.86,
+  "reason_codes": ["capability_match", "low_latency", "historical_success"],
+  "reason": "Selected because it matches the requested capability and has strong historical success.",
+  "fallback_candidates": [
+    {
+      "candidate_id": "generic_email_workflow",
+      "candidate_type": "workflow",
+      "name": "Generic email workflow"
+    }
+  ],
+  "constraints": {
+    "max_latency_ms": 2000,
+    "prefer_low_cost": true
+  },
+  "policy_context_ref": "agent-kernel:policy-ctx:abc",
+  "trace_ref": "router:trace:abc123",
+  "created_at": "2026-05-25T07:59:00Z",
+  "metadata": {}
+}

--- a/well-known/contracts.json
+++ b/well-known/contracts.json
@@ -107,7 +107,7 @@
       "version": "v0",
       "$id": "https://weaver-spec.dev/contracts/v0/extended/execution_candidate.schema.json",
       "path": "contracts/json/extended/execution_candidate.schema.json",
-      "sha256": "3fd869e5c0b5bda9a8d847fe93980959c5d8a31d8dd5fdd34c590df20fc26ba1"
+      "sha256": "55425ac4bb62a9e2e2466a88af270827c77953232d6b0c302ce18c4c336b4c0a"
     },
     {
       "name": "execution_feedback",

--- a/well-known/contracts.json
+++ b/well-known/contracts.json
@@ -93,7 +93,7 @@
       "version": "v0",
       "$id": "https://weaver-spec.dev/contracts/v0/extended/compiled_flow.schema.json",
       "path": "contracts/json/extended/compiled_flow.schema.json",
-      "sha256": "8b2e26c79913c0cb4b42b15e87b98c071f0e49817f8b33f69ebb4794d56fea39"
+      "sha256": "0dc2a8ddfc9b3b8d33f85d442661fe696639e56184c2d89d812ab9cbf0082829"
     },
     {
       "name": "evaluation_artifact",
@@ -121,7 +121,7 @@
       "version": "v0",
       "$id": "https://weaver-spec.dev/contracts/v0/extended/execution_routing_decision.schema.json",
       "path": "contracts/json/extended/execution_routing_decision.schema.json",
-      "sha256": "81d04e517625a196691960fc8f7fcfcb2017c7e7a39abe7024f4f2837af9c001"
+      "sha256": "5f9834fdcd48b53c3c29d20abe295625e34d504a9ea068dbfafac1d4c9ae5d61"
     },
     {
       "name": "extended_frame_metadata",

--- a/well-known/contracts.json
+++ b/well-known/contracts.json
@@ -89,11 +89,39 @@
       "sha256": "0b214fa8fa77bc0859584acd68e767f239716e4e43c3d782cec063517b2e7f92"
     },
     {
+      "name": "compiled_flow",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/compiled_flow.schema.json",
+      "path": "contracts/json/extended/compiled_flow.schema.json",
+      "sha256": "8b2e26c79913c0cb4b42b15e87b98c071f0e49817f8b33f69ebb4794d56fea39"
+    },
+    {
       "name": "evaluation_artifact",
       "version": "v0",
       "$id": "https://weaver-spec.dev/contracts/v0/extended/evaluation_artifact.schema.json",
       "path": "contracts/json/extended/evaluation_artifact.schema.json",
       "sha256": "11b7a02fd3d13881ccfcc85e22e57cf5292411e23f80993d7956d5c474a6af52"
+    },
+    {
+      "name": "execution_candidate",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/execution_candidate.schema.json",
+      "path": "contracts/json/extended/execution_candidate.schema.json",
+      "sha256": "3fd869e5c0b5bda9a8d847fe93980959c5d8a31d8dd5fdd34c590df20fc26ba1"
+    },
+    {
+      "name": "execution_feedback",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/execution_feedback.schema.json",
+      "path": "contracts/json/extended/execution_feedback.schema.json",
+      "sha256": "60478a8f29caf35f964cfbe9abcf66ab0f5a58da1d908f3ae21458933229579c"
+    },
+    {
+      "name": "execution_routing_decision",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/execution_routing_decision.schema.json",
+      "path": "contracts/json/extended/execution_routing_decision.schema.json",
+      "sha256": "81d04e517625a196691960fc8f7fcfcb2017c7e7a39abe7024f4f2837af9c001"
     },
     {
       "name": "extended_frame_metadata",


### PR DESCRIPTION
## Description

Adds four implementation-neutral **Extended** contracts for the boundary between *selecting* a unit of work and *executing* it. They let a static router, the `contextweaver` ChoiceCard layer, and a feedback-aware external router all describe a selection the same way, instead of each integration inventing its own router-to-executor payload. Combines **#61** (generic candidate/decision/feedback contracts) and **#66** (compiled flow contract) — they share one implementation path because a compiled flow *is* a `candidate_type=flow` `ExecutionCandidate`.

**New types (each ships the full eight-artifact Extended set):**

- **`ExecutionCandidate`** — selectable unit; `candidate_type` is a fixed enum (`tool` / `flow` / `capability` / `agent` / `workflow`).
- **`CompiledFlow`** (#66) — a compiled flow (e.g. ChainWeaver) exposed as a routable, executable item. References (does not inline) its I/O schemas, lists internal `tool_dependencies`, carries derived `sensitivity` / `side_effects`. `requires_authorization` defaults to `true` — a pre-compiled flow does not bypass the kernel auth path (**I-07**). Attaches to an `ExecutionCandidate` via `$ref`.
- **`ExecutionRoutingDecision`** — a router's **advisory** recommendation. Named distinctly from the Core `RoutingDecision` (see below). Does **not** grant execution rights; the execution/policy layer still records a `PolicyDecision` and emits a `TraceEvent` before running (**I-02**).
- **`ExecutionFeedback`** — observed execution outcome, correlated by `decision_id` / `candidate_id`, preserving the runtime `trace_ref`. Consuming feedback is optional, keeping deterministic routers deterministic.

Files: 4 JSON Schemas under `contracts/json/extended/`, 4 Python dataclasses in `extended.py` (with `__post_init__` enum/range validation mirroring the schemas), 4 sample payloads (incl. a `contextweaver`→ChainWeaver routing example and an external-router→ChainWeaver→feedback example), roundtrip tests (`test_extended.py`), schema-alignment + 8 negative tests (`test_extended_schema_alignment.py`), new normative `docs/EXECUTION_BOUNDARY.md`, README + AGENTS.md doc maps, regenerated `contracts/COVERAGE.md` + `well-known/contracts.json`.

---

## Type of change

- [x] Additive contract change (new optional types — non-breaking)
- [ ] Docs only / Breaking / CI

---

## Six-artifact checklist

These are **Extended** contracts, so the Extended eight-artifact workflow (`docs/agent-context/workflows.md`) applies rather than the Core six-artifact rule. All satisfied:

- [x] JSON Schemas — `contracts/json/extended/{compiled_flow,execution_candidate,execution_routing_decision,execution_feedback}.schema.json`
- [x] Python dataclasses — `extended.py` (Core `core.py` untouched → **N/A** for the Core list)
- [x] Sample payloads — 4 new under `examples/sample_payloads/`
- [x] Roundtrip + schema-alignment tests — `test_extended.py`, `test_extended_schema_alignment.py` (Core `test_roundtrip_examples.py` → **N/A**)
- [x] CHANGELOG entry added
- [x] Version — **N/A** (see decision below): folded into the already-unreleased `0.6.0` set; no Core change, no further bump

---

## Settled design decisions / spec deltas (Mode B)

- **Naming delta from #61:** the issue calls the generic decision `RoutingDecision`, but the Core `RoutingDecision` (contextweaver ChoiceCard wrapper) is protected under AGENTS.md "Design decisions not to reopen". To avoid conflation it is named **`ExecutionRoutingDecision`**.
- **Versioning:** no tags exist; `0.6.0` is the current *unreleased* set (last release `0.5.0`). These additive Extended contracts are folded into the unreleased `0.6.0` bundle — no second bump. *(Alternative considered: cut `0.7.0`; rejected because it would skip an unreleased `0.6.0` and the existing "bumped to 0.6.0" changelog narrative.)*
- **#61 open questions:** `candidate_type` = fixed enum (Q1); `confidence` and `quality_score` standardized to `[0.0, 1.0]`, enforced in schema (`minimum`/`maximum`) **and** Python `__post_init__` (Q2/Q3); `fallback_candidates` live on the decision (Q4); `policy_context_ref` optional + advisory-only (Q5); `trace_ref` = free-form string (Q6); JSON Schema **and** dataclasses provided (Q7).
- **No ADR:** purely additive Extended contracts, no Core change, not breaking → no ADR/3-day process required.

---

## Deprecations

- [x] N/A — no deprecation in this PR

---

## Invariants

- [x] Verified I-01–I-07 not violated. The new contracts **reinforce** I-02 (decision is advisory; `PolicyDecision` + `TraceEvent` still required) and I-07 (`CompiledFlow.requires_authorization` defaults true; flows delegate to the kernel) in both schema descriptions and `docs/EXECUTION_BOUNDARY.md`. No raw-output field is introduced (I-01).

---

## Cross-repo impact

Opt-in Extended contracts — no sibling repo is required to adopt them; no Core contract changed. When adopted:

- **contextweaver** — may emit `ExecutionRoutingDecision` / `ExecutionCandidate` from its routing phase (in addition to the Core `RoutingDecision`); stays deterministic by default (need not consume feedback).
- **agent-kernel** — may consume an `ExecutionRoutingDecision` as advisory input; still owns authorization/audit (`PolicyDecision` + `TraceEvent`). May treat a `CompiledFlow` as an executable capability.
- **ChainWeaver** — may export a flow as a `CompiledFlow` and convert an execution trace into `ExecutionFeedback`, without a runtime dependency on any router.

- [x] Sibling updates are optional (no coordinated update required to merge)

---

## How verified

- `pytest --cov` — **262 passed**, total coverage **94.49%** (≥80% gate).
- `mypy src/` — **Success: no issues found in 4 source files**.
- `python scripts/check_schema_fields.py` — **Validated 30 schema(s)**.
- `python scripts/generate_contracts_index.py --check` and `generate_coverage_table.py --check` — both **up to date** (30 types; all four new types show full 5-artifact coverage).
- `pre-commit run --all-files` — all hooks **Passed** (markdownlint-cli2, yamllint, JSON/YAML/TOML, schema fields, contracts-index, compatibility manifest).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_0175mu5w3a5UcC7612HfL6R3

---
_Generated by [Claude Code](https://claude.ai/code/session_0175mu5w3a5UcC7612HfL6R3)_