### PR TITLE
ci: add conformance suite with TraceBundle integrity verification (#43, #74)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,3 +281,9 @@ jobs:
 
       - name: Check contracts/COVERAGE.md is up to date
         run: python scripts/generate_coverage_table.py --check
+
+  conformance:
+    name: Conformance Suite
+    permissions:
+      contents: read
+    uses: ./.github/workflows/conformance.yml

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,33 @@
+name: Conformance
+
+# Reusable conformance suite (issues #43, #74). Sibling repos call it with:
+#
+#   jobs:
+#     weaver-conformance:
+#       uses: dgenio/weaver-spec/.github/workflows/conformance.yml@v0.6.0
+#
+# It is also invoked from this repo's ci.yml. See docs/CONFORMANCE.md.
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  conformance:
+    name: Run Conformance Suite
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install conformance dependencies
+        run: pip install jsonschema referencing PyYAML jcs cryptography
+
+      - name: Run conformance runner
+        run: python conformance/run.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This repository is **documentation + contracts only**.
 - It contains JSON Schemas (language-agnostic source of truth), a Python `weaver_contracts` package (stdlib dataclasses mirroring the schemas), specification docs, and examples.
 - **Never add runtime logic, adopter-facing CLI tools, adopter-facing helper utilities, or business logic to this repository.** Validation is limited to construction-time checks in dataclass `__post_init__`.
 - **Build-time spec-maintenance tooling is permitted** under `scripts/`, narrowly scoped: stdlib-only Python that consumes the spec and emits or validates artifacts checked into this repo (e.g., the content-addressed schema index). Such tooling must not be imported by `weaver_contracts` and must not be published to PyPI. Any new script must be added to the repo map below with that scope explicitly stated.
+- **The conformance suite under `conformance/` is build-time / CI tooling**, not runtime code. Unlike `scripts/` it may use the schema-validation/signing dependencies (`jsonschema`, `referencing`, `PyYAML`, `jcs`, `cryptography`), because it defines what "spec-compliant" means as a runnable check (positive/negative corpus + executable invariant assertions + TraceBundle signature verification). The same constraints apply: it is never imported by `weaver_contracts` and never published. See [docs/CONFORMANCE.md](docs/CONFORMANCE.md).
 
 ---
 
@@ -48,6 +49,7 @@ This repository is **documentation + contracts only**.
 | `well-known/contracts.json` | Generated content-addressed schema index (SHA-256 per file) | Regenerate via `scripts/generate_contracts_index.py` after any `contracts/json/` change |
 | `compatibility.yaml` | Machine-readable sibling-repo compatibility manifest (human-readable view in `docs/VERSIONING.md`). Validated by the `validate-compatibility` CI job | When a sibling repo declares or changes its supported spec versions |
 | `scripts/` | Build-time, stdlib-only utilities (e.g., index generator, coverage table generator). Not runtime code. | When the build-time tooling itself changes |
+| `conformance/` | Build-time / CI conformance suite: `run.py` runner, `corpus.yaml` (positive + negative payloads), `invariants.yaml` (executable I-01/I-02/I-04/I-06 assertions), negative fixtures, and a signed TraceBundle fixture + test keyring. Consumes the schema-validation/signing deps; never imported by `weaver_contracts`, never published. | When changing what spec-compliance verifies, or adding fixtures/invariant checks |
 | `CHARTER.md` | Governance roles, decision flow, Working Groups | When governance roles or process change |
 
 ---
@@ -192,6 +194,9 @@ python scripts/generate_contracts_index.py --check
 
 # 5. Markdown lint
 # See CONTRIBUTING.md "Markdown Lint" section for the canonical command.
+
+# 6. Conformance suite (positive/negative corpus + invariants + signature checks)
+python conformance/run.py
 ```
 
 Or, if pre-commit is installed (recommended): `pre-commit run --all-files` runs checks 3–5 automatically. Add `pre-commit install --hook-type pre-push` to also gate check 1 on push.
@@ -219,6 +224,7 @@ For mixed changes, use the prefix for the most impactful change. Mention the sec
 | [docs/ARTIFACT_CONTRACTS.md](docs/ARTIFACT_CONTRACTS.md) | Cross-project Extended artifact vocabulary (memory, session handoff, lesson/skill cards, evaluation, safety gate, failure case) |
 | [docs/EXECUTION_BOUNDARY.md](docs/EXECUTION_BOUNDARY.md) | Selection ↔ execution boundary Extended contracts (ExecutionCandidate, CompiledFlow, ExecutionRoutingDecision, ExecutionFeedback) |
 | [docs/TRACE_BUNDLE.md](docs/TRACE_BUNDLE.md) | TraceBundle Extended contract: end-to-end audit-chain envelope (inlines RoutingDecision + PolicyDecisions + Frames + Handles + TraceEvents; optional JCS signature) |
+| [docs/CONFORMANCE.md](docs/CONFORMANCE.md) | Conformance suite: what spec-compliance checks (positive/negative corpus, executable invariant assertions, TraceBundle signature verification) and how siblings adopt the reusable workflow |
 | [docs/ECOSYSTEM.md](docs/ECOSYSTEM.md) | Derived ecosystem boundary map (owns/consumes/emits per project, end-to-end lifecycle); points to BOUNDARIES.md/LIFECYCLE.md as canonical |
 | [docs/agent-context/architecture.md](docs/agent-context/architecture.md) | Pointers to canonical architecture and boundary docs |
 | [docs/agent-context/workflows.md](docs/agent-context/workflows.md) | Authoritative commands, change sequences, documentation governance |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,31 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
 
 ### Added
 
+- **Conformance suite (`conformance/`).** A build-time / CI runner that defines
+  what "spec-compliant" means as a runnable check, resolving #43 and #74. No
+  contract changed, so no version bump (consistent with this release window's
+  additive-tooling practice); this is CI tooling, never imported by
+  `weaver_contracts` and never published.
+  - `conformance/run.py` validates a **positive corpus** (sample payloads must
+    validate), asserts a **negative corpus** is rejected (≥3 fixtures each for
+    Frame, RoutingDecision, CapabilityToken, PolicyDecision, TraceEvent — by
+    JSON Schema, or by invariant for schema-valid-but-invalid payloads), and
+    evaluates `conformance/invariants.yaml` — executable assertions for **I-01,
+    I-02, I-04, I-06** (I-03/I-05/I-07 remain layer-behaviour invariants checked
+    by sibling harnesses).
+  - **TraceBundle integrity verification (#74):** for every `TraceBundle` the
+    runner recomputes the RFC 8785 (JCS) canonical form excluding `signature`,
+    validates the detached-signature envelope against the
+    `CapabilityTokenSignature` schema and algorithm registry, then
+    **cryptographically verifies** the signature
+    when the `kid` resolves in the keyring. Ships a real ed25519-signed fixture
+    (`conformance/fixtures/trace_bundle_signed_valid.json`) with its public key
+    in `conformance/keyring/`; unknown-key signatures are reported as *skipped*,
+    never as verified.
+  - Reusable workflow `.github/workflows/conformance.yml` (siblings adopt with
+    one `uses:` line) plus a `conformance` job in `ci.yml`; package test
+    `test_conformance.py`; and `docs/CONFORMANCE.md`. The original conformance
+    issue #4 was already closed (not planned) and is superseded by this work.
 - **Audit-chain and replayable-failure Extended contracts.** Two new
   implementation-neutral Extended contracts, folded into the unreleased `0.6.0`
   set (additive, no Core change, no version bump — consistent with the prior

--- a/conformance/corpus.yaml
+++ b/conformance/corpus.yaml
@@ -1,0 +1,51 @@
+# Conformance corpus: the payloads the runner checks.
+#
+# `positive` payloads MUST validate against their named schema (and, where an
+# invariant applies, MUST satisfy it).
+#
+# `negative` payloads MUST be rejected. `by` says how:
+#   - schema    : the payload fails JSON Schema validation.
+#   - invariant : the payload is schema-VALID but violates `violates` (an
+#                 invariant id evaluated by conformance/run.py).
+#
+# Paths are repo-relative. Schema names are the schema file stems (Core or
+# Extended), e.g. `frame`, `trace_bundle`.
+
+positive:
+  - {payload: examples/sample_payloads/routing_decision.json, schema: routing_decision}
+  - {payload: examples/sample_payloads/frame_with_handles.json, schema: frame}
+  - {payload: examples/sample_payloads/capability.json, schema: capability}
+  - {payload: examples/sample_payloads/capability_token.json, schema: capability_token}
+  - {payload: examples/sample_payloads/choice_card.json, schema: choice_card}
+  - {payload: examples/sample_payloads/selectable_item.json, schema: selectable_item}
+  - {payload: examples/sample_payloads/handle.json, schema: handle}
+  - {payload: examples/sample_payloads/policy_decision.json, schema: policy_decision}
+  - {payload: examples/sample_payloads/trace_event.json, schema: trace_event}
+  - {payload: examples/sample_payloads/trace_bundle.json, schema: trace_bundle}
+  - {payload: examples/sample_payloads/trace_bundle_signed.json, schema: trace_bundle}
+  - {payload: conformance/fixtures/trace_bundle_signed_valid.json, schema: trace_bundle}
+
+negative:
+  # Frame
+  - {payload: conformance/negative/frame/missing_summary.json, schema: frame, by: schema, violates: "required:summary"}
+  - {payload: conformance/negative/frame/empty_frame_id.json, schema: frame, by: schema, violates: "minLength:frame_id"}
+  - {payload: conformance/negative/frame/non_string_created_at.json, schema: frame, by: schema, violates: "type:created_at"}
+  # RoutingDecision
+  - {payload: conformance/negative/routing_decision/missing_timestamp.json, schema: routing_decision, by: schema, violates: "required:timestamp"}
+  - {payload: conformance/negative/routing_decision/empty_choice_cards.json, schema: routing_decision, by: schema, violates: "minItems:choice_cards"}
+  - {payload: conformance/negative/routing_decision/empty_id.json, schema: routing_decision, by: schema, violates: "minLength:id"}
+  # CapabilityToken
+  - {payload: conformance/negative/capability_token/empty_scope.json, schema: capability_token, by: schema, violates: "minItems:scope"}
+  - {payload: conformance/negative/capability_token/no_expiry_no_single_use.json, schema: capability_token, by: schema, violates: "anyOf:expiry-or-single-use"}
+  - {payload: conformance/negative/capability_token/missing_principal.json, schema: capability_token, by: schema, violates: "required:principal"}
+  # PolicyDecision
+  - {payload: conformance/negative/policy_decision/bad_decision_enum.json, schema: policy_decision, by: schema, violates: "enum:decision"}
+  - {payload: conformance/negative/policy_decision/missing_decision_id.json, schema: policy_decision, by: schema, violates: "required:decision_id"}
+  - {payload: conformance/negative/policy_decision/empty_capability_id.json, schema: policy_decision, by: schema, violates: "minLength:capability_id"}
+  # TraceEvent
+  - {payload: conformance/negative/trace_event/bad_event_type.json, schema: trace_event, by: schema, violates: "enum:event_type"}
+  - {payload: conformance/negative/trace_event/missing_timestamp.json, schema: trace_event, by: schema, violates: "required:timestamp"}
+  - {payload: conformance/negative/trace_event/empty_event_id.json, schema: trace_event, by: schema, violates: "minLength:event_id"}
+  # TraceBundle — schema-valid but invariant-violating (exercises #74 checks)
+  - {payload: conformance/negative/trace_bundle/i01_frame_carries_raw_output.json, schema: trace_bundle, by: invariant, violates: I-01}
+  - {payload: conformance/negative/trace_bundle/i02_policy_decision_without_trace_event.json, schema: trace_bundle, by: invariant, violates: I-02}

--- a/conformance/fixtures/trace_bundle_signed_valid.json
+++ b/conformance/fixtures/trace_bundle_signed_valid.json
@@ -1,0 +1,75 @@
+{
+  "bundle_id": "tb-conformance-signed-001",
+  "routing_decision": {
+    "id": "rd-conf-001",
+    "choice_cards": [
+      {
+        "id": "card-retrieval",
+        "context_hint": "Select a retrieval action.",
+        "items": [
+          {
+            "id": "search-docs",
+            "label": "Search documentation",
+            "description": "Full-text search across the docs index.",
+            "capability_id": "org.myapp.search_docs"
+          }
+        ]
+      }
+    ],
+    "selected_item_id": "search-docs",
+    "selected_card_id": "card-retrieval",
+    "timestamp": "2026-03-08T06:00:00Z"
+  },
+  "policy_decisions": [
+    {
+      "decision_id": "pd-conf-001",
+      "decision": "allow",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-session-9c2e",
+      "token_id": "tok-conf-001",
+      "timestamp": "2026-03-08T06:00:01Z"
+    }
+  ],
+  "frames": [
+    {
+      "frame_id": "frame-conf-001",
+      "capability_id": "org.myapp.search_docs",
+      "summary": "Found 2 documentation pages matching the query.",
+      "handle_refs": [
+        "handle-conf-001"
+      ],
+      "created_at": "2026-03-08T06:00:05Z"
+    }
+  ],
+  "handles": [
+    {
+      "handle_id": "handle-conf-001",
+      "capability_id": "org.myapp.search_docs",
+      "artifact_type": "application/json",
+      "created_at": "2026-03-08T06:00:05Z",
+      "expires_at": "2026-03-09T06:00:05Z"
+    }
+  ],
+  "trace_events": [
+    {
+      "event_id": "te-conf-001",
+      "event_type": "capability_executed",
+      "timestamp": "2026-03-08T06:00:05Z",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-session-9c2e",
+      "decision_id": "pd-conf-001",
+      "frame_id": "frame-conf-001",
+      "handle_id": "handle-conf-001",
+      "outcome": "success"
+    }
+  ],
+  "canonicalization": "JCS",
+  "created_at": "2026-03-08T06:00:06Z",
+  "signature": {
+    "alg": "ed25519",
+    "kid": "conformance-test-ed25519-2026-01",
+    "sig": "LRB1K8fbJPQNdTbKjrEkzFQWmoiXok-KYARdrSuRJhMJTIOSONgK0gK5W2tdDW5s54z9QycbEwQAMONBX81JDw",
+    "canonicalization": "JCS",
+    "signed_at": "2026-03-08T06:00:06Z"
+  }
+}

--- a/conformance/invariants.yaml
+++ b/conformance/invariants.yaml
@@ -1,0 +1,49 @@
+# Executable invariant assertions for the Weaver conformance runner.
+#
+# Each block declares one invariant and binds it to a NAMED CHECK implemented in
+# conformance/run.py. The "assertion DSL" is intentionally a named-check registry
+# rather than an embedded expression language: every assertion is real, tested
+# Python, so a sibling repo running this manifest gets the same verdict the spec
+# repo does.
+#
+# Descriptions are one-line pointers only. The normative text lives in
+# docs/INVARIANTS.md and is NOT restated here (per AGENTS.md).
+#
+# I-03, I-05, and I-07 are layer-behaviour invariants (routing / ingestion /
+# orchestration runtime). They cannot be asserted against a static artifact and
+# are checked by the sibling-repo conformance harnesses, not here. See
+# docs/CONFORMANCE.md.
+
+invariants:
+  - id: I-01
+    description: "No Frame exposes raw tool output. See docs/INVARIANTS.md."
+    applies_to: [trace_bundle]
+    assertion: frames_have_no_raw_output
+
+  - id: I-02
+    description: "Every PolicyDecision has a matching TraceEvent. See docs/INVARIANTS.md."
+    applies_to: [trace_bundle]
+    assertion: policy_decisions_are_traced
+
+  - id: I-04
+    description: "Core contract required-field surface stays minimal and stable. See docs/INVARIANTS.md."
+    applies_to: [core_schemas]
+    assertion: core_required_surface_stable
+    # Pinned baseline of the Core required-field surface. Growing this set is a
+    # minimality regression (I-04) and must be a deliberate, reviewed change.
+    # This is a focused minimality lock, not a full schema diff (tracked in #45).
+    baseline:
+      capability: [id, name, version, description]
+      capability_token: [token_id, principal, scope, issued_at]
+      choice_card: [id, items]
+      frame: [frame_id, capability_id, summary, created_at]
+      handle: [handle_id, capability_id, artifact_type, created_at]
+      policy_decision: [decision_id, decision, capability_id, principal, timestamp]
+      routing_decision: [id, choice_cards, timestamp]
+      selectable_item: [id, label, description]
+      trace_event: [event_id, event_type, timestamp]
+
+  - id: I-06
+    description: "CapabilityTokens are scoped and single-use or expiring. See docs/INVARIANTS.md."
+    applies_to: [capability_token]
+    assertion: capability_token_scoped

--- a/conformance/keyring/README.md
+++ b/conformance/keyring/README.md
@@ -1,0 +1,14 @@
+# Conformance test keyring
+
+`test_keyring.json` holds **public** keys only, used by
+[`../run.py`](../run.py) to cryptographically verify signed `TraceBundle`
+fixtures (issue #74).
+
+- `conformance-test-ed25519-2026-01` — ed25519 public key for
+  [`../fixtures/trace_bundle_signed_valid.json`](../fixtures/trace_bundle_signed_valid.json).
+  The matching **private key was generated once and discarded**; it exists only
+  to produce that one fixture's signature. No secret material is committed.
+
+Adopters verifying their own bundles supply their own keyring via
+`python conformance/run.py --keyring <path>`. See
+[../../docs/CONFORMANCE.md](../../docs/CONFORMANCE.md).

--- a/conformance/keyring/test_keyring.json
+++ b/conformance/keyring/test_keyring.json
@@ -1,0 +1,9 @@
+{
+  "keys": [
+    {
+      "kid": "conformance-test-ed25519-2026-01",
+      "alg": "ed25519",
+      "public_key_b64url": "qs-PkKBMWTOlYYi8vLNwVSEISlYETpqlWtu9e_fJ4F0"
+    }
+  ]
+}

--- a/conformance/negative/capability_token/empty_scope.json
+++ b/conformance/negative/capability_token/empty_scope.json
@@ -1,0 +1,7 @@
+{
+  "token_id": "tok-neg-001",
+  "principal": "agent-7",
+  "scope": [],
+  "issued_at": "2026-03-08T06:00:00Z",
+  "expires_at": "2026-03-09T06:00:00Z"
+}

--- a/conformance/negative/capability_token/missing_principal.json
+++ b/conformance/negative/capability_token/missing_principal.json
@@ -1,0 +1,8 @@
+{
+  "token_id": "tok-neg-003",
+  "scope": [
+    "org.myapp.search_docs"
+  ],
+  "issued_at": "2026-03-08T06:00:00Z",
+  "single_use": true
+}

--- a/conformance/negative/capability_token/no_expiry_no_single_use.json
+++ b/conformance/negative/capability_token/no_expiry_no_single_use.json
@@ -1,0 +1,8 @@
+{
+  "token_id": "tok-neg-002",
+  "principal": "agent-7",
+  "scope": [
+    "org.myapp.search_docs"
+  ],
+  "issued_at": "2026-03-08T06:00:00Z"
+}

--- a/conformance/negative/frame/empty_frame_id.json
+++ b/conformance/negative/frame/empty_frame_id.json
@@ -1,0 +1,6 @@
+{
+  "frame_id": "",
+  "capability_id": "org.myapp.search_docs",
+  "summary": "ok",
+  "created_at": "2026-03-08T06:00:05Z"
+}

--- a/conformance/negative/frame/missing_summary.json
+++ b/conformance/negative/frame/missing_summary.json
@@ -1,0 +1,5 @@
+{
+  "frame_id": "frame-neg-001",
+  "capability_id": "org.myapp.search_docs",
+  "created_at": "2026-03-08T06:00:05Z"
+}

--- a/conformance/negative/frame/non_string_created_at.json
+++ b/conformance/negative/frame/non_string_created_at.json
@@ -1,0 +1,6 @@
+{
+  "frame_id": "frame-neg-003",
+  "capability_id": "org.myapp.search_docs",
+  "summary": "ok",
+  "created_at": 1709877605
+}

--- a/conformance/negative/policy_decision/bad_decision_enum.json
+++ b/conformance/negative/policy_decision/bad_decision_enum.json
@@ -1,0 +1,7 @@
+{
+  "decision_id": "pd-neg-001",
+  "decision": "maybe",
+  "capability_id": "org.myapp.search_docs",
+  "principal": "agent-7",
+  "timestamp": "2026-03-08T06:00:01Z"
+}

--- a/conformance/negative/policy_decision/empty_capability_id.json
+++ b/conformance/negative/policy_decision/empty_capability_id.json
@@ -1,0 +1,7 @@
+{
+  "decision_id": "pd-neg-003",
+  "decision": "allow",
+  "capability_id": "",
+  "principal": "agent-7",
+  "timestamp": "2026-03-08T06:00:01Z"
+}

--- a/conformance/negative/policy_decision/missing_decision_id.json
+++ b/conformance/negative/policy_decision/missing_decision_id.json
@@ -1,0 +1,6 @@
+{
+  "decision": "allow",
+  "capability_id": "org.myapp.search_docs",
+  "principal": "agent-7",
+  "timestamp": "2026-03-08T06:00:01Z"
+}

--- a/conformance/negative/routing_decision/empty_choice_cards.json
+++ b/conformance/negative/routing_decision/empty_choice_cards.json
@@ -1,0 +1,5 @@
+{
+  "id": "rd-neg-002",
+  "choice_cards": [],
+  "timestamp": "2026-03-08T06:00:00Z"
+}

--- a/conformance/negative/routing_decision/empty_id.json
+++ b/conformance/negative/routing_decision/empty_id.json
@@ -1,0 +1,16 @@
+{
+  "id": "",
+  "choice_cards": [
+    {
+      "id": "card-1",
+      "items": [
+        {
+          "id": "i-1",
+          "label": "L",
+          "description": "D"
+        }
+      ]
+    }
+  ],
+  "timestamp": "2026-03-08T06:00:00Z"
+}

--- a/conformance/negative/routing_decision/missing_timestamp.json
+++ b/conformance/negative/routing_decision/missing_timestamp.json
@@ -1,0 +1,15 @@
+{
+  "id": "rd-neg-001",
+  "choice_cards": [
+    {
+      "id": "card-1",
+      "items": [
+        {
+          "id": "i-1",
+          "label": "L",
+          "description": "D"
+        }
+      ]
+    }
+  ]
+}

--- a/conformance/negative/trace_bundle/i01_frame_carries_raw_output.json
+++ b/conformance/negative/trace_bundle/i01_frame_carries_raw_output.json
@@ -1,0 +1,69 @@
+{
+  "bundle_id": "tb-neg-i01",
+  "routing_decision": {
+    "id": "rd-tbneg-001",
+    "choice_cards": [
+      {
+        "id": "card-1",
+        "items": [
+          {
+            "id": "search-docs",
+            "label": "Search documentation",
+            "description": "Full-text search.",
+            "capability_id": "org.myapp.search_docs"
+          }
+        ]
+      }
+    ],
+    "selected_item_id": "search-docs",
+    "selected_card_id": "card-1",
+    "timestamp": "2026-03-08T06:00:00Z"
+  },
+  "policy_decisions": [
+    {
+      "decision_id": "pd-tbneg-001",
+      "decision": "allow",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-7",
+      "timestamp": "2026-03-08T06:00:01Z"
+    }
+  ],
+  "frames": [
+    {
+      "frame_id": "frame-tbneg-001",
+      "capability_id": "org.myapp.search_docs",
+      "summary": "Found 3 pages.",
+      "handle_refs": [
+        "handle-tbneg-001"
+      ],
+      "created_at": "2026-03-08T06:00:05Z",
+      "raw_output": {
+        "http_status": 200,
+        "body": "...secret raw bytes..."
+      }
+    }
+  ],
+  "handles": [
+    {
+      "handle_id": "handle-tbneg-001",
+      "capability_id": "org.myapp.search_docs",
+      "artifact_type": "application/json",
+      "created_at": "2026-03-08T06:00:05Z",
+      "expires_at": "2026-03-09T06:00:05Z"
+    }
+  ],
+  "trace_events": [
+    {
+      "event_id": "te-tbneg-001",
+      "event_type": "capability_executed",
+      "timestamp": "2026-03-08T06:00:05Z",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-7",
+      "decision_id": "pd-tbneg-001",
+      "frame_id": "frame-tbneg-001",
+      "handle_id": "handle-tbneg-001",
+      "outcome": "success"
+    }
+  ],
+  "canonicalization": "JCS"
+}

--- a/conformance/negative/trace_bundle/i02_policy_decision_without_trace_event.json
+++ b/conformance/negative/trace_bundle/i02_policy_decision_without_trace_event.json
@@ -1,0 +1,65 @@
+{
+  "bundle_id": "tb-neg-i02",
+  "routing_decision": {
+    "id": "rd-tbneg-001",
+    "choice_cards": [
+      {
+        "id": "card-1",
+        "items": [
+          {
+            "id": "search-docs",
+            "label": "Search documentation",
+            "description": "Full-text search.",
+            "capability_id": "org.myapp.search_docs"
+          }
+        ]
+      }
+    ],
+    "selected_item_id": "search-docs",
+    "selected_card_id": "card-1",
+    "timestamp": "2026-03-08T06:00:00Z"
+  },
+  "policy_decisions": [
+    {
+      "decision_id": "pd-tbneg-001",
+      "decision": "allow",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-7",
+      "timestamp": "2026-03-08T06:00:01Z"
+    }
+  ],
+  "frames": [
+    {
+      "frame_id": "frame-tbneg-001",
+      "capability_id": "org.myapp.search_docs",
+      "summary": "Found 3 pages.",
+      "handle_refs": [
+        "handle-tbneg-001"
+      ],
+      "created_at": "2026-03-08T06:00:05Z"
+    }
+  ],
+  "handles": [
+    {
+      "handle_id": "handle-tbneg-001",
+      "capability_id": "org.myapp.search_docs",
+      "artifact_type": "application/json",
+      "created_at": "2026-03-08T06:00:05Z",
+      "expires_at": "2026-03-09T06:00:05Z"
+    }
+  ],
+  "trace_events": [
+    {
+      "event_id": "te-tbneg-001",
+      "event_type": "capability_executed",
+      "timestamp": "2026-03-08T06:00:05Z",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-7",
+      "decision_id": "pd-does-not-exist",
+      "frame_id": "frame-tbneg-001",
+      "handle_id": "handle-tbneg-001",
+      "outcome": "success"
+    }
+  ],
+  "canonicalization": "JCS"
+}

--- a/conformance/negative/trace_event/bad_event_type.json
+++ b/conformance/negative/trace_event/bad_event_type.json
@@ -1,0 +1,5 @@
+{
+  "event_id": "te-neg-001",
+  "event_type": "exploded",
+  "timestamp": "2026-03-08T06:00:05Z"
+}

--- a/conformance/negative/trace_event/empty_event_id.json
+++ b/conformance/negative/trace_event/empty_event_id.json
@@ -1,0 +1,5 @@
+{
+  "event_id": "",
+  "event_type": "capability_executed",
+  "timestamp": "2026-03-08T06:00:05Z"
+}

--- a/conformance/negative/trace_event/missing_timestamp.json
+++ b/conformance/negative/trace_event/missing_timestamp.json
@@ -1,0 +1,4 @@
+{
+  "event_id": "te-neg-002",
+  "event_type": "capability_executed"
+}

--- a/conformance/run.py
+++ b/conformance/run.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Weaver conformance runner.
+
+This is build-time / CI conformance tooling, not runtime code. It is NOT part of
+the ``weaver_contracts`` package, is never imported by it, and is never
+published. Sibling repos invoke it through the reusable workflow
+``.github/workflows/conformance.yml`` to declare conformance in one CI line; see
+docs/CONFORMANCE.md.
+
+What it checks (issues #43 and #74):
+
+* Positive corpus  — every payload in ``conformance/corpus.yaml`` ``positive``
+  validates against its JSON Schema.
+* Negative corpus  — every ``negative`` payload is rejected, either by JSON
+  Schema (``by: schema``) or, for schema-valid payloads, by the invariant named
+  in ``violates`` (``by: invariant``).
+* Invariants       — the executable assertions declared in
+  ``conformance/invariants.yaml`` (I-01, I-02, I-04, I-06) hold for the relevant
+  positive payloads / schemas. I-03/I-05/I-07 are layer-behaviour invariants
+  checked by sibling harnesses (see docs/CONFORMANCE.md).
+* TraceBundle integrity (#74) — for every TraceBundle the runner recomputes the
+  RFC 8785 (JCS) canonical form excluding ``signature``; when a signature is
+  present it validates the detached-signature envelope and, if the signing key
+  is in the supplied keyring, cryptographically verifies it.
+
+Exit code is non-zero on any positive failure, negative acceptance, invariant
+violation, or signature failure.
+
+Usage::
+
+    python conformance/run.py
+    python conformance/run.py --keyring conformance/keyring/test_keyring.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import jcs
+import yaml
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT202012
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CORE_SCHEMA_DIR = REPO_ROOT / "contracts" / "json"
+EXTENDED_SCHEMA_DIR = CORE_SCHEMA_DIR / "extended"
+CONF_DIR = REPO_ROOT / "conformance"
+DEFAULT_KEYRING = CONF_DIR / "keyring" / "test_keyring.json"
+
+# Frames must never carry raw tool output (I-01). These keys are treated as raw
+# passthrough and are forbidden on any Frame inside a bundle.
+FORBIDDEN_FRAME_KEYS = frozenset({"raw_output", "raw", "raw_result", "tool_output"})
+
+SIGNATURE_ALG_REGISTRY = frozenset({"ed25519", "es256"})
+
+
+# ---------------------------------------------------------------------------
+# Schema loading
+# ---------------------------------------------------------------------------
+
+def load_schemas() -> tuple[dict[str, dict], Registry]:
+    """Return (schemas_by_stem, registry) for all Core + Extended schemas."""
+    schemas_by_stem: dict[str, dict] = {}
+    registry = Registry()
+    for path in sorted(CORE_SCHEMA_DIR.glob("*.schema.json")) + sorted(
+        EXTENDED_SCHEMA_DIR.glob("*.schema.json")
+    ):
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        stem = path.name.removesuffix(".schema.json")
+        schemas_by_stem[stem] = schema
+        if "$id" in schema:
+            registry = registry.with_resource(
+                uri=schema["$id"],
+                resource=Resource(contents=schema, specification=DRAFT202012),
+            )
+    return schemas_by_stem, registry
+
+
+def schema_errors(payload: dict, schema: dict, registry: Registry) -> list[str]:
+    """Return a sorted list of validation error messages (empty == valid)."""
+    validator = Draft202012Validator(
+        schema, registry=registry, format_checker=Draft202012Validator.FORMAT_CHECKER
+    )
+    errors = sorted(validator.iter_errors(payload), key=lambda e: list(e.absolute_path))
+    out = []
+    for err in errors:
+        loc = "/".join(str(p) for p in err.absolute_path) or "<root>"
+        out.append(f"{loc}: {err.message}")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Invariant checks (the named-check registry referenced by invariants.yaml)
+# ---------------------------------------------------------------------------
+
+def frames_have_no_raw_output(bundle: dict) -> list[str]:
+    """I-01: no Frame in the bundle carries raw tool output."""
+    violations = []
+    for i, frame in enumerate(bundle.get("frames", [])):
+        present = sorted(FORBIDDEN_FRAME_KEYS & set(frame))
+        if present:
+            fid = frame.get("frame_id", f"index {i}")
+            violations.append(f"Frame {fid!r} carries forbidden raw-output key(s): {present}")
+    return violations
+
+
+def policy_decisions_are_traced(bundle: dict) -> list[str]:
+    """I-02: every PolicyDecision has a matching TraceEvent (decision_id linkage)."""
+    traced = {
+        te.get("decision_id")
+        for te in bundle.get("trace_events", [])
+        if te.get("decision_id") is not None
+    }
+    violations = []
+    for pd in bundle.get("policy_decisions", []):
+        did = pd.get("decision_id")
+        if did not in traced:
+            violations.append(f"PolicyDecision {did!r} has no matching TraceEvent")
+    return violations
+
+
+def capability_token_scoped(token: dict) -> list[str]:
+    """I-06: a CapabilityToken is scoped and either single-use or expiring."""
+    violations = []
+    scope = token.get("scope")
+    if not isinstance(scope, list) or not scope:
+        violations.append("scope is empty or missing; unbounded scope is not permitted")
+    if not (token.get("single_use") is True or token.get("expires_at")):
+        violations.append("token is neither single_use nor has expires_at")
+    return violations
+
+
+def core_required_surface_stable(baseline: dict, schemas_by_stem: dict[str, dict]) -> list[str]:
+    """I-04: the Core required-field surface matches the pinned baseline."""
+    violations = []
+    for stem, expected in baseline.items():
+        schema = schemas_by_stem.get(stem)
+        if schema is None:
+            violations.append(f"Core schema {stem!r} not found")
+            continue
+        actual = list(schema.get("required", []))
+        if actual != list(expected):
+            violations.append(
+                f"{stem}: required surface drifted — expected {expected}, found {actual}"
+            )
+    return violations
+
+
+BUNDLE_INVARIANTS: dict[str, Callable[[dict], list[str]]] = {
+    "frames_have_no_raw_output": frames_have_no_raw_output,
+    "policy_decisions_are_traced": policy_decisions_are_traced,
+}
+
+
+# ---------------------------------------------------------------------------
+# TraceBundle signature verification (#74)
+# ---------------------------------------------------------------------------
+
+def _b64url_decode(s: str) -> bytes:
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+def load_keyring(path: Optional[Path]) -> dict[str, dict]:
+    """Return kid -> key entry from a keyring JSON file (empty if none)."""
+    if path is None or not path.exists():
+        return {}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return {k["kid"]: k for k in data.get("keys", [])}
+
+
+def _crypto_verify(alg: str, key_entry: dict, message: bytes, sig: bytes) -> bool:
+    """Cryptographically verify a signature. Raises if the crypto lib is absent."""
+    pub_bytes = _b64url_decode(key_entry["public_key_b64url"])
+    if alg == "ed25519":
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+        Ed25519PublicKey.from_public_bytes(pub_bytes).verify(sig, message)
+        return True
+    if alg == "es256":
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import ec, utils
+
+        pub = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256R1(), pub_bytes)
+        r = int.from_bytes(sig[:32], "big")
+        s = int.from_bytes(sig[32:], "big")
+        pub.verify(utils.encode_dss_signature(r, s), message, ec.ECDSA(hashes.SHA256()))
+        return True
+    raise ValueError(f"unsupported alg {alg!r}")
+
+
+def check_trace_bundle(
+    bundle: dict,
+    schemas_by_stem: dict[str, dict],
+    registry: Registry,
+    keyring: dict[str, dict],
+) -> tuple[list[str], list[str]]:
+    """Return (errors, notes) for a TraceBundle's integrity + signature (#74)."""
+    errors: list[str] = []
+    notes: list[str] = []
+
+    # Recompute the JCS canonical form excluding `signature` (always).
+    unsigned = {k: v for k, v in bundle.items() if k != "signature"}
+    try:
+        canonical = jcs.canonicalize(unsigned)
+    except Exception as exc:  # pragma: no cover - defensive
+        errors.append(f"JCS canonicalization failed: {exc}")
+        return errors, notes
+
+    signature = bundle.get("signature")
+    if signature is None:
+        notes.append("unsigned bundle (canonical form recomputed)")
+        return errors, notes
+
+    # Validate the detached-signature envelope against its Extended schema.
+    sig_errs = schema_errors(signature, schemas_by_stem["capability_token_signature"], registry)
+    if sig_errs:
+        errors.extend(f"signature envelope invalid: {e}" for e in sig_errs)
+    if signature.get("alg") not in SIGNATURE_ALG_REGISTRY:
+        errors.append(f"signature alg {signature.get('alg')!r} not in registry")
+    if signature.get("canonicalization", "JCS") != "JCS":
+        errors.append("signature canonicalization must be JCS")
+    if errors:
+        return errors, notes
+
+    kid = signature["kid"]
+    key_entry = keyring.get(kid)
+    if key_entry is None:
+        notes.append(f"signature envelope valid; crypto verify skipped (kid {kid!r} not in keyring)")
+        return errors, notes
+    try:
+        _crypto_verify(signature["alg"], key_entry, canonical, _b64url_decode(signature["sig"]))
+        notes.append(f"signature cryptographically verified (kid {kid!r})")
+    except ImportError:  # pragma: no cover - cryptography is a declared dep
+        notes.append("crypto verify skipped (cryptography not installed)")
+    except Exception as exc:
+        errors.append(f"signature verification FAILED for kid {kid!r}: {exc}")
+    return errors, notes
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+def run(keyring_path: Optional[Path]) -> int:
+    schemas_by_stem, registry = load_schemas()
+    corpus = yaml.safe_load((CONF_DIR / "corpus.yaml").read_text(encoding="utf-8"))
+    invariants_doc = yaml.safe_load((CONF_DIR / "invariants.yaml").read_text(encoding="utf-8"))
+    keyring = load_keyring(keyring_path)
+
+    failures: list[str] = []
+    checks = 0
+
+    def load(rel: str) -> dict:
+        return json.loads((REPO_ROOT / rel).read_text(encoding="utf-8"))
+
+    # 1. Positive corpus must validate.
+    for entry in corpus["positive"]:
+        checks += 1
+        errs = schema_errors(load(entry["payload"]), schemas_by_stem[entry["schema"]], registry)
+        if errs:
+            failures.append(f"POSITIVE {entry['payload']} should validate but did not: {errs}")
+
+    # 2. Negative corpus must be rejected.
+    for entry in corpus["negative"]:
+        checks += 1
+        payload = load(entry["payload"])
+        schema = schemas_by_stem[entry["schema"]]
+        if entry["by"] == "schema":
+            if not schema_errors(payload, schema, registry):
+                failures.append(
+                    f"NEGATIVE {entry['payload']} should fail schema ({entry['violates']}) but validated"
+                )
+        elif entry["by"] == "invariant":
+            # Must be schema-valid first, then rejected by the named invariant.
+            if schema_errors(payload, schema, registry):
+                failures.append(f"NEGATIVE {entry['payload']} expected schema-valid but failed schema")
+                continue
+            check = BUNDLE_INVARIANTS.get(_assertion_for(invariants_doc, entry["violates"]))
+            if check is None or not check(payload):
+                failures.append(
+                    f"NEGATIVE {entry['payload']} should violate {entry['violates']} but passed"
+                )
+        else:  # pragma: no cover - guarded by corpus authoring
+            failures.append(f"NEGATIVE {entry['payload']} has unknown `by`: {entry['by']!r}")
+
+    # 3. Invariant assertions over positive targets / schemas.
+    positive_by_schema: dict[str, list[dict]] = {}
+    for entry in corpus["positive"]:
+        positive_by_schema.setdefault(entry["schema"], []).append(load(entry["payload"]))
+
+    for inv in invariants_doc["invariants"]:
+        applies_to = inv["applies_to"]
+        assertion = inv["assertion"]
+        if applies_to == ["core_schemas"]:
+            checks += 1
+            v = core_required_surface_stable(inv["baseline"], schemas_by_stem)
+            if v:
+                failures.append(f"INVARIANT {inv['id']} failed: {v}")
+        elif applies_to == ["capability_token"]:
+            for token in positive_by_schema.get("capability_token", []):
+                checks += 1
+                v = capability_token_scoped(token)
+                if v:
+                    failures.append(f"INVARIANT {inv['id']} failed on a capability_token: {v}")
+        elif applies_to == ["trace_bundle"]:
+            check = BUNDLE_INVARIANTS[assertion]
+            for bundle in positive_by_schema.get("trace_bundle", []):
+                checks += 1
+                v = check(bundle)
+                if v:
+                    failures.append(f"INVARIANT {inv['id']} failed on {bundle.get('bundle_id')!r}: {v}")
+
+    # 4. TraceBundle integrity + signature (#74) over every positive bundle.
+    for bundle in positive_by_schema.get("trace_bundle", []):
+        checks += 1
+        errs, notes = check_trace_bundle(bundle, schemas_by_stem, registry, keyring)
+        for note in notes:
+            print(f"  bundle {bundle.get('bundle_id')!r}: {note}")
+        if errs:
+            failures.append(f"TRACEBUNDLE {bundle.get('bundle_id')!r}: {errs}")
+
+    # Report.
+    print(f"\nConformance: ran {checks} checks.")
+    if failures:
+        print(f"FAILED ({len(failures)}):", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+    print("All conformance checks passed.")
+    return 0
+
+
+def _assertion_for(invariants_doc: dict, invariant_id: str) -> str:
+    for inv in invariants_doc["invariants"]:
+        if inv["id"] == invariant_id:
+            return str(inv["assertion"])
+    raise KeyError(f"no invariant block for {invariant_id!r}")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the Weaver conformance suite.")
+    parser.add_argument(
+        "--keyring",
+        type=Path,
+        default=DEFAULT_KEYRING,
+        help="JSON keyring (kid -> public key) for signature verification.",
+    )
+    args = parser.parse_args(argv)
+    return run(args.keyring)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/conformance/run.py
+++ b/conformance/run.py
@@ -144,10 +144,12 @@ def core_required_surface_stable(baseline: dict, schemas_by_stem: dict[str, dict
         if schema is None:
             violations.append(f"Core schema {stem!r} not found")
             continue
-        actual = list(schema.get("required", []))
-        if actual != list(expected):
+        # `required` is an unordered set in JSON Schema, so compare as sets:
+        # reordering fields in a schema file is a semantic no-op.
+        actual = sorted(schema.get("required", []))
+        if actual != sorted(expected):
             violations.append(
-                f"{stem}: required surface drifted — expected {expected}, found {actual}"
+                f"{stem}: required surface drifted — expected {sorted(expected)}, found {actual}"
             )
     return violations
 
@@ -232,6 +234,12 @@ def check_trace_bundle(
     key_entry = keyring.get(kid)
     if key_entry is None:
         notes.append(f"signature envelope valid; crypto verify skipped (kid {kid!r} not in keyring)")
+        return errors, notes
+    if key_entry.get("alg") != signature["alg"]:
+        errors.append(
+            f"keyring entry for kid {kid!r} is alg {key_entry.get('alg')!r}, "
+            f"but the signature declares alg {signature['alg']!r}"
+        )
         return errors, notes
     try:
         _crypto_verify(signature["alg"], key_entry, canonical, _b64url_decode(signature["sig"]))

--- a/conformance/run.py
+++ b/conformance/run.py
@@ -39,7 +39,7 @@ import base64
 import json
 import sys
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Callable, Optional
 
 import jcs
 import yaml
@@ -93,6 +93,46 @@ def schema_errors(payload: dict, schema: dict, registry: Registry) -> list[str]:
         loc = "/".join(str(p) for p in err.absolute_path) or "<root>"
         out.append(f"{loc}: {err.message}")
     return out
+
+
+def schema_error_details(
+    payload: dict, schema: dict, registry: Registry
+) -> list[tuple[str, str, str]]:
+    """Return (keyword, location, message) per validation error (empty == valid).
+
+    Unlike :func:`schema_errors`, this preserves the failing JSON Schema keyword
+    (``required``, ``minLength``, ``enum``, …) so a negative fixture can be
+    checked against the *reason* it is supposed to fail, not merely that it
+    fails somehow.
+    """
+    validator = Draft202012Validator(
+        schema, registry=registry, format_checker=Draft202012Validator.FORMAT_CHECKER
+    )
+    details = []
+    for err in validator.iter_errors(payload):
+        loc = "/".join(str(p) for p in err.absolute_path) or "<root>"
+        details.append((str(err.validator), loc, err.message))
+    return details
+
+
+def negative_schema_reason_met(violates: str, details: list[tuple[str, str, str]]) -> bool:
+    """True if some validation error matches the declared ``violates`` reason.
+
+    ``violates`` is ``"<keyword>:<target>"`` (e.g. ``"required:summary"``,
+    ``"minLength:frame_id"``). The keyword must match a failing keyword; the
+    target must appear in that error's location or message — except for keywords
+    like ``anyOf`` whose target is a human label rather than a field path.
+    """
+    keyword, _, target = violates.partition(":")
+    label_only = {"anyOf", "oneOf", "allOf", "not"}
+    for kw, loc, msg in details:
+        if kw != keyword:
+            continue
+        if not target or keyword in label_only:
+            return True
+        if target in loc or target in msg:
+            return True
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -220,7 +260,14 @@ def check_trace_bundle(
         return errors, notes
 
     # Validate the detached-signature envelope against its Extended schema.
-    sig_errs = schema_errors(signature, schemas_by_stem["capability_token_signature"], registry)
+    sig_schema = schemas_by_stem.get("capability_token_signature")
+    if sig_schema is None:
+        errors.append(
+            "Extended schema 'capability_token_signature' not found; "
+            "cannot validate the signature envelope"
+        )
+        return errors, notes
+    sig_errs = schema_errors(signature, sig_schema, registry)
     if sig_errs:
         errors.extend(f"signature envelope invalid: {e}" for e in sig_errs)
     if signature.get("alg") not in SIGNATURE_ALG_REGISTRY:
@@ -280,9 +327,16 @@ def run(keyring_path: Optional[Path]) -> int:
         payload = load(entry["payload"])
         schema = schemas_by_stem[entry["schema"]]
         if entry["by"] == "schema":
-            if not schema_errors(payload, schema, registry):
+            details = schema_error_details(payload, schema, registry)
+            if not details:
                 failures.append(
                     f"NEGATIVE {entry['payload']} should fail schema ({entry['violates']}) but validated"
+                )
+            elif not negative_schema_reason_met(entry["violates"], details):
+                observed = sorted({kw for kw, _, _ in details})
+                failures.append(
+                    f"NEGATIVE {entry['payload']} should fail by {entry['violates']!r} "
+                    f"but failed by {observed} instead"
                 )
         elif entry["by"] == "invariant":
             # Must be schema-valid first, then rejected by the named invariant.

--- a/contracts/python/pyproject.toml
+++ b/contracts/python/pyproject.toml
@@ -14,11 +14,17 @@ dependencies = []
 [project.optional-dependencies]
 dev = [
     "pytest>=7.4",
-    "jsonschema>=4.17",
+    "jsonschema>=4.18",
+    "referencing>=0.30",
     "mypy>=1.0",
     "pytest-cov>=4.0",
     "pre-commit>=3.5",
     "yamllint>=1.35",
+    # Conformance runner (conformance/run.py) extras — build-time/CI only,
+    # never imported by weaver_contracts.
+    "PyYAML>=6.0",
+    "jcs>=0.2.1",
+    "cryptography>=41.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/contracts/python/tests/test_conformance.py
+++ b/contracts/python/tests/test_conformance.py
@@ -69,6 +69,31 @@ def test_negative_is_rejected(entry):
         assert check(payload), f"{entry['payload']} should violate {entry['violates']}"
 
 
+@pytest.mark.parametrize(
+    "entry",
+    [e for e in CORPUS["negative"] if e["by"] == "schema"],
+    ids=lambda e: e["payload"],
+)
+def test_negative_schema_fails_by_declared_reason(entry):
+    # The fixture must fail for the *reason* named in `violates`, not just fail
+    # somehow — this guards against fixtures rotting into the wrong failure.
+    details = conf.schema_error_details(_load(entry["payload"]), SCHEMAS[entry["schema"]], REGISTRY)
+    assert conf.negative_schema_reason_met(entry["violates"], details), (
+        f"{entry['payload']} expected to fail by {entry['violates']!r}, "
+        f"observed {sorted({kw for kw, _, _ in details})}"
+    )
+
+
+def test_negative_reason_mismatch_is_detected():
+    # A fixture that fails by a different keyword than declared must NOT be
+    # accepted as matching.
+    details = conf.schema_error_details(
+        _load("conformance/negative/frame/missing_summary.json"), SCHEMAS["frame"], REGISTRY
+    )
+    assert conf.negative_schema_reason_met("required:summary", details)
+    assert not conf.negative_schema_reason_met("minLength:frame_id", details)
+
+
 # ---------------------------------------------------------------------------
 # Invariant checks (unit level)
 # ---------------------------------------------------------------------------

--- a/contracts/python/tests/test_conformance.py
+++ b/contracts/python/tests/test_conformance.py
@@ -95,6 +95,14 @@ def test_i04_baseline_matches_and_detects_drift():
     assert conf.core_required_surface_stable(drifted, SCHEMAS)
 
 
+def test_i04_reordering_required_is_a_no_op():
+    # `required` is an unordered set; a reordered baseline must still pass.
+    inv = yaml.safe_load((REPO_ROOT / "conformance" / "invariants.yaml").read_text())
+    baseline = next(i["baseline"] for i in inv["invariants"] if i["id"] == "I-04")
+    reordered = {stem: list(reversed(fields)) for stem, fields in baseline.items()}
+    assert conf.core_required_surface_stable(reordered, SCHEMAS) == []
+
+
 def test_i06_flags_empty_scope_and_missing_expiry():
     assert conf.capability_token_scoped(_load("examples/sample_payloads/capability_token.json")) == []
     assert conf.capability_token_scoped(
@@ -121,6 +129,14 @@ def test_tampered_bundle_fails_verification():
     keyring = conf.load_keyring(conf.DEFAULT_KEYRING)
     errs, _ = conf.check_trace_bundle(bundle, SCHEMAS, REGISTRY, keyring)
     assert any("verification FAILED" in e for e in errs)
+
+
+def test_keyring_alg_mismatch_is_rejected():
+    bundle = _load("conformance/fixtures/trace_bundle_signed_valid.json")
+    kid = bundle["signature"]["kid"]
+    mismatched = {kid: {"kid": kid, "alg": "es256", "public_key_b64url": "AAAA"}}
+    errs, _ = conf.check_trace_bundle(bundle, SCHEMAS, REGISTRY, mismatched)
+    assert any("alg" in e and kid in e for e in errs)
 
 
 def test_unsigned_bundle_recomputes_canonical_form_without_error():

--- a/contracts/python/tests/test_conformance.py
+++ b/contracts/python/tests/test_conformance.py
@@ -1,0 +1,139 @@
+"""Tests for the conformance runner (conformance/run.py, issues #43 + #74).
+
+The runner lives outside the ``weaver_contracts`` package (it is build-time CI
+tooling, not shipped code), so it is loaded by path rather than imported.
+"""
+
+import importlib.util
+import json
+import pathlib
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+RUN_PY = REPO_ROOT / "conformance" / "run.py"
+
+
+def _load_runner():
+    spec = importlib.util.spec_from_file_location("conformance_run", RUN_PY)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+conf = _load_runner()
+CORPUS = yaml.safe_load((REPO_ROOT / "conformance" / "corpus.yaml").read_text())
+SCHEMAS, REGISTRY = conf.load_schemas()
+
+
+def _load(rel: str) -> dict:
+    return json.loads((REPO_ROOT / rel).read_text())
+
+
+# ---------------------------------------------------------------------------
+# End-to-end
+# ---------------------------------------------------------------------------
+
+def test_full_suite_passes():
+    assert conf.run(conf.DEFAULT_KEYRING) == 0
+
+
+# ---------------------------------------------------------------------------
+# Positive / negative corpus
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("entry", CORPUS["positive"], ids=lambda e: e["payload"])
+def test_positive_validates(entry):
+    errs = conf.schema_errors(_load(entry["payload"]), SCHEMAS[entry["schema"]], REGISTRY)
+    assert errs == [], f"{entry['payload']} should validate: {errs}"
+
+
+@pytest.mark.parametrize("entry", CORPUS["negative"], ids=lambda e: e["payload"])
+def test_negative_is_rejected(entry):
+    payload = _load(entry["payload"])
+    schema = SCHEMAS[entry["schema"]]
+    if entry["by"] == "schema":
+        assert conf.schema_errors(payload, schema, REGISTRY), \
+            f"{entry['payload']} should fail schema ({entry['violates']})"
+    else:
+        # Invariant negatives must be schema-valid first, then caught by the invariant.
+        assert conf.schema_errors(payload, schema, REGISTRY) == []
+        check = conf.BUNDLE_INVARIANTS[
+            conf._assertion_for(
+                yaml.safe_load((REPO_ROOT / "conformance" / "invariants.yaml").read_text()),
+                entry["violates"],
+            )
+        ]
+        assert check(payload), f"{entry['payload']} should violate {entry['violates']}"
+
+
+# ---------------------------------------------------------------------------
+# Invariant checks (unit level)
+# ---------------------------------------------------------------------------
+
+def test_i01_flags_raw_output_and_passes_clean_bundle():
+    dirty = _load("conformance/negative/trace_bundle/i01_frame_carries_raw_output.json")
+    clean = _load("examples/sample_payloads/trace_bundle.json")
+    assert conf.frames_have_no_raw_output(dirty)
+    assert conf.frames_have_no_raw_output(clean) == []
+
+
+def test_i02_flags_unlinked_policy_decision_and_passes_clean_bundle():
+    dirty = _load("conformance/negative/trace_bundle/i02_policy_decision_without_trace_event.json")
+    clean = _load("examples/sample_payloads/trace_bundle.json")
+    assert conf.policy_decisions_are_traced(dirty)
+    assert conf.policy_decisions_are_traced(clean) == []
+
+
+def test_i04_baseline_matches_and_detects_drift():
+    inv = yaml.safe_load((REPO_ROOT / "conformance" / "invariants.yaml").read_text())
+    baseline = next(i["baseline"] for i in inv["invariants"] if i["id"] == "I-04")
+    assert conf.core_required_surface_stable(baseline, SCHEMAS) == []
+    drifted = {**baseline, "frame": baseline["frame"] + ["surprise_field"]}
+    assert conf.core_required_surface_stable(drifted, SCHEMAS)
+
+
+def test_i06_flags_empty_scope_and_missing_expiry():
+    assert conf.capability_token_scoped(_load("examples/sample_payloads/capability_token.json")) == []
+    assert conf.capability_token_scoped(
+        {"token_id": "t", "principal": "p", "scope": [], "single_use": True})
+    assert conf.capability_token_scoped(
+        {"token_id": "t", "principal": "p", "scope": ["c"], "issued_at": "2026-01-01T00:00:00Z"})
+
+
+# ---------------------------------------------------------------------------
+# TraceBundle signature verification (#74)
+# ---------------------------------------------------------------------------
+
+def test_signed_fixture_cryptographically_verifies():
+    bundle = _load("conformance/fixtures/trace_bundle_signed_valid.json")
+    keyring = conf.load_keyring(conf.DEFAULT_KEYRING)
+    errs, notes = conf.check_trace_bundle(bundle, SCHEMAS, REGISTRY, keyring)
+    assert errs == []
+    assert any("cryptographically verified" in n for n in notes)
+
+
+def test_tampered_bundle_fails_verification():
+    bundle = _load("conformance/fixtures/trace_bundle_signed_valid.json")
+    bundle["bundle_id"] = "tampered-after-signing"  # changes the canonical form
+    keyring = conf.load_keyring(conf.DEFAULT_KEYRING)
+    errs, _ = conf.check_trace_bundle(bundle, SCHEMAS, REGISTRY, keyring)
+    assert any("verification FAILED" in e for e in errs)
+
+
+def test_unsigned_bundle_recomputes_canonical_form_without_error():
+    bundle = _load("examples/sample_payloads/trace_bundle.json")
+    errs, notes = conf.check_trace_bundle(bundle, SCHEMAS, REGISTRY, {})
+    assert errs == []
+    assert any("unsigned bundle" in n for n in notes)
+
+
+def test_signature_with_unknown_kid_is_skipped_not_failed():
+    # The illustrative sample sig uses a kid absent from the test keyring.
+    bundle = _load("examples/sample_payloads/trace_bundle_signed.json")
+    keyring = conf.load_keyring(conf.DEFAULT_KEYRING)
+    errs, notes = conf.check_trace_bundle(bundle, SCHEMAS, REGISTRY, keyring)
+    assert errs == []
+    assert any("skipped" in n for n in notes)

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -1,0 +1,90 @@
+# Conformance
+
+> [!NOTE]
+> This document describes the **build-time conformance suite** under
+> [`conformance/`](../conformance). The suite is CI tooling, not part of the
+> `weaver_contracts` package: it is never imported by the package and never
+> published. It defines what "spec-compliant" means as a runnable check.
+
+The conformance runner answers one question: *does a payload (or a sibling
+repo's emitted artifact) honour the Weaver contracts and invariants?* It goes
+beyond JSON Schema validation by also asserting the cross-field invariants that
+Schema cannot express.
+
+## What it checks
+
+| Layer | Source | Meaning |
+| ----- | ------ | ------- |
+| Positive corpus | [`conformance/corpus.yaml`](../conformance/corpus.yaml) `positive` | Each payload **must** validate against its schema. |
+| Negative corpus | `conformance/corpus.yaml` `negative` | Each payload **must** be rejected — by JSON Schema (`by: schema`) or, for schema-valid payloads, by an invariant (`by: invariant`). |
+| Invariants | [`conformance/invariants.yaml`](../conformance/invariants.yaml) | Executable assertions for **I-01, I-02, I-04, I-06** (see [INVARIANTS.md](INVARIANTS.md)). |
+| TraceBundle integrity | runner (`#74`) | Recomputes the RFC 8785 (JCS) canonical form excluding `signature`; validates the detached-signature envelope; cryptographically verifies the signature when the signing key is in the supplied keyring. |
+
+`invariants.yaml` is intentionally a **named-check registry**, not an embedded
+expression language: each block binds an invariant `id` to a real Python check
+in [`conformance/run.py`](../conformance/run.py), so a sibling repo running the
+manifest gets the same verdict this repo does. The invariant descriptions point
+to [INVARIANTS.md](INVARIANTS.md) and do not restate the normative text.
+
+### Invariant coverage
+
+I-01, I-02, I-04, and I-06 are statically checkable and are enforced here.
+**I-03, I-05, and I-07 are layer-behaviour invariants** (routing, ingestion, and
+orchestration runtime); they cannot be asserted against a static artifact and
+are checked by the sibling-repo conformance harnesses instead.
+
+## Running locally
+
+```bash
+python conformance/run.py
+```
+
+The runner exits non-zero on any positive failure, negative acceptance,
+invariant violation, or signature failure. By default it loads the test keyring
+at `conformance/keyring/test_keyring.json`; pass `--keyring <path>` to verify
+bundles signed with your own keys.
+
+Dependencies (`jsonschema`, `referencing`, `PyYAML`, `jcs`, `cryptography`) are
+declared as the `dev` extra of the Python package:
+
+```bash
+pip install -e "contracts/python[dev]"
+```
+
+## Signature verification (`#74`)
+
+For every `TraceBundle` the runner recomputes the JCS canonical form and, when a
+`signature` is present, validates it against the
+`CapabilityTokenSignature` schema and the algorithm registry, then verifies it
+cryptographically **if** the `kid` resolves in the keyring. The procedure mirrors
+[SIGNING.md](SIGNING.md). When the key is unknown the result is honestly
+reported as *skipped* — never as verified.
+
+The fixture [`conformance/fixtures/trace_bundle_signed_valid.json`](../conformance/fixtures/trace_bundle_signed_valid.json)
+carries a **real** ed25519 signature (its public key is in
+`conformance/keyring/test_keyring.json`; the private key was discarded after
+generation), so the verification path is exercised end-to-end. The illustrative
+sample in `examples/sample_payloads/trace_bundle_signed.json` keeps its
+documented placeholder signature and is reported as *skipped*.
+
+## Adopting it in a sibling repo
+
+The suite ships as a reusable workflow. Add one job to your CI, pinned to a
+released tag:
+
+```yaml
+jobs:
+  weaver-conformance:
+    uses: dgenio/weaver-spec/.github/workflows/conformance.yml@v0.6.0
+```
+
+This runs the spec repo's own corpus against the published schemas. To assert
+conformance of *your* emitted artifacts, point the runner at your payloads via a
+local `corpus.yaml` (same shape) and your own keyring.
+
+## Related
+
+- [INVARIANTS.md](INVARIANTS.md) — the normative I-01..I-07 definitions.
+- [SIGNING.md](SIGNING.md) — canonicalization + signature algorithm registry.
+- [TRACE_BUNDLE.md](TRACE_BUNDLE.md) — the audit-chain envelope.
+- [AGENTS.md](../AGENTS.md) — repo scope rule covering `conformance/`.

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -70,7 +70,7 @@ If the change affects a contract that a sibling repo produces or consumes, coord
 
 ## Local validation commands
 
-Run all five before submitting any PR. CI enforces all five.
+Run all six before submitting any PR. CI enforces all six.
 
 ```bash
 # 1. Python tests (with coverage)
@@ -90,6 +90,9 @@ python scripts/generate_contracts_index.py --check
 
 # 5. Markdown lint
 # See CONTRIBUTING.md "Markdown Lint" section for the canonical command.
+
+# 6. Conformance suite (corpus + executable invariants + TraceBundle signatures)
+python conformance/run.py
 ```
 
 If step 4 fails, regenerate the index and commit the result:


### PR DESCRIPTION
## Description

Adds `conformance/` — a build-time / CI conformance suite that defines what
"spec-compliant" means as a runnable check. Resolves the two issues from the
triage's recommended combined group:

- **#43** — invariant-aware harness, negative fixtures, reusable workflow
  (scope-expand of the already-closed #4).
- **#74** — conformance verification of TraceBundle integrity + invariants
  (the remaining acceptance criterion of #50; depended on the runner from #43,
  which is why these ship together).

### What changed

- **`conformance/run.py`** — validates a **positive corpus** (sample payloads
  must validate), asserts a **negative corpus** is rejected, and evaluates
  **`conformance/invariants.yaml`** (executable assertions for I-01, I-02, I-04,
  I-06). The assertion "DSL" is a named-check registry — every assertion is real
  tested Python, so siblings get the same verdict this repo does.
- **Negative fixtures** — ≥3 each for Frame, RoutingDecision, CapabilityToken,
  PolicyDecision, TraceEvent (rejected `by: schema`), plus 2 schema-valid
  TraceBundles rejected `by: invariant` (a Frame carrying `raw_output` → I-01;
  an untraced PolicyDecision → I-02). `corpus.yaml` labels each with how it is
  rejected.
- **TraceBundle verification (#74)** — for every bundle the runner recomputes
  the RFC 8785 (JCS) canonical form excluding `signature`, validates the
  detached-signature envelope against `CapabilityTokenSignature` + the algorithm
  registry, and **cryptographically verifies** the signature when the `kid`
  resolves in the keyring. Ships a **real** ed25519-signed fixture
  (`conformance/fixtures/trace_bundle_signed_valid.json`); the matching private
  key was generated once and discarded. Unknown-key signatures (e.g. the
  illustrative `examples/.../trace_bundle_signed.json`) are reported as
  *skipped*, never as verified — honoring the "no aspirational claims" rule.
- **Wiring** — reusable `.github/workflows/conformance.yml` (siblings adopt with
  one `uses:` line) + a `conformance` job in `ci.yml`; package
  `test_conformance.py`; `docs/CONFORMANCE.md`; `AGENTS.md` repo map / scope /
  docs map; `workflows.md` validation commands; CHANGELOG; and
  `PyYAML`/`jcs`/`cryptography`/`referencing` added to the `dev` extra.

## Why

The triage selected #43 + #74 as the most coherent single-PR group: #74's body
states it is blocked until the #43 runner exists, both live in the same new
`conformance/run.py`, and #74's other dependency (#44 signing) had already
merged. #4 (the original conformance issue) was already closed (not planned) and
is superseded here.

## How verified

All run locally (`python -m pytest` — note: bare `pytest` resolves a different
interpreter in this environment):

- `python conformance/run.py` → **40 checks, all passed** (incl. the real
  ed25519 signature verifying and a tampered-bundle case failing).
- `pytest --cov` → **328 passed** (38 new), **coverage 95%** (gate 80%).
- `mypy src/` → clean.
- `scripts/check_schema_fields.py`, `generate_contracts_index.py --check`,
  `generate_coverage_table.py --check`, compatibility self-test → all OK.
- `markdownlint` + `yamllint -c .yamllint.yml …` + internal link checker → clean.

---

## Type of change

- [x] Docs only (no contract changes)  <!-- partially: docs included -->
- [ ] Additive contract change (new optional field or new type — non-breaking)
- [ ] Breaking contract change (requires ADR — see [CONTRIBUTING.md](CONTRIBUTING.md))
- [x] CI / tooling change

---

## Six-artifact checklist

No Core (or Extended) contract changed — this is CI/conformance tooling only.

- [x] JSON Schema updated — **N/A**
- [x] Python dataclass updated — **N/A**
- [x] Sample payload updated — **N/A** (new fixtures live under `conformance/`, not `examples/sample_payloads/`)
- [x] Roundtrip test updated — **N/A** (new `tests/test_conformance.py` instead)
- [x] CHANGELOG entry added
- [x] Version bumped — **N/A** (no contract change; deliberate deviation from #43's literal "MINOR bump", consistent with this release window's additive-tooling practice — easy to add a bump if preferred)

---

## Deprecations

- [x] `docs/DEPRECATIONS.md` updated — **N/A** (no deprecation)

---

## Invariants

- [x] I have verified that invariants I-01 through I-07 in `docs/INVARIANTS.md` are not violated. This PR *enforces* I-01/I-02/I-04/I-06 and changes no contract.

---

## Cross-repo impact

- [ ] **contextweaver** — needs coordinated update
- [ ] **agent-kernel** — needs coordinated update
- [ ] **ChainWeaver** — needs coordinated update
- [x] No *contract* change. **Opt-in only:** siblings may adopt the reusable workflow (`uses: dgenio/weaver-spec/.github/workflows/conformance.yml@<tag>`) to declare conformance, but nothing is required of them.

---

## Notes / caveats

- New top-level `conformance/` is **not** under `scripts/` and is **not**
  stdlib-only (it needs `jsonschema`/`jcs`/`cryptography`). This is the design
  #43 specifies; I extended the `AGENTS.md` scope rule to cover it explicitly
  rather than silently bending the existing wording.
- I-04's executable check is a focused "Core required-surface" lock, kept
  distinct from a full schema diff (tracked separately in #45, out of scope).
- es256 verification is implemented but only an ed25519 vector ships.

https://claude.ai/code/session_01GP6XWDzLKomdUYaJEuBzPQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GP6XWDzLKomdUYaJEuBzPQ)_