### PR TITLE
docs: add Weaver Stack explainer + front-door blocks and launch-post draft (#5, #6, #79, #81)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,8 @@ For mixed changes, use the prefix for the most impactful change. Mention the sec
 | [docs/TRACE_BUNDLE.md](docs/TRACE_BUNDLE.md) | TraceBundle Extended contract: end-to-end audit-chain envelope (inlines RoutingDecision + PolicyDecisions + Frames + Handles + TraceEvents; optional JCS signature) |
 | [docs/CONFORMANCE.md](docs/CONFORMANCE.md) | Conformance suite: what spec-compliance checks (positive/negative corpus, executable invariant assertions, TraceBundle signature verification) and how siblings adopt the reusable workflow |
 | [docs/ECOSYSTEM.md](docs/ECOSYSTEM.md) | Derived ecosystem boundary map (owns/consumes/emits per project, end-to-end lifecycle); points to BOUNDARIES.md/LIFECYCLE.md as canonical |
+| [docs/WEAVER_STACK.md](docs/WEAVER_STACK.md) | Ecosystem-level explainer ("What Is the Weaver Stack?"): narrative entry point, derived architecture + closed-loop diagram, and the single source for the reusable front-door / cross-repo README blocks and shared topics. Informative; points to INVARIANTS/BOUNDARIES/ARCHITECTURE as canonical |
+| [docs/WEAVER_STACK_LAUNCH.md](docs/WEAVER_STACK_LAUNCH.md) | Draft ecosystem-level launch-post artifact (distinct from per-repo launches); informative, not a spec |
 | [docs/agent-context/architecture.md](docs/agent-context/architecture.md) | Pointers to canonical architecture and boundary docs |
 | [docs/agent-context/workflows.md](docs/agent-context/workflows.md) | Authoritative commands, change sequences, documentation governance |
 | [docs/agent-context/invariants.md](docs/agent-context/invariants.md) | Hard constraints, forbidden shortcuts, safe-vs-unsafe changes |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
 
 ### Added
 
+- **Ecosystem front door — "What Is the Weaver Stack?" explainer + launch-post
+  draft (#5, #6, #79, #81).** Documentation only; no contract shape changed, so
+  no version bump (consistent with this release window's additive-docs practice).
+  - New [`docs/WEAVER_STACK.md`](docs/WEAVER_STACK.md): the ecosystem-level
+    explainer (#81) — the problem, the layered architecture, and a
+    request-path-plus-closed-learning-loop Mermaid diagram **derived** from
+    `docs/BOUNDARIES.md`/`docs/ARCHITECTURE.md` (canonical). It is also the
+    single source for the reusable **front-door** copy: the org/landing profile
+    README block, the per-repo "Part of the Weaver Stack" block (#6), and the
+    shared topic set, plus a rollout checklist for the out-of-repo steps
+    (org creation #79, sibling-repo edits #6, landing page #5).
+  - New [`docs/WEAVER_STACK_LAUNCH.md`](docs/WEAVER_STACK_LAUNCH.md): a drafted
+    ecosystem-level launch post (#81), honest about maturity, with the
+    cross-repo golden path as the centerpiece proof.
+  - Added the "Part of the Weaver Stack" block + explainer links to
+    `README.md`, and cross-links from `docs/ECOSYSTEM.md`, `docs/VISION.md`, and
+    the `AGENTS.md` documentation map.
 - **Closed-loop interchange, firewall seam, and cross-repo golden path (#82, #83,
   #84).** Documentation + examples + conformance fixtures that finalize the
   cross-repo story. No contract shape changed, so no version bump (consistent

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 [![Weaver-compatible](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/dgenio/weaver-spec/main/docs/badges/weaver-spec.json)](docs/SELF_CERTIFICATION.md)
 
+> **Part of the [Weaver Stack](docs/WEAVER_STACK.md)**
+>
+> | Repo | Role |
+> |------|------|
+> | [weaver-spec](https://github.com/dgenio/weaver-spec) | Canonical specs + contracts |
+> | [contextweaver](https://github.com/dgenio/contextweaver) | Context compilation + routing |
+> | [agent-kernel](https://github.com/dgenio/agent-kernel) | Execution + firewalling + audit |
+> | [ChainWeaver](https://github.com/dgenio/ChainWeaver) | Flow orchestration |
+>
+> New here? Start with [What Is the Weaver Stack?](docs/WEAVER_STACK.md).
+
 This repository is the single source of truth for the vocabulary, invariants, responsibility boundaries, versioning rules, and language-agnostic contract schemas that keep the Weaver ecosystem composable and compatible.
 
 ---
@@ -46,8 +57,10 @@ This repo is the contract layer for all of the above. You do not need to adopt e
 
 | What you need | Where to look |
 | --------------- | --------------- |
+| What is the Weaver Stack? (explainer) | [docs/WEAVER_STACK.md](docs/WEAVER_STACK.md) |
 | Ecosystem overview | [docs/VISION.md](docs/VISION.md) |
 | Ecosystem boundary map | [docs/ECOSYSTEM.md](docs/ECOSYSTEM.md) |
+| Ecosystem launch post (draft) | [docs/WEAVER_STACK_LAUNCH.md](docs/WEAVER_STACK_LAUNCH.md) |
 | Quick-start (Python + JS/TS) | [docs/QUICKSTART.md](docs/QUICKSTART.md) |
 | Contract field reference | [docs/CONTRACT_REFERENCE.md](docs/CONTRACT_REFERENCE.md) |
 | Layer architecture | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |

--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -3,6 +3,8 @@
 A neutral map of the projects in the Weaver ecosystem: what each one is, where the boundaries are, and which contracts cross between them.
 
 > [!NOTE]
+> For a narrative introduction — the problem, the layered architecture, and the closed learning loop — see [What Is the Weaver Stack?](WEAVER_STACK.md). This page is the boundary-focused companion to that explainer.
+>
 > This page is a **derived, informative** overview. The canonical authorities are [`docs/BOUNDARIES.md`](BOUNDARIES.md) (responsibility boundaries and artifact ownership), [`docs/LIFECYCLE.md`](LIFECYCLE.md) (the normative five-phase lifecycle), and [`docs/ARTIFACT_CONTRACTS.md`](ARTIFACT_CONTRACTS.md) (cross-project artifacts). Where this page and a canonical doc differ, the canonical doc wins.
 
 ---

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,5 +1,8 @@
 # Vision
 
+> [!NOTE]
+> For the ecosystem-level narrative — how the layers and the closed learning loop fit together — see [What Is the Weaver Stack?](WEAVER_STACK.md).
+
 ## The Problem
 
 Modern LLM-based agents face four compounding problems:

--- a/docs/WEAVER_STACK.md
+++ b/docs/WEAVER_STACK.md
@@ -1,0 +1,249 @@
+# What Is the Weaver Stack?
+
+The Weaver Stack is a set of independently adoptable repositories that together
+describe a **governed, context-budgeted, auditable agent runtime** — and a
+**closed learning loop** that lets that runtime improve from its own traces.
+This page is the ecosystem-level explainer: why the pieces exist together and
+what becomes possible when they do.
+
+> [!NOTE]
+> This page is **informative**. It is a narrative entry point, not a
+> specification. The canonical authorities remain
+> [`docs/INVARIANTS.md`](INVARIANTS.md), [`docs/BOUNDARIES.md`](BOUNDARIES.md),
+> and [`docs/ARCHITECTURE.md`](ARCHITECTURE.md); where this page and a canonical
+> doc differ, the canonical doc wins. Authority order:
+> `INVARIANTS.md > BOUNDARIES.md > ARCHITECTURE.md > everything else`.
+>
+> **Maturity.** The Weaver Stack is an early, single-author project. The
+> credible part today is the **architecture and the contracts** — the shared
+> shapes and invariants in this repository — not production hardening or
+> adoption numbers. This page leads with the design on purpose.
+
+---
+
+## The problem
+
+Modern LLM-based agents hit four compounding problems (see
+[`docs/VISION.md`](VISION.md) for the longer form):
+
+1. **Tool explosion** — injecting 1000+ tool schemas into every prompt is
+   expensive and noisy.
+2. **Context bloat** — raw tool outputs are large, sometimes sensitive, and
+   unsafe to pass to an LLM unfiltered.
+3. **Unsafe execution** — without a principled authorization layer, an agent can
+   call any tool with any arguments, with no auditable record.
+4. **Flaky orchestration** — ad-hoc chaining produces non-deterministic,
+   hard-to-debug pipelines.
+
+Each problem has been solved in isolation many times. The gap the Weaver Stack
+addresses is solving them **with one shared contract set**, so the pieces compose
+instead of each re-inventing the boundary.
+
+---
+
+## The layered architecture
+
+The stack is three runtime layers on the request path, plus adjacent tools that
+share the same contracts. Each layer owns a single responsibility and
+communicates only through the contracts defined in this repository.
+
+| Layer | Repository | Responsibility |
+| ----- | ---------- | -------------- |
+| **Routing** | [contextweaver](https://github.com/dgenio/contextweaver) | Compiles context, selects tools as `ChoiceCard`s, emits a `RoutingDecision`. Never executes tools; never sees raw output. |
+| **Execution** | [agent-kernel](https://github.com/dgenio/agent-kernel) | Authorizes capabilities, executes tools, firewalls raw output into a `Frame` (+ `Handle`), emits `TraceEvent`s. Owns the only firewall. |
+| **Orchestration** | [ChainWeaver](https://github.com/dgenio/ChainWeaver) | Runs deterministic DAG flows; delegates every capability step to agent-kernel. |
+
+Adjacent tools (not on the runtime request path, but contract-compatible):
+
+| Tool | Role |
+| ---- | ---- |
+| **AgentFence** | External policy firewall / proxy at the edge. Complements — does not replace — the agent-kernel firewall. |
+| **lessonweaver** | Reviews captured traces into reusable `LessonCard` / `SkillCard` artifacts. |
+| **vibeguard** | Pre-merge safety gate for AI-generated code and file changes. |
+
+> [!IMPORTANT]
+> The runtime artifact-ownership rows above are a convenience view of the
+> normative table in [`docs/BOUNDARIES.md`](BOUNDARIES.md). That document is
+> canonical; this page must not contradict it. Changing a runtime boundary
+> requires a spec-level ADR.
+
+---
+
+## The request path and the closed learning loop
+
+The diagram below is **derived** from the artifact-ownership table in
+[`docs/BOUNDARIES.md`](BOUNDARIES.md) (canonical) and the data flow in
+[`docs/ARCHITECTURE.md`](ARCHITECTURE.md). The solid path is a single request;
+the dashed path is the learning loop that feeds the next one.
+
+```mermaid
+graph TD
+    A([User / Caller]) -->|conversation state| B[contextweaver<br/>routing]
+    B -->|RoutingDecision + CapabilityToken| C[agent-kernel<br/>execution]
+    C -->|validate token| D{Policy}
+    D -->|deny| Z([PolicyDecision: deny])
+    D -->|allow| E[Tool Executor]
+    E -->|raw output| F[Firewall]
+    F -->|Frame| B
+    F -->|Handle| H[(HandleStore)]
+    C -->|TraceEvent| L[(Audit Log)]
+    B -->|enriched context| A
+
+    subgraph Orchestration
+        O[ChainWeaver<br/>flow DAG] -->|delegates each step| C
+    end
+    A -->|flow request| O
+
+    subgraph Edge
+        AF[AgentFence<br/>external policy edge]
+    end
+    C -.optional external gate.- AF
+
+    subgraph "Closed learning loop"
+        L -.TraceEvent / ActionTrace.-> FC[FailureCaseArtifact<br/>+ TraceBundle]
+        FC -.review.-> LW[lessonweaver]
+        LW -.LessonCard / SkillCard.-> B
+    end
+```
+
+Reading the diagram:
+
+- **Routing → execution:** contextweaver emits a `RoutingDecision`; agent-kernel
+  authorizes (`PolicyDecision`), executes, and firewalls. Only a `Frame` (safe
+  view) and an optional `Handle` (opaque reference) leave the kernel — never raw
+  output. This is invariant
+  [I-01](INVARIANTS.md#i-01-llm-never-sees-raw-tool-output-by-default).
+- **Orchestration:** ChainWeaver sequences multi-step flows but delegates every
+  capability invocation back to agent-kernel.
+- **Audit:** every execution appends a `TraceEvent` to the audit log.
+- **Closed loop:** traces map into one canonical interchange — a
+  [`FailureCaseArtifact`](ARTIFACT_CONTRACTS.md#the-canonical-findingfailure-interchange-the-closed-loop)
+  referencing a [`TraceBundle`](TRACE_BUNDLE.md) — which lessonweaver reviews
+  into `LessonCard` / `SkillCard` artifacts that re-enter routing. The
+  end-to-end sequence is tracked in [`docs/GOLDEN_PATH.md`](GOLDEN_PATH.md).
+
+---
+
+## What becomes possible when the pieces compose
+
+Adopting one layer solves one problem. Adopting the set is what makes the four
+properties of [`docs/VISION.md`](VISION.md) hold *together*:
+
+- **Bounded choices** — the LLM selects from a small, pre-screened set of
+  `ChoiceCard`s, not an unbounded tool list.
+- **Auditable execution** — every invocation is authorized and recorded against
+  a request and principal.
+- **Safe outputs** — the LLM never sees raw output by default; it sees `Frame`s.
+- **Self-improvement** — the closed loop turns audit traces into reviewed
+  lessons and skills that improve the next request.
+
+None of this requires a single monolith. The contracts are the interfaces; the
+repositories are the reference implementations.
+
+---
+
+## Adopt one or adopt all
+
+Every layer is independently useful. You only need to honor the contracts at the
+boundaries you actually cross (see the [adoption paths](../README.md#adoption-paths)
+and [`docs/ADOPTION_GUIDE.md`](ADOPTION_GUIDE.md)).
+
+| If you want… | Adopt | And bring |
+| ------------ | ----- | --------- |
+| Smarter, bounded tool routing | contextweaver | your own execution layer that returns a `Frame` |
+| Authorization, firewalling, and audit | agent-kernel | your own routing that returns a `RoutingDecision` |
+| Deterministic multi-step flows | ChainWeaver | any backend honoring `CapabilityToken` + `RoutingDecision` |
+| Just the shared contracts | this repo | nothing — read the schemas or `pip install weaver_contracts` |
+
+For the proof that the pieces actually fit, see the runnable
+[reference implementation](../examples/reference_impl/) and the cross-repo
+[golden path](GOLDEN_PATH.md).
+
+---
+
+## The ecosystem front door
+
+This section is the **single source** for the reusable copy that the stack's
+public surfaces share — the org / landing-page profile and the per-repo
+cross-link block. Authoring it once here keeps the diagram and one-line roles
+from drifting across surfaces.
+
+> [!NOTE]
+> Creating the GitHub Organization and editing sibling-repo READMEs are actions
+> outside this repository. The blocks below are the source content for those
+> steps; the steps themselves are tracked as a checklist at the end of this
+> section.
+
+### Profile / landing-page README block
+
+Paste into the organization (or `dgenio/dgenio`) profile README and the landing
+page. Render the architecture diagram from the
+[request-path diagram above](#the-request-path-and-the-closed-learning-loop).
+
+```markdown
+# The Weaver Stack
+
+A governed, context-budgeted, auditable agent runtime — plus a closed learning
+loop that improves it from its own traces. Adopt one repo or the whole set;
+they compose through one shared contract layer.
+
+| Repo | Role |
+| ---- | ---- |
+| [weaver-spec](https://github.com/dgenio/weaver-spec) | Canonical specs + shared contracts |
+| [contextweaver](https://github.com/dgenio/contextweaver) | Context compilation + tool routing |
+| [agent-kernel](https://github.com/dgenio/agent-kernel) | Execution + firewalling + audit |
+| [ChainWeaver](https://github.com/dgenio/ChainWeaver) | Deterministic flow orchestration |
+
+**Start here:** read [weaver-spec](https://github.com/dgenio/weaver-spec), then
+adopt the layer you need.
+```
+
+### Per-repo "Part of the Weaver Stack" block
+
+Paste near the top of each repo's `README.md`:
+
+```markdown
+> **Part of the [Weaver Stack](https://github.com/dgenio/weaver-spec)**
+>
+> | Repo | Role |
+> |------|------|
+> | [weaver-spec](https://github.com/dgenio/weaver-spec) | Canonical specs + contracts |
+> | [contextweaver](https://github.com/dgenio/contextweaver) | Context compilation + routing |
+> | [agent-kernel](https://github.com/dgenio/agent-kernel) | Execution + firewalling + audit |
+> | [ChainWeaver](https://github.com/dgenio/ChainWeaver) | Flow orchestration |
+```
+
+### Shared GitHub topics
+
+Apply the same topic set to every repo so they are discoverable via
+`topic:weaver-stack`:
+
+```text
+weaver-stack
+mcp
+agent-tools
+context-management
+capabilities
+```
+
+### Front-door rollout checklist
+
+- [ ] Create a GitHub Organization (brand hub) **or** decide brand-only and
+      document the transfer-vs-brand-only choice (transfers change clone URLs).
+- [ ] Publish the profile / landing-page README block (above) with the
+      architecture diagram.
+- [ ] Add the "Part of the Weaver Stack" block to each repo README:
+      `weaver-spec`, `contextweaver`, `agent-kernel`, `ChainWeaver`.
+- [ ] Apply the shared topic set across the repos.
+- [ ] Point the launch post ([`docs/WEAVER_STACK_LAUNCH.md`](WEAVER_STACK_LAUNCH.md))
+      at the golden-path demo.
+
+---
+
+## See also
+
+- [`docs/VISION.md`](VISION.md) — the problem and the four properties in full.
+- [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) — the canonical layer model and data flow.
+- [`docs/ECOSYSTEM.md`](ECOSYSTEM.md) — the neutral boundary map (owns / consumes / emits).
+- [`docs/GOLDEN_PATH.md`](GOLDEN_PATH.md) — the end-to-end demo sequence.
+- [`docs/WEAVER_STACK_LAUNCH.md`](WEAVER_STACK_LAUNCH.md) — the ecosystem launch-post draft.

--- a/docs/WEAVER_STACK.md
+++ b/docs/WEAVER_STACK.md
@@ -189,10 +189,10 @@ they compose through one shared contract layer.
 
 | Repo | Role |
 | ---- | ---- |
-| [weaver-spec](https://github.com/dgenio/weaver-spec) | Canonical specs + shared contracts |
-| [contextweaver](https://github.com/dgenio/contextweaver) | Context compilation + tool routing |
+| [weaver-spec](https://github.com/dgenio/weaver-spec) | Canonical specs + contracts |
+| [contextweaver](https://github.com/dgenio/contextweaver) | Context compilation + routing |
 | [agent-kernel](https://github.com/dgenio/agent-kernel) | Execution + firewalling + audit |
-| [ChainWeaver](https://github.com/dgenio/ChainWeaver) | Deterministic flow orchestration |
+| [ChainWeaver](https://github.com/dgenio/ChainWeaver) | Flow orchestration |
 
 **Start here:** read [weaver-spec](https://github.com/dgenio/weaver-spec), then
 adopt the layer you need.
@@ -212,6 +212,9 @@ Paste near the top of each repo's `README.md`:
 > | [agent-kernel](https://github.com/dgenio/agent-kernel) | Execution + firewalling + audit |
 > | [ChainWeaver](https://github.com/dgenio/ChainWeaver) | Flow orchestration |
 ```
+
+The `Weaver Stack` link points at `weaver-spec` as the interim front door. Once
+the GitHub Organization exists (#79), repoint it at the org profile.
 
 ### Shared GitHub topics
 

--- a/docs/WEAVER_STACK_LAUNCH.md
+++ b/docs/WEAVER_STACK_LAUNCH.md
@@ -1,0 +1,77 @@
+# Ecosystem Launch Post — Draft
+
+> [!NOTE]
+> This is a **draft marketing artifact**, not a specification. It is kept in the
+> repo so the ecosystem-level narrative has one versioned source. It is distinct
+> from each repo's own launch. Keep it honest about maturity — the project is
+> early and single-author; lead with the architecture and the ideas. The
+> canonical technical source is [`docs/WEAVER_STACK.md`](WEAVER_STACK.md).
+
+---
+
+## Title options
+
+- "The Weaver Stack: a governed, self-improving agent runtime — assembled from
+  small, independent contracts"
+- "Show HN: Weaver Stack — bounded tool routing, a firewalled kernel, and a
+  closed learning loop, sharing one contract set"
+
+---
+
+## Blog / Show HN body
+
+Most agent frameworks ship as one large runtime. The Weaver Stack is the
+opposite bet: a handful of **independently adoptable** repositories that agree on
+**one shared contract layer**, so each piece is useful alone and the set composes
+without lock-in.
+
+The four problems it targets — tool explosion, context bloat, unsafe execution,
+and flaky orchestration — are familiar. What is different here is solving them
+behind shared, language-agnostic contracts (JSON Schemas + a stdlib Python
+mirror) rather than inside one framework's internals:
+
+- **contextweaver** compiles context and routes — the LLM picks from a small set
+  of pre-screened `ChoiceCard`s instead of an unbounded tool list.
+- **agent-kernel** authorizes, executes, and firewalls. Raw tool output never
+  reaches the model by default; only a safe `Frame` (and an opaque `Handle`)
+  leaves the kernel. Every call is recorded as a `TraceEvent`.
+- **ChainWeaver** runs deterministic flows, delegating every step back to the
+  kernel.
+- A **closed learning loop** turns those audit traces into reviewed
+  `LessonCard` / `SkillCard` artifacts (via lessonweaver) that re-enter routing
+  and improve the next request.
+
+Because the boundaries are defined as **contracts, not code coupling**, you can
+adopt one layer and bring your own for the rest — or read the schemas and
+integrate nothing at all.
+
+### The honest part
+
+This is early, single-author work. The credible deliverable today is the
+**architecture and the contracts**: the invariants, the responsibility
+boundaries, and the schemas in
+[weaver-spec](https://github.com/dgenio/weaver-spec) — not production scale or an
+adoption story. If you care about *how to draw the boundaries* for a safe,
+auditable, self-improving agent runtime, that is what this is for.
+
+### Try it
+
+The cross-repo [golden path](GOLDEN_PATH.md) is the centerpiece: one request
+flowing through routing → execution → audit → learning. The runnable
+[reference implementation](../examples/reference_impl/) constructs every Core
+artifact end-to-end and validates it against the schemas.
+
+Start at [weaver-spec](https://github.com/dgenio/weaver-spec); the
+[explainer](WEAVER_STACK.md) has the full architecture and the closed-loop
+diagram.
+
+---
+
+## Distribution checklist
+
+- [ ] Publish on the landing page / org profile (see the front-door section of
+      [`docs/WEAVER_STACK.md`](WEAVER_STACK.md)).
+- [ ] Cross-post (blog + Show HN / relevant subreddits) as the *ecosystem*
+      story, distinct from the per-repo launches.
+- [ ] Link the golden-path demo as the centerpiece proof.
+- [ ] Keep claims consistent with the per-repo positioning and the maturity note.


### PR DESCRIPTION
Author the ecosystem-level narrative once and surface it across the stack's
public surfaces, so the architecture diagram and one-line roles do not drift.

- docs/WEAVER_STACK.md: "What Is the Weaver Stack?" explainer (#81) — problem,
  layered architecture, and a request-path + closed-learning-loop Mermaid
  diagram derived from BOUNDARIES.md/ARCHITECTURE.md (canonical). Also the
  single source for the reusable front-door copy: org/landing profile README
  block, the per-repo "Part of the Weaver Stack" block (#6), and the shared
  topic set, plus a rollout checklist for the out-of-repo steps (org #79,
  sibling-repo edits #6, landing page #5).
- docs/WEAVER_STACK_LAUNCH.md: drafted ecosystem-level launch post (#81),
  honest about maturity, golden path as centerpiece.
- README.md: add "Part of the Weaver Stack" block + explainer/launch nav links.
- docs/ECOSYSTEM.md, docs/VISION.md: cross-link the explainer.
- AGENTS.md: add documentation-map rows for the two new docs.
- CHANGELOG.md: Unreleased docs-only entry (no contract change, no version bump).

Docs only; no Core/Extended contract touched (six-artifact rule N/A). The
out-of-repo actions (creating the GitHub Org, editing sibling READMEs, the
landing page) consume the paste-ready blocks here and are tracked as checklists.