### PR TITLE
contracts: add TraceBundle and FailureCaseArtifact Extended contracts (#50, #72)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,5 +2,6 @@
   "MD013": false,
   "MD024": { "siblings_only": true },
   "MD033": false,
-  "MD041": false
+  "MD041": false,
+  "MD060": false
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,8 +216,9 @@ For mixed changes, use the prefix for the most impactful change. Mention the sec
 | [docs/DEPRECATIONS.md](docs/DEPRECATIONS.md) | Deprecation register and removal policy |
 | [docs/SCHEMA_HOSTING.md](docs/SCHEMA_HOSTING.md) | `$id` URL pattern, immutability rule, content-addressed index |
 | [docs/DOCS_CONVENTIONS.md](docs/DOCS_CONVENTIONS.md) | Markup convention for normative requirements vs informative notes vs examples |
-| [docs/ARTIFACT_CONTRACTS.md](docs/ARTIFACT_CONTRACTS.md) | Cross-project Extended artifact vocabulary (memory, session handoff, lesson/skill cards, evaluation, safety gate) |
+| [docs/ARTIFACT_CONTRACTS.md](docs/ARTIFACT_CONTRACTS.md) | Cross-project Extended artifact vocabulary (memory, session handoff, lesson/skill cards, evaluation, safety gate, failure case) |
 | [docs/EXECUTION_BOUNDARY.md](docs/EXECUTION_BOUNDARY.md) | Selection ↔ execution boundary Extended contracts (ExecutionCandidate, CompiledFlow, ExecutionRoutingDecision, ExecutionFeedback) |
+| [docs/TRACE_BUNDLE.md](docs/TRACE_BUNDLE.md) | TraceBundle Extended contract: end-to-end audit-chain envelope (inlines RoutingDecision + PolicyDecisions + Frames + Handles + TraceEvents; optional JCS signature) |
 | [docs/ECOSYSTEM.md](docs/ECOSYSTEM.md) | Derived ecosystem boundary map (owns/consumes/emits per project, end-to-end lifecycle); points to BOUNDARIES.md/LIFECYCLE.md as canonical |
 | [docs/agent-context/architecture.md](docs/agent-context/architecture.md) | Pointers to canonical architecture and boundary docs |
 | [docs/agent-context/workflows.md](docs/agent-context/workflows.md) | Authoritative commands, change sequences, documentation governance |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
     signature type; an absent signature means unsigned. Redefines no invariant
     (Frames stay free of raw output, I-01; each PolicyDecision is still expected
     to have a matching TraceEvent, I-02). Signed + unsigned sample payloads and
-    the normative `docs/TRACE_BUNDLE.md`. Closes #50.
+    the normative `docs/TRACE_BUNDLE.md`. Part of #50 — the contract, schema,
+    payloads, and an interim I-01/I-02 sample test land here; conformance-runner
+    verification of bundle integrity + invariants is tracked in #74 (depends on
+    the conformance runner, #43).
   - **`FailureCaseArtifact`** — a small record of a replayable failure
     discovered by fuzzing / property testing / replay, capturing the failed
     `property_name`, reproduction inputs (`seed`, `generator_config`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
 
 ### Added
 
+- **Audit-chain and replayable-failure Extended contracts.** Two new
+  implementation-neutral Extended contracts, folded into the unreleased `0.6.0`
+  set (additive, no Core change, no version bump — consistent with the prior
+  Extended-contract additions in this release window).
+  - **`TraceBundle`** — a tamper-evident audit-chain envelope that *inlines* one
+    request's Core artifacts (`routing_decision`, `policy_decisions`, `frames`,
+    `handles`, `trace_events`) so the chain can be canonicalized (RFC 8785 JCS)
+    and optionally signed. The full chain is required (a bundle describes a
+    complete request); each member is validated against its Core schema via
+    `$ref`. The optional `signature` reuses the `CapabilityTokenSignature`
+    shape applied to the canonicalized bundle rather than inventing a second
+    signature type; an absent signature means unsigned. Redefines no invariant
+    (Frames stay free of raw output, I-01; each PolicyDecision is still expected
+    to have a matching TraceEvent, I-02). Signed + unsigned sample payloads and
+    the normative `docs/TRACE_BUNDLE.md`. Closes #50.
+  - **`FailureCaseArtifact`** — a small record of a replayable failure
+    discovered by fuzzing / property testing / replay, capturing the failed
+    `property_name`, reproduction inputs (`seed`, `generator_config`,
+    `trace_ref`), `minimized` provenance, and a lifecycle `status`
+    (`candidate` / `regression` / `ignored` / `fixed`). It *references* large
+    artifacts rather than inlining them and is explicitly reproducible evidence,
+    not proof of a bug. Documented in `docs/ARTIFACT_CONTRACTS.md` alongside the
+    rest of the cross-project artifact family. Closes #72.
+  - JSON Schemas under `contracts/json/extended/`, Python dataclasses in
+    `extended.py` (with `__post_init__` enum/non-empty validation mirroring the
+    schemas), sample payloads, roundtrip tests in `test_extended.py`,
+    schema-alignment + negative tests in `test_extended_schema_alignment.py`.
+    `contracts/COVERAGE.md` and `well-known/contracts.json` regenerated.
+    Cross-repo impact: Extended/opt-in only — contextweaver, agent-kernel, and
+    ChainWeaver may emit these but are not required to; no migration needed.
 - **Selection ↔ execution boundary Extended contracts.** Four new
   implementation-neutral Extended contracts describing the boundary between
   selecting a unit of work and executing it, so static routers, the

--- a/contracts/COVERAGE.md
+++ b/contracts/COVERAGE.md
@@ -17,12 +17,12 @@ CI runs the same script with `--check` and fails if this file is stale.
 
 ## Summary
 
-- Total contract types: **30**
-- JSON Schemas: **30 / 30**
-- Python classes: **30 / 30**
-- Sample payloads: **30 / 30**
-- Roundtrip tests: **30 / 30**
-- Schema validation tests: **24 / 30**
+- Total contract types: **32**
+- JSON Schemas: **32 / 32**
+- Python classes: **32 / 32**
+- Sample payloads: **32 / 32**
+- Roundtrip tests: **32 / 32**
+- Schema validation tests: **26 / 32**
 
 ## Coverage table
 
@@ -58,6 +58,8 @@ CI runs the same script with `--check` and fails if this file is stale.
 | Extended | `ExecutionCandidate` | OK | OK | OK | OK | OK |
 | Extended | `ExecutionRoutingDecision` | OK | OK | OK | OK | OK |
 | Extended | `ExecutionFeedback` | OK | OK | OK | OK | OK |
+| Extended | `TraceBundle` | OK | OK | OK | OK | OK |
+| Extended | `FailureCaseArtifact` | OK | OK | OK | OK | OK |
 
 ## Legend
 

--- a/contracts/json/extended/failure_case_artifact.schema.json
+++ b/contracts/json/extended/failure_case_artifact.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/failure_case_artifact.schema.json",
+  "title": "FailureCaseArtifact",
+  "description": "Extended. A small, language-neutral record of a replayable failure discovered by fuzzing, property-based testing, replay, or trace analysis. It captures which property/invariant failed, what is needed to reproduce it (seed, generator config, trace reference), whether it was minimized, and its lifecycle status. It references large artifacts (traces) rather than inlining them. A FailureCaseArtifact is reproducible evidence, NOT proof of a bug by itself; triage decides whether a real defect exists. Distinct from a TraceBundle (which inlines a full audit chain) and from a ReviewArtifact (a generic review/trace interchange shape). See docs/ARTIFACT_CONTRACTS.md.",
+  "type": "object",
+  "required": ["failure_case_id", "created_at", "source_project", "property_name", "status"],
+  "properties": {
+    "failure_case_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique stable identifier for this failure case."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when the failure case was captured."
+    },
+    "source_project": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Project that discovered/produced this failure case (e.g. ChainWeaver, agent-kernel, contextweaver, lessonweaver)."
+    },
+    "property_name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Machine-readable name of the property or invariant that failed (e.g. `I-02-policy-decision-has-trace-event`, `flow_is_idempotent`)."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["candidate", "regression", "ignored", "fixed"],
+      "description": "Lifecycle state. `candidate` = newly discovered / under review; `regression` = promoted into a regression test; `ignored` = triaged as not actionable; `fixed` = the underlying defect has been resolved."
+    },
+    "property_description": {
+      "type": ["string", "null"],
+      "description": "Optional human-readable description of the property/invariant and how it was violated."
+    },
+    "severity": {
+      "type": ["string", "null"],
+      "enum": ["low", "medium", "high", "critical", null],
+      "description": "Optional triage severity."
+    },
+    "seed": {
+      "type": ["string", "null"],
+      "description": "Optional generator/fuzzer seed needed to reproduce the case. A string to stay language-neutral across arbitrarily large seeds."
+    },
+    "generator_config": {
+      "type": "object",
+      "description": "Optional generator/fuzzer configuration needed to reproduce the case (e.g. strategy, size bounds, framework version). Namespace project-specific keys.",
+      "additionalProperties": true
+    },
+    "trace_ref": {
+      "type": ["string", "null"],
+      "description": "Optional reference to where the captured trace lives (e.g. `chainweaver:trace_id:abc123`). Replayable cases should set this; manually captured cases may rely on `evidence_refs` instead."
+    },
+    "minimized": {
+      "type": "boolean",
+      "description": "Whether the case has been minimized/shrunk to a smaller reproducer.",
+      "default": false
+    },
+    "minimized_from_ref": {
+      "type": ["string", "null"],
+      "description": "Optional reference to the original, un-minimized failure case this was reduced from."
+    },
+    "expected_failure_mode": {
+      "type": ["string", "null"],
+      "description": "Optional description of how the failure manifests when replayed (e.g. `raises TimeoutError`, `frame contains raw_output marker`)."
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "References to supporting evidence (traces, logs, payloads, TraceBundles)."
+    },
+    "sensitivity": {
+      "type": "string",
+      "enum": ["public", "internal", "confidential", "restricted"],
+      "description": "Sensitivity of the failure case (a reproducer may embed sensitive inputs).",
+      "default": "internal"
+    },
+    "provenance": {
+      "type": "object",
+      "description": "Optional structured record of how/why the artifact was derived.",
+      "additionalProperties": true
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional implementation-specific metadata. Namespace project-specific keys.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/json/extended/trace_bundle.schema.json
+++ b/contracts/json/extended/trace_bundle.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/trace_bundle.schema.json",
+  "title": "TraceBundle",
+  "description": "Extended. A tamper-evident audit-chain envelope that gathers one end-to-end request's Core artifacts into a single document: the RoutingDecision, every PolicyDecision, every Frame, every Handle, and every TraceEvent. The bundle is canonicalized (RFC 8785 JCS) so it can be hashed and, optionally, signed with the same detached-signature shape as a CapabilityToken (CapabilityTokenSignature). It does not redefine any invariant: Frames remain free of raw output (I-01) and each PolicyDecision is still expected to have a matching TraceEvent (I-02). Distinct from a FailureCaseArtifact (which references rather than inlines a trace). See docs/TRACE_BUNDLE.md.",
+  "type": "object",
+  "required": ["bundle_id", "routing_decision", "policy_decisions", "frames", "handles", "trace_events"],
+  "properties": {
+    "bundle_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for this bundle."
+    },
+    "routing_decision": {
+      "$ref": "https://weaver-spec.dev/contracts/v0/routing_decision.schema.json",
+      "description": "The Core RoutingDecision that opened this request's audit chain."
+    },
+    "policy_decisions": {
+      "type": "array",
+      "items": {
+        "$ref": "https://weaver-spec.dev/contracts/v0/policy_decision.schema.json"
+      },
+      "description": "Every PolicyDecision recorded for this request. May be empty only if no capability was authorized; each entry should have a matching TraceEvent (invariant I-02)."
+    },
+    "frames": {
+      "type": "array",
+      "items": {
+        "$ref": "https://weaver-spec.dev/contracts/v0/frame.schema.json"
+      },
+      "description": "Every safe-to-display Frame produced during this request. Frames never carry raw output (invariant I-01)."
+    },
+    "handles": {
+      "type": "array",
+      "items": {
+        "$ref": "https://weaver-spec.dev/contracts/v0/handle.schema.json"
+      },
+      "description": "Every opaque Handle referenced by the Frames in this bundle."
+    },
+    "trace_events": {
+      "type": "array",
+      "items": {
+        "$ref": "https://weaver-spec.dev/contracts/v0/trace_event.schema.json"
+      },
+      "description": "The append-only TraceEvents for this request, in emission order."
+    },
+    "canonicalization": {
+      "type": "string",
+      "enum": ["JCS"],
+      "description": "Canonicalization scheme applied to the bundle before hashing/signing. JCS = JSON Canonicalization Scheme (RFC 8785). The `signature` field itself is excluded from the canonical form before hashing.",
+      "default": "JCS"
+    },
+    "signature": {
+      "$ref": "https://weaver-spec.dev/contracts/v0/extended/capability_token_signature.schema.json",
+      "description": "Optional detached signature over the JCS-canonicalized bundle (the same signature shape used for CapabilityTokens). When absent, the bundle is unsigned; producers MUST NOT describe an unsigned bundle as signed."
+    },
+    "created_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "Optional ISO 8601 timestamp of when the bundle was assembled."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional implementation-specific metadata. Namespace project-specific keys.",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/python/src/weaver_contracts/extended.py
+++ b/contracts/python/src/weaver_contracts/extended.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from .core import Frame, Handle, PolicyDecision, RoutingDecision, TraceEvent
+
 
 # ---------------------------------------------------------------------------
 # TelemetryHint — attached to any contract for observability enrichment
@@ -849,3 +851,120 @@ class ExecutionFeedback:
             raise ValueError("ExecutionFeedback.latency_ms must be >= 0")
         if self.quality_score is not None and not 0.0 <= self.quality_score <= 1.0:
             raise ValueError("ExecutionFeedback.quality_score must be in [0.0, 1.0]")
+
+
+# ===========================================================================
+# Audit-chain and replayable-failure artifacts
+#
+# TraceBundle (#50) is a tamper-evident envelope that *inlines* one request's
+# Core audit chain (RoutingDecision + PolicyDecisions + Frames + Handles +
+# TraceEvents) so it can be canonicalized (RFC 8785 JCS) and optionally signed
+# with the same detached-signature shape as a CapabilityToken. It redefines no
+# invariant: Frames stay free of raw output (I-01) and each PolicyDecision is
+# still expected to have a matching TraceEvent (I-02).
+#
+# FailureCaseArtifact (#72) is the complement: a small record that *references*
+# a replayable failure (seed, generator config, trace ref) rather than inlining
+# it. It is reproducible evidence, not proof of a bug. Field-by-field docs:
+#   - docs/TRACE_BUNDLE.md
+#   - docs/ARTIFACT_CONTRACTS.md
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# TraceBundle — signed, JCS-canonicalized end-to-end audit-chain envelope
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TraceBundle:
+    """A tamper-evident audit-chain envelope for one end-to-end request.
+
+    Gathers the Core artifacts of a single request — the ``routing_decision``,
+    every ``policy_decisions`` entry, every ``frames`` entry, every ``handles``
+    entry, and every ``trace_events`` entry — so the chain can be canonicalized
+    (RFC 8785 JCS) and optionally signed. The full audit chain is required: a
+    TraceBundle describes a complete request, not a fragment. ``signature``
+    reuses the ``CapabilityTokenSignature`` shape; when absent the bundle is
+    unsigned and must not be described as signed. See ``docs/TRACE_BUNDLE.md``.
+    """
+
+    bundle_id: str
+    routing_decision: RoutingDecision
+    policy_decisions: List[PolicyDecision]
+    frames: List[Frame]
+    handles: List[Handle]
+    trace_events: List[TraceEvent]
+    canonicalization: str = "JCS"
+    signature: Optional[CapabilityTokenSignature] = None
+    created_at: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    _VALID_CANONICALIZATIONS = frozenset({"JCS"})
+
+    def __post_init__(self) -> None:
+        if not self.bundle_id:
+            raise ValueError("TraceBundle.bundle_id must be non-empty")
+        if self.canonicalization not in self._VALID_CANONICALIZATIONS:
+            raise ValueError(
+                "TraceBundle.canonicalization must be one of "
+                f"{self._VALID_CANONICALIZATIONS}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# FailureCaseArtifact — replayable failure discovered by fuzzing/replay/review
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FailureCaseArtifact:
+    """A replayable failure discovered by fuzzing, property testing, or replay.
+
+    Captures which ``property_name`` failed, what is needed to reproduce it
+    (``seed``, ``generator_config``, ``trace_ref``), whether it was
+    ``minimized``, and its lifecycle ``status``. References large artifacts
+    rather than inlining them. It is reproducible evidence, not proof of a bug
+    by itself — triage decides whether a real defect exists.
+    """
+
+    failure_case_id: str
+    created_at: str
+    source_project: str
+    property_name: str
+    status: str
+    property_description: Optional[str] = None
+    severity: Optional[str] = None
+    seed: Optional[str] = None
+    generator_config: Dict[str, Any] = field(default_factory=dict)
+    trace_ref: Optional[str] = None
+    minimized: bool = False
+    minimized_from_ref: Optional[str] = None
+    expected_failure_mode: Optional[str] = None
+    evidence_refs: List[str] = field(default_factory=list)
+    sensitivity: str = "internal"
+    provenance: Dict[str, Any] = field(default_factory=dict)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    _STATUSES = frozenset({"candidate", "regression", "ignored", "fixed"})
+    _SEVERITIES = frozenset({"low", "medium", "high", "critical"})
+
+    def __post_init__(self) -> None:
+        if not self.failure_case_id:
+            raise ValueError("FailureCaseArtifact.failure_case_id must be non-empty")
+        if not self.created_at:
+            raise ValueError("FailureCaseArtifact.created_at must be non-empty")
+        if not self.source_project:
+            raise ValueError("FailureCaseArtifact.source_project must be non-empty")
+        if not self.property_name:
+            raise ValueError("FailureCaseArtifact.property_name must be non-empty")
+        if self.status not in self._STATUSES:
+            raise ValueError(
+                f"FailureCaseArtifact.status must be one of {self._STATUSES}"
+            )
+        if self.severity is not None and self.severity not in self._SEVERITIES:
+            raise ValueError(
+                f"FailureCaseArtifact.severity must be one of {self._SEVERITIES}"
+            )
+        if self.sensitivity not in _SENSITIVITY_LEVELS:
+            raise ValueError(
+                f"FailureCaseArtifact.sensitivity must be one of {_SENSITIVITY_LEVELS}"
+            )

--- a/contracts/python/tests/test_extended.py
+++ b/contracts/python/tests/test_extended.py
@@ -3,10 +3,20 @@
 import json
 import pathlib
 from dataclasses import asdict
+from datetime import datetime
 from typing import Optional
 
 import pytest
 
+from weaver_contracts.core import (
+    ChoiceCard,
+    Frame,
+    Handle,
+    PolicyDecision,
+    RoutingDecision,
+    SelectableItem,
+    TraceEvent,
+)
 from weaver_contracts.extended import (
     ArtifactSafetyGateRequest,
     ArtifactSafetyReport,
@@ -18,6 +28,7 @@ from weaver_contracts.extended import (
     ExecutionRoutingDecision,
     ExtendedFrameMetadata,
     ExtendedSelectableItemMetadata,
+    FailureCaseArtifact,
     LessonCard,
     MemoryArtifact,
     OtelTraceMapping,
@@ -28,8 +39,14 @@ from weaver_contracts.extended import (
     SessionHandoff,
     SkillCard,
     TelemetryHint,
+    TraceBundle,
     UIHint,
 )
+
+
+def parse_dt(s: str) -> datetime:
+    """Parse an ISO 8601 string to a datetime (UTC)."""
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent.parent.parent
 PAYLOADS_DIR = REPO_ROOT / "examples" / "sample_payloads"
@@ -1155,3 +1172,254 @@ class TestExecutionFeedback:
         data = asdict(fb)
         json.dumps(data)
         assert data["error_type"] == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# Audit-chain and replayable-failure artifacts (#50, #72)
+# ---------------------------------------------------------------------------
+
+
+def _routing_decision_from(d: dict) -> RoutingDecision:
+    cards = [
+        ChoiceCard(
+            id=c["id"],
+            items=[
+                SelectableItem(
+                    id=it["id"],
+                    label=it["label"],
+                    description=it["description"],
+                    capability_id=it.get("capability_id"),
+                )
+                for it in c["items"]
+            ],
+            context_hint=c.get("context_hint"),
+        )
+        for c in d["choice_cards"]
+    ]
+    return RoutingDecision(
+        id=d["id"],
+        choice_cards=cards,
+        timestamp=parse_dt(d["timestamp"]),
+        selected_item_id=d.get("selected_item_id"),
+        selected_card_id=d.get("selected_card_id"),
+        context_summary=d.get("context_summary"),
+    )
+
+
+def _policy_decision_from(d: dict) -> PolicyDecision:
+    return PolicyDecision(
+        decision_id=d["decision_id"],
+        decision=d["decision"],
+        capability_id=d["capability_id"],
+        principal=d["principal"],
+        timestamp=parse_dt(d["timestamp"]),
+        token_id=d.get("token_id"),
+        reason=d.get("reason"),
+        metadata=d.get("metadata", {}),
+    )
+
+
+def _frame_from(d: dict) -> Frame:
+    return Frame(
+        frame_id=d["frame_id"],
+        capability_id=d["capability_id"],
+        summary=d["summary"],
+        created_at=parse_dt(d["created_at"]),
+        handle_refs=d.get("handle_refs", []),
+        redaction_notes=d.get("redaction_notes"),
+    )
+
+
+def _handle_from(d: dict) -> Handle:
+    return Handle(
+        handle_id=d["handle_id"],
+        capability_id=d["capability_id"],
+        artifact_type=d["artifact_type"],
+        created_at=parse_dt(d["created_at"]),
+        expires_at=parse_dt(d["expires_at"]) if d.get("expires_at") else None,
+        access_policy=d.get("access_policy"),
+        byte_size=d.get("byte_size"),
+        metadata=d.get("metadata", {}),
+    )
+
+
+def _trace_event_from(d: dict) -> TraceEvent:
+    return TraceEvent(
+        event_id=d["event_id"],
+        event_type=d["event_type"],
+        timestamp=parse_dt(d["timestamp"]),
+        capability_id=d.get("capability_id"),
+        principal=d.get("principal"),
+        decision_id=d.get("decision_id"),
+        frame_id=d.get("frame_id"),
+        handle_id=d.get("handle_id"),
+        outcome=d.get("outcome"),
+        error_message=d.get("error_message"),
+        metadata=d.get("metadata", {}),
+    )
+
+
+def _trace_bundle_from(p: dict) -> TraceBundle:
+    sig = p.get("signature")
+    return TraceBundle(
+        bundle_id=p["bundle_id"],
+        routing_decision=_routing_decision_from(p["routing_decision"]),
+        policy_decisions=[_policy_decision_from(d) for d in p["policy_decisions"]],
+        frames=[_frame_from(d) for d in p["frames"]],
+        handles=[_handle_from(d) for d in p["handles"]],
+        trace_events=[_trace_event_from(d) for d in p["trace_events"]],
+        canonicalization=p.get("canonicalization", "JCS"),
+        signature=(
+            CapabilityTokenSignature(
+                alg=sig["alg"],
+                kid=sig["kid"],
+                sig=sig["sig"],
+                canonicalization=sig.get("canonicalization", "JCS"),
+                signed_at=sig.get("signed_at"),
+            )
+            if sig is not None
+            else None
+        ),
+        created_at=p.get("created_at"),
+        metadata=p.get("metadata", {}),
+    )
+
+
+class TestTraceBundle:
+    # Core artifacts carry datetimes, so (like the Core roundtrip tests) this
+    # constructs from the payload and asserts; it does not asdict/json.dumps.
+    def test_unsigned_from_payload(self):
+        p = load_payload("trace_bundle")
+        bundle = _trace_bundle_from(p)
+        assert bundle.bundle_id == "tb-20260308-001"
+        assert bundle.routing_decision.id == "rd-20260308-001"
+        assert len(bundle.policy_decisions) == 1
+        assert bundle.policy_decisions[0].decision == "allow"
+        assert bundle.frames[0].frame_id == "frame-20260308-001"
+        assert bundle.handles[0].handle_id == "handle-rawresult-20260308-001"
+        assert bundle.trace_events[0].outcome == "success"
+        assert bundle.canonicalization == "JCS"
+        assert bundle.signature is None
+
+    def test_signed_from_payload(self):
+        p = load_payload("trace_bundle_signed")
+        bundle = _trace_bundle_from(p)
+        assert bundle.signature is not None
+        assert bundle.signature.alg == "ed25519"
+        assert bundle.signature.canonicalization == "JCS"
+
+    def test_invariant_frames_have_no_raw_output(self):
+        # I-01: Frames in a bundle expose no raw_output attribute.
+        p = load_payload("trace_bundle")
+        bundle = _trace_bundle_from(p)
+        assert all(not hasattr(f, "raw_output") for f in bundle.frames)
+
+    def _minimal_kwargs(self, **overrides):
+        base = dict(
+            bundle_id="tb-1",
+            routing_decision=_routing_decision_from(
+                load_payload("trace_bundle")["routing_decision"]
+            ),
+            policy_decisions=[],
+            frames=[],
+            handles=[],
+            trace_events=[],
+        )
+        base.update(overrides)
+        return base
+
+    def test_empty_bundle_id_raises(self):
+        with pytest.raises(ValueError, match="bundle_id must be non-empty"):
+            TraceBundle(**self._minimal_kwargs(bundle_id=""))
+
+    def test_invalid_canonicalization_raises(self):
+        with pytest.raises(ValueError, match="canonicalization must be one of"):
+            TraceBundle(**self._minimal_kwargs(canonicalization="sorted-keys"))
+
+    def test_defaults(self):
+        bundle = TraceBundle(**self._minimal_kwargs())
+        assert bundle.canonicalization == "JCS"
+        assert bundle.signature is None
+        assert bundle.created_at is None
+        assert bundle.metadata == {}
+
+
+class TestFailureCaseArtifact:
+    def _kwargs(self, **overrides):
+        base = dict(
+            failure_case_id="fc-1",
+            created_at="2026-05-28T14:12:00Z",
+            source_project="ChainWeaver",
+            property_name="flow_is_idempotent",
+            status="candidate",
+        )
+        base.update(overrides)
+        return base
+
+    def test_valid_from_payload(self):
+        p = load_payload("failure_case_artifact")
+        fc = FailureCaseArtifact(
+            failure_case_id=p["failure_case_id"],
+            created_at=p["created_at"],
+            source_project=p["source_project"],
+            property_name=p["property_name"],
+            status=p["status"],
+            property_description=p.get("property_description"),
+            severity=p.get("severity"),
+            seed=p.get("seed"),
+            generator_config=p.get("generator_config", {}),
+            trace_ref=p.get("trace_ref"),
+            minimized=p.get("minimized", False),
+            minimized_from_ref=p.get("minimized_from_ref"),
+            expected_failure_mode=p.get("expected_failure_mode"),
+            evidence_refs=p.get("evidence_refs", []),
+            sensitivity=p.get("sensitivity", "internal"),
+            provenance=p.get("provenance", {}),
+            metadata=p.get("metadata", {}),
+        )
+        assert fc.failure_case_id == "fc-20260528-001"
+        assert fc.status == "candidate"
+        assert fc.severity == "high"
+        assert fc.minimized is True
+        assert fc.trace_ref == "chainweaver:trace_id:abc123"
+
+    def test_empty_failure_case_id_raises(self):
+        with pytest.raises(ValueError, match="failure_case_id must be non-empty"):
+            FailureCaseArtifact(**self._kwargs(failure_case_id=""))
+
+    def test_empty_property_name_raises(self):
+        with pytest.raises(ValueError, match="property_name must be non-empty"):
+            FailureCaseArtifact(**self._kwargs(property_name=""))
+
+    def test_invalid_status_raises(self):
+        with pytest.raises(ValueError, match="status must be one of"):
+            FailureCaseArtifact(**self._kwargs(status="open"))
+
+    def test_invalid_severity_raises(self):
+        with pytest.raises(ValueError, match="severity must be one of"):
+            FailureCaseArtifact(**self._kwargs(severity="extreme"))
+
+    def test_invalid_sensitivity_raises(self):
+        with pytest.raises(ValueError, match="sensitivity must be one of"):
+            FailureCaseArtifact(**self._kwargs(sensitivity="secret"))
+
+    def test_all_statuses_accepted(self):
+        for status in ("candidate", "regression", "ignored", "fixed"):
+            fc = FailureCaseArtifact(**self._kwargs(status=status))
+            assert fc.status == status
+
+    def test_defaults(self):
+        fc = FailureCaseArtifact(**self._kwargs())
+        assert fc.severity is None
+        assert fc.minimized is False
+        assert fc.evidence_refs == []
+        assert fc.sensitivity == "internal"
+        assert fc.generator_config == {}
+
+    def test_serialization(self):
+        fc = FailureCaseArtifact(
+            **self._kwargs(status="regression", evidence_refs=["trace:x"])
+        )
+        data = asdict(fc)
+        json.dumps(data)
+        assert data["evidence_refs"] == ["trace:x"]

--- a/contracts/python/tests/test_extended.py
+++ b/contracts/python/tests/test_extended.py
@@ -1314,6 +1314,21 @@ class TestTraceBundle:
         bundle = _trace_bundle_from(p)
         assert all(not hasattr(f, "raw_output") for f in bundle.frames)
 
+    def test_invariant_policy_decisions_have_matching_trace_event(self):
+        # I-02: every PolicyDecision in the bundle has a matching TraceEvent,
+        # linked by decision_id (policy_decisions[*].decision_id is referenced
+        # by some trace_events[*].decision_id). Interim artifact-level lock-in
+        # until the conformance runner enforces this across arbitrary bundles
+        # (#74).
+        p = load_payload("trace_bundle")
+        bundle = _trace_bundle_from(p)
+        traced_decision_ids = {
+            te.decision_id for te in bundle.trace_events if te.decision_id is not None
+        }
+        assert bundle.policy_decisions, "sample bundle should exercise I-02"
+        for pd in bundle.policy_decisions:
+            assert pd.decision_id in traced_decision_ids
+
     def _minimal_kwargs(self, **overrides):
         base = dict(
             bundle_id="tb-1",

--- a/contracts/python/tests/test_extended_schema_alignment.py
+++ b/contracts/python/tests/test_extended_schema_alignment.py
@@ -27,7 +27,8 @@ PAYLOADS_DIR = REPO_ROOT / "examples" / "sample_payloads"
 # ReviewArtifact, MemoryArtifact, SessionHandoff, LessonCard, SkillCard,
 # EvaluationArtifact, ArtifactSafetyGateRequest, ArtifactSafetyReport,
 # CapabilityTokenSignature, OtelTraceMapping, CompiledFlow,
-# ExecutionCandidate, ExecutionRoutingDecision, ExecutionFeedback.
+# ExecutionCandidate, ExecutionRoutingDecision, ExecutionFeedback,
+# TraceBundle, FailureCaseArtifact.
 EXTENDED_TYPES = [
     ("TelemetryHint", "telemetry_hint"),
     ("SchemaFingerprint", "schema_fingerprint"),
@@ -50,6 +51,8 @@ EXTENDED_TYPES = [
     ("ExecutionCandidate", "execution_candidate"),
     ("ExecutionRoutingDecision", "execution_routing_decision"),
     ("ExecutionFeedback", "execution_feedback"),
+    ("TraceBundle", "trace_bundle"),
+    ("FailureCaseArtifact", "failure_case_artifact"),
 ]
 
 
@@ -350,6 +353,90 @@ class TestExtendedNegativeCases:
             "success": True,
             "timestamp": "2026-05-25T08:00:00Z",
             "latency_ms": -1,
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_trace_bundle_signed_payload_validates(self):
+        # #50: a signed bundle embeds a `signature` resolved via $ref to the
+        # CapabilityTokenSignature schema; the nested Core artifacts resolve
+        # via the local schema store. The whole document must validate.
+        schema = load_extended_schema("trace_bundle")
+        payload = load_payload("trace_bundle_signed")
+        validate(payload, schema)
+
+    def test_trace_bundle_missing_required_chain_fails(self):
+        # #50: the full audit chain is required; a bundle missing the array
+        # members must be rejected.
+        schema = load_extended_schema("trace_bundle")
+        bad = {
+            "bundle_id": "tb-1",
+            "routing_decision": {
+                "id": "rd-1",
+                "choice_cards": [
+                    {
+                        "id": "card-1",
+                        "items": [
+                            {"id": "i1", "label": "L", "description": "D"}
+                        ],
+                    }
+                ],
+                "timestamp": "2026-03-08T06:00:00Z",
+            },
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_trace_bundle_bad_canonicalization_fails(self):
+        # canonicalization is constrained to the JCS registry.
+        schema = load_extended_schema("trace_bundle")
+        bad = {
+            "bundle_id": "tb-1",
+            "routing_decision": {
+                "id": "rd-1",
+                "choice_cards": [
+                    {"id": "c1", "items": [{"id": "i1", "label": "L", "description": "D"}]}
+                ],
+                "timestamp": "2026-03-08T06:00:00Z",
+            },
+            "policy_decisions": [],
+            "frames": [],
+            "handles": [],
+            "trace_events": [],
+            "canonicalization": "sorted-keys",
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_failure_case_artifact_missing_required_fails(self):
+        # #72: failure_case_id/created_at/source_project/property_name/status
+        # are all required.
+        schema = load_extended_schema("failure_case_artifact")
+        bad = {"failure_case_id": "fc-1"}
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_failure_case_artifact_bad_status_fails(self):
+        schema = load_extended_schema("failure_case_artifact")
+        bad = {
+            "failure_case_id": "fc-1",
+            "created_at": "2026-05-28T14:12:00Z",
+            "source_project": "ChainWeaver",
+            "property_name": "p",
+            "status": "open",
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_failure_case_artifact_bad_severity_fails(self):
+        schema = load_extended_schema("failure_case_artifact")
+        bad = {
+            "failure_case_id": "fc-1",
+            "created_at": "2026-05-28T14:12:00Z",
+            "source_project": "ChainWeaver",
+            "property_name": "p",
+            "status": "candidate",
+            "severity": "extreme",
         }
         with pytest.raises(AssertionError, match="Schema validation failed"):
             validate(bad, schema)

--- a/docs/ARTIFACT_CONTRACTS.md
+++ b/docs/ARTIFACT_CONTRACTS.md
@@ -50,6 +50,7 @@ contracts. Pick the narrowest type that fits:
 | `SkillCard` | A reviewed, reusable procedure derived from traces. | A flow definition or a Core `Capability`. |
 | `EvaluationArtifact` | A statistical evaluation report with semantics. | Proof of statistical validity; a deploy approval. |
 | `ArtifactSafetyGateRequest` / `ArtifactSafetyReport` | Inputs/outputs of an artifact safety gate. | A specific scanner or rule set. |
+| `FailureCaseArtifact` | A reference to a replayable failure (fuzz/property/replay). | Proof of a bug; a `TraceBundle` (which *inlines* an audit chain). |
 
 ---
 
@@ -231,13 +232,57 @@ agent-kernel as the policy gate that acts on the result.
 }
 ```
 
+## FailureCaseArtifact
+
+A small, language-neutral record of a **replayable failure** discovered by
+fuzzing, property-based testing, replay, or trace analysis. It captures which
+`property_name` (property or invariant) failed, what is needed to reproduce it
+(`seed`, `generator_config`, `trace_ref`), whether it was `minimized`, and its
+lifecycle `status` (`candidate` → `regression` / `ignored` / `fixed`). It
+*references* large artifacts (traces) via `trace_ref` / `evidence_refs` rather
+than inlining them.
+
+> [!IMPORTANT]
+> A `FailureCaseArtifact` is **reproducible evidence, not proof of a bug**.
+> Triage decides whether a real defect exists; a failing property may itself be
+> wrong. This is why the default `status` is `candidate`.
+
+It is distinct from a [`TraceBundle`](TRACE_BUNDLE.md) (which *inlines* a full
+audit chain and may be the artifact a `FailureCaseArtifact` points at), from a
+raw trace (which a `trace_ref` points to), and from a `ReviewArtifact` (a
+generic review/trace interchange shape with no reproduction metadata).
+
+**Produced/consumed by:** ChainWeaver, agent-kernel, contextweaver,
+lessonweaver (producers via fuzz/replay harnesses); regression-test and audit
+tooling (consumers).
+
+<!-- schema: failure_case_artifact -->
+```json
+{
+  "failure_case_id": "fc-20260528-001",
+  "created_at": "2026-05-28T14:12:00Z",
+  "source_project": "ChainWeaver",
+  "property_name": "I-02-policy-decision-has-trace-event",
+  "status": "candidate",
+  "severity": "high",
+  "seed": "0x9f3a21c8",
+  "generator_config": {"strategy": "stateful_flow_replay", "max_steps": 32},
+  "trace_ref": "chainweaver:trace_id:abc123",
+  "minimized": true,
+  "minimized_from_ref": "fc-20260528-000",
+  "expected_failure_mode": "PolicyDecision(decision=deny) present with no matching TraceEvent",
+  "evidence_refs": ["chainweaver:trace_id:abc123"]
+}
+```
+
 ---
 
 ## Status and versioning
 
 These types are **Extended**: optional and opt-in. Per `docs/VERSIONING.md`,
 Extended contracts may change (including breaking changes) in a MINOR version.
-They were introduced in contract version `0.5.0`. Full sample payloads live in
+The original artifacts were introduced in contract version `0.5.0`;
+`FailureCaseArtifact` was added in the `0.6.0` set. Full sample payloads live in
 [`examples/sample_payloads/`](../examples/sample_payloads/) and are validated in
 CI against the schemas under
 [`contracts/json/extended/`](../contracts/json/extended/).

--- a/docs/TRACE_BUNDLE.md
+++ b/docs/TRACE_BUNDLE.md
@@ -1,0 +1,166 @@
+# TraceBundle — end-to-end audit-chain envelope
+
+> [!NOTE]
+> This page is **informative**. `TraceBundle` is an **Extended** contract:
+> optional, not required for spec compliance (invariant I-04). Authority order
+> remains `INVARIANTS.md > BOUNDARIES.md > ARCHITECTURE.md > everything else`.
+> Nothing here redefines an invariant or a normative boundary.
+
+Today a request's audit trail is implicit: a `RoutingDecision` lives in one log
+line, a `PolicyDecision` somewhere else, a `Frame` in a third place, and
+`TraceEvent`s scattered across an append-only log. There is no single artifact
+that says "here is what happened, end-to-end, tamper-evident."
+
+`TraceBundle` is that artifact. It is a hosting envelope that **inlines** one
+request's Core audit chain so the whole thing can be canonicalized, hashed, and
+optionally signed as a unit. The schema lives at
+[`contracts/json/extended/trace_bundle.schema.json`](../contracts/json/extended/trace_bundle.schema.json);
+the Python mirror is `TraceBundle` in
+[`weaver_contracts.extended`](../contracts/python/src/weaver_contracts/extended.py).
+
+---
+
+## Shape
+
+| Field | Required | Meaning |
+| ----- | :------: | ------- |
+| `bundle_id` | yes | Non-empty stable identifier for the bundle. |
+| `routing_decision` | yes | The Core `RoutingDecision` that opened the chain. |
+| `policy_decisions` | yes | Array of Core `PolicyDecision`s recorded for the request. |
+| `frames` | yes | Array of Core `Frame`s produced (safe to display; never raw output). |
+| `handles` | yes | Array of Core `Handle`s referenced by the frames. |
+| `trace_events` | yes | Array of Core `TraceEvent`s, in emission order. |
+| `canonicalization` | no | Canonicalization scheme; fixed to `JCS` (RFC 8785). |
+| `signature` | no | Optional detached signature (see below). |
+| `created_at` | no | Optional ISO 8601 assembly timestamp. |
+| `metadata` | no | Open extension bag; namespace project-specific keys. |
+
+The full audit chain is required: a `TraceBundle` describes a **complete**
+request, not a fragment. Each nested member is validated against its own Core
+schema via `$ref`, so a bundle is only valid if every artifact it carries is
+valid.
+
+---
+
+## Invariants it preserves (does not redefine)
+
+> [!IMPORTANT]
+> A `TraceBundle` carries the same artifacts the request already produced; it
+> adds no new authority and relaxes no rule.
+>
+> - **I-01** — `Frame`s in the bundle carry no raw output; raw artifacts remain
+>   behind `Handle`s.
+> - **I-02** — each `PolicyDecision` is still expected to have a matching
+>   `TraceEvent`. The bundle makes this checkable in one place, but a
+>   conformance runner (tracked separately) is what asserts it.
+
+---
+
+## Signing
+
+`signature` reuses the existing detached-signature shape,
+[`CapabilityTokenSignature`](SIGNING.md) (`alg` / `kid` / `sig` /
+`canonicalization` / `signed_at`), applied to the **JCS-canonicalized bundle**
+with the `signature` field excluded from the canonical form before hashing.
+This deliberately avoids inventing a second signature shape (see `AGENTS.md` →
+"Domain clarifications").
+
+> [!IMPORTANT]
+> Signing is opt-in. When `signature` is absent the bundle is **unsigned**, and
+> producers must not describe it as signed (`AGENTS.md` forbidden behavior:
+> never describe aspirational features as current).
+
+---
+
+## Example (unsigned)
+
+<!-- schema: trace_bundle -->
+```json
+{
+  "bundle_id": "tb-20260308-001",
+  "routing_decision": {
+    "id": "rd-20260308-001",
+    "choice_cards": [
+      {
+        "id": "card-retrieval",
+        "items": [
+          {
+            "id": "search-docs",
+            "label": "Search documentation",
+            "description": "Full-text search across the product documentation index.",
+            "capability_id": "org.myapp.search_docs"
+          }
+        ]
+      }
+    ],
+    "selected_item_id": "search-docs",
+    "selected_card_id": "card-retrieval",
+    "timestamp": "2026-03-08T06:00:00Z"
+  },
+  "policy_decisions": [
+    {
+      "decision_id": "pd-20260308-001",
+      "decision": "allow",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-session-7f3a",
+      "token_id": "tok-20260308-abc123",
+      "timestamp": "2026-03-08T06:00:01Z"
+    }
+  ],
+  "frames": [
+    {
+      "frame_id": "frame-20260308-001",
+      "capability_id": "org.myapp.search_docs",
+      "summary": "Found 3 documentation pages matching 'retry configuration'.",
+      "handle_refs": ["handle-rawresult-20260308-001"],
+      "created_at": "2026-03-08T06:00:05Z"
+    }
+  ],
+  "handles": [
+    {
+      "handle_id": "handle-rawresult-20260308-001",
+      "capability_id": "org.myapp.search_docs",
+      "artifact_type": "application/json",
+      "created_at": "2026-03-08T06:00:05Z",
+      "expires_at": "2026-03-09T06:00:05Z"
+    }
+  ],
+  "trace_events": [
+    {
+      "event_id": "te-20260308-005",
+      "event_type": "capability_executed",
+      "timestamp": "2026-03-08T06:00:05Z",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-session-7f3a",
+      "decision_id": "pd-20260308-001",
+      "frame_id": "frame-20260308-001",
+      "handle_id": "handle-rawresult-20260308-001",
+      "outcome": "success"
+    }
+  ],
+  "canonicalization": "JCS",
+  "created_at": "2026-03-08T06:00:06Z"
+}
+```
+
+A signed variant lives at
+[`examples/sample_payloads/trace_bundle_signed.json`](../examples/sample_payloads/trace_bundle_signed.json).
+
+---
+
+## TraceBundle vs neighbouring artifacts
+
+| Compared with | Difference |
+| ------------- | ---------- |
+| Raw append-only trace log | A bundle is a single, self-contained, hashable document for one request, not a stream. |
+| `ReviewArtifact` | `ReviewArtifact` is a thin interchange shape that *references* evidence; a `TraceBundle` *inlines* the actual Core artifacts. |
+| [`FailureCaseArtifact`](ARTIFACT_CONTRACTS.md) | A `FailureCaseArtifact` *references* a replayable failure (via `trace_ref`); a `TraceBundle` inlines a full successful-or-failed audit chain and may itself be the referenced evidence. |
+| `EvaluationArtifact` | `EvaluationArtifact` is a statistical decision report; a `TraceBundle` is a literal audit chain of one request. |
+
+---
+
+## Status and versioning
+
+`TraceBundle` is **Extended**: optional and opt-in. Per
+[`docs/VERSIONING.md`](VERSIONING.md), Extended contracts may change (including
+breaking changes) in a MINOR version. It was introduced in the `0.6.0` set.

--- a/examples/sample_payloads/failure_case_artifact.json
+++ b/examples/sample_payloads/failure_case_artifact.json
@@ -1,0 +1,28 @@
+{
+  "failure_case_id": "fc-20260528-001",
+  "created_at": "2026-05-28T14:12:00Z",
+  "source_project": "ChainWeaver",
+  "property_name": "I-02-policy-decision-has-trace-event",
+  "status": "candidate",
+  "property_description": "Every PolicyDecision must have a matching TraceEvent. The replayed flow emitted a deny PolicyDecision with no corresponding TraceEvent.",
+  "severity": "high",
+  "seed": "0x9f3a21c8",
+  "generator_config": {
+    "strategy": "stateful_flow_replay",
+    "max_steps": 32,
+    "framework": "hypothesis@6.103.0"
+  },
+  "trace_ref": "chainweaver:trace_id:abc123",
+  "minimized": true,
+  "minimized_from_ref": "fc-20260528-000",
+  "expected_failure_mode": "PolicyDecision(decision=deny) present with no TraceEvent referencing its decision_id",
+  "evidence_refs": ["chainweaver:trace_id:abc123", "tb-20260308-001"],
+  "sensitivity": "internal",
+  "provenance": {
+    "discovered_by": "nightly-fuzz",
+    "run_id": "fuzz-20260528-02"
+  },
+  "metadata": {
+    "flow_id": "invoice_reminder_flow"
+  }
+}

--- a/examples/sample_payloads/trace_bundle.json
+++ b/examples/sample_payloads/trace_bundle.json
@@ -1,0 +1,80 @@
+{
+  "bundle_id": "tb-20260308-001",
+  "routing_decision": {
+    "id": "rd-20260308-001",
+    "choice_cards": [
+      {
+        "id": "card-retrieval",
+        "context_hint": "Select the most appropriate document retrieval action for the user's query.",
+        "items": [
+          {
+            "id": "search-docs",
+            "label": "Search documentation",
+            "description": "Full-text search across the product documentation index.",
+            "capability_id": "org.myapp.search_docs"
+          },
+          {
+            "id": "fetch-page",
+            "label": "Fetch a specific page",
+            "description": "Retrieve a known documentation page by its slug.",
+            "capability_id": "org.myapp.fetch_doc_page"
+          }
+        ]
+      }
+    ],
+    "selected_item_id": "search-docs",
+    "selected_card_id": "card-retrieval",
+    "timestamp": "2026-03-08T06:00:00Z",
+    "context_summary": "User asked: 'How do I configure retries?'. Routing to documentation retrieval."
+  },
+  "policy_decisions": [
+    {
+      "decision_id": "pd-20260308-001",
+      "decision": "allow",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-session-7f3a",
+      "token_id": "tok-20260308-abc123",
+      "reason": "Token scope includes org.myapp.search_docs; token unexpired; principal authorized for documentation retrieval.",
+      "timestamp": "2026-03-08T06:00:01Z"
+    }
+  ],
+  "frames": [
+    {
+      "frame_id": "frame-20260308-001",
+      "capability_id": "org.myapp.search_docs",
+      "summary": "Found 3 documentation pages matching 'retry configuration'. The most relevant is 'Retry Policies Overview'.",
+      "handle_refs": ["handle-rawresult-20260308-001"],
+      "redaction_notes": "Raw search index response stored as Handle. Only titles, slugs, and relevance scores summarized.",
+      "created_at": "2026-03-08T06:00:05Z"
+    }
+  ],
+  "handles": [
+    {
+      "handle_id": "handle-rawresult-20260308-001",
+      "capability_id": "org.myapp.search_docs",
+      "artifact_type": "application/json",
+      "created_at": "2026-03-08T06:00:05Z",
+      "expires_at": "2026-03-09T06:00:05Z",
+      "access_policy": "policy://agent-kernel/handle-default",
+      "byte_size": 18432
+    }
+  ],
+  "trace_events": [
+    {
+      "event_id": "te-20260308-005",
+      "event_type": "capability_executed",
+      "timestamp": "2026-03-08T06:00:05Z",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-session-7f3a",
+      "decision_id": "pd-20260308-001",
+      "frame_id": "frame-20260308-001",
+      "handle_id": "handle-rawresult-20260308-001",
+      "outcome": "success"
+    }
+  ],
+  "canonicalization": "JCS",
+  "created_at": "2026-03-08T06:00:06Z",
+  "metadata": {
+    "audit_log_sequence_range": [24890, 24891]
+  }
+}

--- a/examples/sample_payloads/trace_bundle_signed.json
+++ b/examples/sample_payloads/trace_bundle_signed.json
@@ -1,0 +1,73 @@
+{
+  "bundle_id": "tb-20260308-signed-001",
+  "routing_decision": {
+    "id": "rd-20260308-002",
+    "choice_cards": [
+      {
+        "id": "card-retrieval",
+        "context_hint": "Select the most appropriate document retrieval action.",
+        "items": [
+          {
+            "id": "search-docs",
+            "label": "Search documentation",
+            "description": "Full-text search across the product documentation index.",
+            "capability_id": "org.myapp.search_docs"
+          }
+        ]
+      }
+    ],
+    "selected_item_id": "search-docs",
+    "selected_card_id": "card-retrieval",
+    "timestamp": "2026-03-08T06:00:00Z"
+  },
+  "policy_decisions": [
+    {
+      "decision_id": "pd-20260308-002",
+      "decision": "allow",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-session-7f3a",
+      "token_id": "tok-20260308-abc123",
+      "timestamp": "2026-03-08T06:00:01Z"
+    }
+  ],
+  "frames": [
+    {
+      "frame_id": "frame-20260308-002",
+      "capability_id": "org.myapp.search_docs",
+      "summary": "Found 3 documentation pages matching 'retry configuration'.",
+      "handle_refs": ["handle-rawresult-20260308-002"],
+      "created_at": "2026-03-08T06:00:05Z"
+    }
+  ],
+  "handles": [
+    {
+      "handle_id": "handle-rawresult-20260308-002",
+      "capability_id": "org.myapp.search_docs",
+      "artifact_type": "application/json",
+      "created_at": "2026-03-08T06:00:05Z",
+      "expires_at": "2026-03-09T06:00:05Z"
+    }
+  ],
+  "trace_events": [
+    {
+      "event_id": "te-20260308-006",
+      "event_type": "capability_executed",
+      "timestamp": "2026-03-08T06:00:05Z",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-session-7f3a",
+      "decision_id": "pd-20260308-002",
+      "frame_id": "frame-20260308-002",
+      "handle_id": "handle-rawresult-20260308-002",
+      "outcome": "success"
+    }
+  ],
+  "canonicalization": "JCS",
+  "created_at": "2026-03-08T06:00:06Z",
+  "signature": {
+    "alg": "ed25519",
+    "kid": "agent-kernel-2026-05-key-01",
+    "sig": "CxIZICcuNTxDSlFYX2ZtdHuCiZCXnqWss7rByM_W3eTr8vkABw4VHCMqMTg_Rk1UW2JpcHd-hYyTmqGor7a9xA",
+    "canonicalization": "JCS",
+    "signed_at": "2026-03-08T06:00:06Z"
+  }
+}

--- a/well-known/contracts.json
+++ b/well-known/contracts.json
@@ -138,6 +138,13 @@
       "sha256": "86c42335dcb1d5fe2935978ab766be97e727ee4d85c39fe448b13f2117165841"
     },
     {
+      "name": "failure_case_artifact",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/failure_case_artifact.schema.json",
+      "path": "contracts/json/extended/failure_case_artifact.schema.json",
+      "sha256": "fc658ea70b6637f2f3588dc36524e6407109aa17cdfcb11fa3e3d8b6df649434"
+    },
+    {
       "name": "lesson_card",
       "version": "v0",
       "$id": "https://weaver-spec.dev/contracts/v0/extended/lesson_card.schema.json",
@@ -206,6 +213,13 @@
       "$id": "https://weaver-spec.dev/contracts/v0/extended/telemetry_hint.schema.json",
       "path": "contracts/json/extended/telemetry_hint.schema.json",
       "sha256": "84e31eb6f441a2f79b2ab65b1f487af73da6473ba6b3c2434f1d51813ce3c33c"
+    },
+    {
+      "name": "trace_bundle",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/trace_bundle.schema.json",
+      "path": "contracts/json/extended/trace_bundle.schema.json",
+      "sha256": "781141519743c0f53217937ee3622cf0f69774b0a1dbf402c3d326a067a65ec5"
     },
     {
       "name": "ui_hint",


### PR DESCRIPTION
## Description

Adds two additive **Extended** contracts in one PR (the coherent group identified during triage — both follow the identical six-artifact path under `contracts/json/extended/`):

- **`TraceBundle` (closes #50)** — a tamper-evident audit-chain *envelope* that **inlines** one request's Core artifacts (`routing_decision`, `policy_decisions`, `frames`, `handles`, `trace_events`) via `$ref` so the chain can be JCS-canonicalized (RFC 8785) and optionally signed. The full chain is required (a bundle describes a complete request). The optional `signature` reuses the existing `CapabilityTokenSignature` shape rather than inventing a second signature type (per `AGENTS.md` → "Domain clarifications"); an absent signature means unsigned. New normative `docs/TRACE_BUNDLE.md`; signed + unsigned sample payloads.
- **`FailureCaseArtifact` (closes #72)** — a small, reference-based record of a replayable failure (fuzz/property/replay): `property_name`, lifecycle `status` (`candidate`/`regression`/`ignored`/`fixed`), reproduction inputs (`seed`, `generator_config`, `trace_ref`), and `minimized` provenance. It references large artifacts rather than inlining them and is explicitly **reproducible evidence, not proof of a bug**. Documented in `docs/ARTIFACT_CONTRACTS.md` and positioned against `TraceBundle` / raw traces / `ReviewArtifact` / `EvaluationArtifact` (satisfies #72's "document how this differs" criterion).

### What changed (by file)
- New schemas: `contracts/json/extended/{trace_bundle,failure_case_artifact}.schema.json`
- Python mirrors in `extended.py` (dataclasses with `__post_init__` enum/non-empty validation; `TraceBundle` imports the Core types it inlines)
- Sample payloads: `trace_bundle.json`, `trace_bundle_signed.json`, `failure_case_artifact.json`
- Tests: roundtrip in `test_extended.py`, schema-alignment + 5 negative cases + signed-bundle positive in `test_extended_schema_alignment.py`
- Docs: new `docs/TRACE_BUNDLE.md`; `docs/ARTIFACT_CONTRACTS.md` taxonomy row + section; `AGENTS.md` doc-map row
- Regenerated `contracts/COVERAGE.md` (32/32 schemas, 32/32 payloads) and `well-known/contracts.json`
- `CHANGELOG.md` `[Unreleased]` entry
- `.markdownlint.json`: disabled **MD060** — see "tooling note" below

### Versioning
Folded into the unreleased `0.6.0` set; **no version bump**, matching the immediately-preceding PR #71 which folded additive Extended contracts into the same window.

### Tooling note (separate concern)
`markdownlint-cli` 0.48 newly enables **MD060 (`table-column-style`)**, which conflicts with the repo's established padded-table convention and flagged **pre-existing, untouched** tables in `AGENTS.md` (lines 22, 130). Disabled it in `.markdownlint.json` (one line) to keep CI green and preserve the existing doc style. Flagging as a distinct change for visibility.

## Type of change

- [ ] Docs only (no contract changes)
- [x] Additive contract change (new optional field or new type — non-breaking)
- [ ] Breaking contract change (requires ADR — see [CONTRIBUTING.md](CONTRIBUTING.md))
- [x] CI / tooling change (markdownlint MD060 disable)

## Six-artifact checklist

These are **Extended** contracts (not Core), so the Core-specific paths are N/A, but the equivalent Extended artifacts are all present:

- [x] JSON Schema added (`contracts/json/extended/`)
- [x] Python dataclass added (`extended.py`) — N/A for `core.py` (Extended, not Core)
- [x] Sample payload(s) added (`examples/sample_payloads/`)
- [x] Roundtrip + schema-alignment tests added (`test_extended.py`, `test_extended_schema_alignment.py`) — N/A for `test_roundtrip_examples.py` (Core-only)
- [x] CHANGELOG entry added
- [x] Version bump — **N/A** (folded into unreleased 0.6.0, per PR #71 precedent)

## Deprecations

- [x] N/A (no deprecation in this PR)

## Invariants

- [x] Verified I-01..I-07 are not violated. `TraceBundle` carries existing artifacts only: Frames stay free of raw output (I-01) and each PolicyDecision is still expected to have a matching TraceEvent (I-02); the bundle adds no authority. A test asserts bundle Frames expose no `raw_output` attribute.

## Cross-repo impact

- [x] No cross-repo impact (Extended/opt-in — contextweaver, agent-kernel, ChainWeaver may emit these but are not required to; no migration).

## How verified

- `mypy src/` — clean (4 files)
- `pytest -q` — **289 passed**
- `python scripts/check_schema_fields.py` — 32 schemas valid
- `python scripts/generate_contracts_index.py --check` — up to date
- `python scripts/generate_coverage_table.py --check` — up to date
- inline-payload (walkthrough) validation — 51 payloads across 38 md files pass (incl. both new doc examples)
- `markdownlint` (full CI set, with repo config) — exit 0

https://claude.ai/code/session_01Cpw87GLJDi1QsgiSsGxfUo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cpw87GLJDi1QsgiSsGxfUo)_