### PR TITLE
fix: update self-cert badge to v0.7.0

### DIFF
--- a/docs/badges/weaver-spec.json
+++ b/docs/badges/weaver-spec.json
@@ -2,6 +2,6 @@
   "color": "brightgreen",
   "isError": false,
   "label": "weaver-compatible",
-  "message": "v0.6.0",
+  "message": "v0.7.0",
   "schemaVersion": 1
 }


### PR DESCRIPTION
## Problem

The `reference-impl` CI job fails after the v0.7.0 release because `docs/badges/weaver-spec.json` still shows `v0.6.0`. The conformance runner regenerates the badge at runtime and `git diff --exit-code` rejects the stale version.

## Fix

Update the badge `message` field from `v0.6.0` → `v0.7.0`.

## Checklist

- [x] Badge version matches current `CONTRACT_VERSION`
- [x] CI `reference-impl` job will no longer fail on badge staleness
- [ ] Merge triggers green CI on `main`