### PR TITLE
ci: enforce schema/dataclass parity, version consistency, and consolidate alignment tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,22 @@ jobs:
       - name: Check well-known/contracts.json is up to date
         run: python scripts/generate_contracts_index.py --check
 
+  validate-version-consistency:
+    name: Validate Version Consistency
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check the contract version string is consistent everywhere
+        run: python scripts/check_version_consistency.py
+
   validate-walkthroughs:
     name: Validate Walkthrough Payloads
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,17 @@ repos:
         pass_filenames: false
         files: '^(contracts/json/.*\.schema\.json|well-known/contracts\.json|scripts/generate_contracts_index\.py|contracts/python/src/weaver_contracts/version\.py)$'
 
+      - id: version-consistency
+        name: contract version string is consistent everywhere
+        description: |
+          Mirrors the validate-version-consistency CI job. Fails when any
+          tracked file's version string drifts from CONTRACT_VERSION in
+          version.py (the single source of truth).
+        entry: python scripts/check_version_consistency.py
+        language: system
+        pass_filenames: false
+        files: '^(contracts/python/src/weaver_contracts/version\.py|contracts/python/pyproject\.toml|well-known/contracts\.json|CHANGELOG\.md|README\.md|docs/VERSIONING\.md|compatibility\.yaml|scripts/check_version_consistency\.py)$'
+
       - id: weaver-contracts-tests
         name: weaver_contracts pytest (changed Python files only)
         description: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ This repository is **documentation + contracts only**.
 | `docs/SELF_CERTIFICATION.md` | "Weaver-compatible" badge + self-certification flow (#77), derived from a verifiable conformance result | When changing the badge/result contract or self-cert flow |
 | `examples/reference_impl/` | Runnable reference implementation (#76): constructs every Core artifact, mints+verifies an ephemeral ed25519 signature over a `TraceBundle`, validates against the schemas, asserts I-01/I-02. **Example tier**, not the package — it reuses the conformance dev deps (`jcs`/`cryptography`/`jsonschema`), is never imported by `weaver_contracts`, is never published, and is CI-checked by the `reference-impl` job. The one runnable demonstration in this repo, kept isolated under `examples/`. | When illustrating end-to-end Core-contract usage, or after any Core schema change (the example must still validate) |
 | `scripts/generate_coverage_table.py` | Build-time tooling (stdlib only) that regenerates `contracts/COVERAGE.md` from the filesystem | When adding a new contract type, sample payload, or test class |
+| `scripts/check_version_consistency.py` | Build-time tooling (stdlib only — no YAML/TOML/JSON parser) that asserts every tracked file's version string matches `CONTRACT_VERSION` in `version.py`; run by the `validate-version-consistency` CI job and the `version-consistency` pre-commit hook | When the contract version is bumped, or when adding a file that states the version |
 | `scripts/validate_compatibility.py` | Build-time tooling (stdlib only — no YAML parser) holding the `compatibility.yaml` validation logic + self-test; callers (the `validate-compatibility` CI job and the `compatibility-manifest` pre-commit hook) parse the YAML and call `validate()` | When changing the compatibility manifest's required fields or validation rules |
 | `scripts/validate_meta_package.py` | Build-time tooling (stdlib only — no YAML/TOML parser) holding the `weaver-stack` meta-package consistency logic + self-test; callers (the `validate-meta-package` CI job and the `meta-package` pre-commit hook) parse `compatibility.yaml` + the meta-package `pyproject.toml` and call `validate()` | When changing how the meta-package's pins must track `compatibility.yaml` |
 | `packaging/weaver-stack/` | Umbrella meta-package (#80): `pyproject.toml` + `README.md` only, no code. Pins a known-compatible set (base = `weaver_contracts`; `runtime`/`devtools` extras) derived from `compatibility.yaml`. Published to PyPI as `weaver-stack`; never imported by `weaver_contracts`. | When the compatible set, extras, or meta-package version changes |
@@ -79,6 +80,10 @@ For JSON schema conventions specifically, `contracts/json/README.md` is authorit
 JSON Schemas are the language-agnostic source of truth for all **Core** contract definitions. Python Core types must mirror them exactly — same field names, same types, same required/optional status. Zero divergence.
 
 Extended contracts define JSON Schemas under `contracts/json/extended/`. The Python dataclass in `extended.py` must mirror its schema (same as Core).
+
+This mirroring is enforced mechanically — not just by review — by `contracts/python/tests/test_schema_parity.py`, which checks field names, required/optional status, and a coarse type shape for every Core and Extended type against its schema.
+
+The single source of truth for the contract *version* string is `weaver_contracts.version.CONTRACT_VERSION`; `scripts/check_version_consistency.py` (the `validate-version-consistency` CI job) fails if any tracked file drifts from it.
 
 ---
 
@@ -198,6 +203,9 @@ python scripts/check_schema_fields.py
 
 # 4. Contracts index freshness — regenerate first if any contracts/json/ file changed
 python scripts/generate_contracts_index.py --check
+
+# 4b. Contract version string consistency (single source: version.py)
+python scripts/check_version_consistency.py
 
 # 5. Markdown lint
 # See CONTRIBUTING.md "Markdown Lint" section for the canonical command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
 
 ## [Unreleased]
 
+### Added
+
+- Mechanical dataclass ⟷ JSON Schema parity test (`contracts/python/tests/test_schema_parity.py`)
+  covering every Core and Extended type — field names, required/optional status, and a coarse
+  type shape — turning the "schemas lead, Python mirrors exactly" rule into an enforced guarantee
+  (#111, #112).
+- `scripts/check_version_consistency.py` plus the `validate-version-consistency` CI job and a
+  `version-consistency` pre-commit hook: `weaver_contracts.version.CONTRACT_VERSION` is now the
+  single source of truth for the contract version, and any drift in `README.md`, `pyproject.toml`,
+  `well-known/contracts.json`, `CHANGELOG.md`, `docs/VERSIONING.md`, or `compatibility.yaml` fails
+  CI (#110).
+
+### Changed
+
+- Consolidated the schema-alignment test boilerplate onto a shared
+  `contracts/python/tests/_schema_alignment.py` helper and migrated both alignment modules off the
+  deprecated `jsonschema.RefResolver` to the modern `referencing.Registry` pattern used by the
+  conformance runner. The suite now runs clean under `-W error::DeprecationWarning` (#113, #114).
+- Documented Extended contracts as **schema-led** (same authority as Core; the MINOR-breaking
+  exception is a stability promise, not a different source of truth) across `CONTRACT_REFERENCE.md`
+  and `VERSIONING.md` (#112).
+
+### Fixed
+
+- Corrected the contract version stated in `README.md`, `docs/VERSIONING.md`, and
+  `compatibility.yaml` from a stale `0.5.0` to the current `0.7.0` (#110).
+
 ---
 
 ## [0.7.0] - 2026-06-06

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ examples/
 
 The spec and contracts follow semantic versioning. See [docs/VERSIONING.md](docs/VERSIONING.md) for the full compatibility promise.
 
-Current contract version: **0.5.0**
+Current contract version: **0.7.0**
 
 ---
 

--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -20,7 +20,7 @@ schema_version: 1
 # weaver-spec contract versions this manifest reasons about. All 0.x versions
 # share MAJOR 0 and are mutually compatible (see docs/VERSIONING.md).
 contract_versions:
-  - "0.5.0"
+  - "0.7.0"
 
 repositories:
   - name: contextweaver

--- a/contracts/COVERAGE.md
+++ b/contracts/COVERAGE.md
@@ -22,21 +22,21 @@ CI runs the same script with `--check` and fails if this file is stale.
 - Python classes: **32 / 32**
 - Sample payloads: **32 / 32**
 - Roundtrip tests: **32 / 32**
-- Schema validation tests: **26 / 32**
+- Schema validation tests: **32 / 32**
 
 ## Coverage table
 
 | Tier | Type | JSON Schema | Python Class | Sample Payload | Roundtrip Test | Schema Test |
 | ---- | ---- | :---------: | :----------: | :------------: | :------------: | :---------: |
-| Core | `SelectableItem` | OK | OK | OK | OK | -- |
+| Core | `SelectableItem` | OK | OK | OK | OK | OK |
 | Core | `ChoiceCard` | OK | OK | OK | OK | OK |
-| Core | `RoutingDecision` | OK | OK | OK | OK | -- |
-| Core | `Capability` | OK | OK | OK | OK | -- |
+| Core | `RoutingDecision` | OK | OK | OK | OK | OK |
+| Core | `Capability` | OK | OK | OK | OK | OK |
 | Core | `CapabilityToken` | OK | OK | OK | OK | OK |
-| Core | `PolicyDecision` | OK | OK | OK | OK | -- |
+| Core | `PolicyDecision` | OK | OK | OK | OK | OK |
 | Core | `Frame` | OK | OK | OK | OK | OK |
-| Core | `Handle` | OK | OK | OK | OK | -- |
-| Core | `TraceEvent` | OK | OK | OK | OK | -- |
+| Core | `Handle` | OK | OK | OK | OK | OK |
+| Core | `TraceEvent` | OK | OK | OK | OK | OK |
 | Extended | `TelemetryHint` | OK | OK | OK | OK | OK |
 | Extended | `SchemaFingerprint` | OK | OK | OK | OK | OK |
 | Extended | `RedactionPolicy` | OK | OK | OK | OK | OK |

--- a/contracts/python/tests/_schema_alignment.py
+++ b/contracts/python/tests/_schema_alignment.py
@@ -1,0 +1,78 @@
+"""Shared schema-alignment harness for the contract test suite.
+
+Single home for the registry/validation boilerplate consumed by the Core
+(``test_json_schema_alignment.py``) and Extended
+(``test_extended_schema_alignment.py``) alignment modules. It builds one
+``referencing.Registry`` over every local schema and validates with
+``Draft202012Validator`` — the same modern pattern the conformance runner uses
+(``conformance/run.py:load_schemas``), replacing the deprecated
+``jsonschema.RefResolver`` the alignment tests used before (issues #113, #114).
+
+This is a helper, not a test module: the leading underscore keeps pytest from
+collecting it.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT202012
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+CORE_SCHEMA_DIR = REPO_ROOT / "contracts" / "json"
+EXTENDED_SCHEMA_DIR = CORE_SCHEMA_DIR / "extended"
+PAYLOADS_DIR = REPO_ROOT / "examples" / "sample_payloads"
+
+
+def build_registry() -> Registry:
+    """Preload every Core + Extended schema by ``$id`` so cross-schema ``$ref``s
+    resolve offline (no network), mirroring ``conformance/run.py:load_schemas``."""
+    registry: Registry = Registry()
+    for path in sorted(CORE_SCHEMA_DIR.glob("*.schema.json")) + sorted(
+        EXTENDED_SCHEMA_DIR.glob("*.schema.json")
+    ):
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        if "$id" in schema:
+            registry = registry.with_resource(
+                uri=schema["$id"],
+                resource=Resource(contents=schema, specification=DRAFT202012),
+            )
+    return registry
+
+
+REGISTRY = build_registry()
+
+
+def load_core_schema(stem: str) -> dict:
+    return json.loads((CORE_SCHEMA_DIR / f"{stem}.schema.json").read_text(encoding="utf-8"))
+
+
+def load_extended_schema(stem: str) -> dict:
+    return json.loads(
+        (EXTENDED_SCHEMA_DIR / f"{stem}.schema.json").read_text(encoding="utf-8")
+    )
+
+
+def load_payload(stem: str) -> dict:
+    return json.loads((PAYLOADS_DIR / f"{stem}.json").read_text(encoding="utf-8"))
+
+
+def validate(payload: dict, schema: dict) -> None:
+    """Validate ``payload`` against ``schema`` using the preloaded registry for
+    offline ``$ref`` resolution and full format checking.
+
+    Raises ``AssertionError`` listing every error on failure, preserving the
+    ``"Schema validation failed:"`` prefix the negative-case tests match on.
+    """
+    validator = Draft202012Validator(
+        schema,
+        registry=REGISTRY,
+        format_checker=Draft202012Validator.FORMAT_CHECKER,
+    )
+    errors = list(validator.iter_errors(payload))
+    if errors:
+        msgs = "\n".join(str(e) for e in errors)
+        raise AssertionError(f"Schema validation failed:\n{msgs}")

--- a/contracts/python/tests/_schema_alignment.py
+++ b/contracts/python/tests/_schema_alignment.py
@@ -27,6 +27,20 @@ EXTENDED_SCHEMA_DIR = CORE_SCHEMA_DIR / "extended"
 PAYLOADS_DIR = REPO_ROOT / "examples" / "sample_payloads"
 
 
+def _read_json(path: pathlib.Path) -> dict:
+    """Parse a JSON file, annotating parse errors with the path.
+
+    ``build_registry`` runs at import time, so a malformed schema would
+    otherwise surface as a bare ``JSONDecodeError`` during pytest collection
+    with no indication of which file is broken. Stdlib-only.
+    """
+    text = path.read_text(encoding="utf-8")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path}: invalid JSON: {exc}") from exc
+
+
 def build_registry() -> Registry:
     """Preload every Core + Extended schema by ``$id`` so cross-schema ``$ref``s
     resolve offline (no network), mirroring ``conformance/run.py:load_schemas``."""
@@ -34,7 +48,7 @@ def build_registry() -> Registry:
     for path in sorted(CORE_SCHEMA_DIR.glob("*.schema.json")) + sorted(
         EXTENDED_SCHEMA_DIR.glob("*.schema.json")
     ):
-        schema = json.loads(path.read_text(encoding="utf-8"))
+        schema = _read_json(path)
         if "$id" in schema:
             registry = registry.with_resource(
                 uri=schema["$id"],
@@ -47,17 +61,15 @@ REGISTRY = build_registry()
 
 
 def load_core_schema(stem: str) -> dict:
-    return json.loads((CORE_SCHEMA_DIR / f"{stem}.schema.json").read_text(encoding="utf-8"))
+    return _read_json(CORE_SCHEMA_DIR / f"{stem}.schema.json")
 
 
 def load_extended_schema(stem: str) -> dict:
-    return json.loads(
-        (EXTENDED_SCHEMA_DIR / f"{stem}.schema.json").read_text(encoding="utf-8")
-    )
+    return _read_json(EXTENDED_SCHEMA_DIR / f"{stem}.schema.json")
 
 
 def load_payload(stem: str) -> dict:
-    return json.loads((PAYLOADS_DIR / f"{stem}.json").read_text(encoding="utf-8"))
+    return _read_json(PAYLOADS_DIR / f"{stem}.json")
 
 
 def validate(payload: dict, schema: dict) -> None:

--- a/contracts/python/tests/test_extended_schema_alignment.py
+++ b/contracts/python/tests/test_extended_schema_alignment.py
@@ -9,16 +9,18 @@ schema-test artifact for that type.
 """
 
 import json
-import pathlib
 
 import pytest
 
-jsonschema = pytest.importorskip("jsonschema")
+pytest.importorskip("jsonschema")
 
-REPO_ROOT = pathlib.Path(__file__).parent.parent.parent.parent
-CORE_SCHEMA_DIR = REPO_ROOT / "contracts" / "json"
-EXTENDED_SCHEMA_DIR = CORE_SCHEMA_DIR / "extended"
-PAYLOADS_DIR = REPO_ROOT / "examples" / "sample_payloads"
+from tests._schema_alignment import (  # noqa: E402
+    CORE_SCHEMA_DIR,
+    EXTENDED_SCHEMA_DIR,
+    load_extended_schema,
+    load_payload,
+    validate,
+)
 
 # (dataclass name, snake_case schema/payload stem). The dataclass names appear
 # here as whole tokens so the coverage generator marks the schema test present:
@@ -54,51 +56,6 @@ EXTENDED_TYPES = [
     ("TraceBundle", "trace_bundle"),
     ("FailureCaseArtifact", "failure_case_artifact"),
 ]
-
-
-def load_extended_schema(stem: str) -> dict:
-    with open(EXTENDED_SCHEMA_DIR / f"{stem}.schema.json") as f:
-        return json.load(f)
-
-
-def load_payload(stem: str) -> dict:
-    with open(PAYLOADS_DIR / f"{stem}.json") as f:
-        return json.load(f)
-
-
-def build_store() -> dict:
-    """URI -> schema for all local schemas (Core + Extended), so $ref
-    resolution works without network access."""
-    store = {}
-    for schema_file in list(CORE_SCHEMA_DIR.glob("*.schema.json")) + list(
-        EXTENDED_SCHEMA_DIR.glob("*.schema.json")
-    ):
-        with open(schema_file) as f:
-            schema = json.load(f)
-        if "$id" in schema:
-            store[schema["$id"]] = schema
-    return store
-
-
-_SCHEMA_STORE = build_store()
-
-
-def validate(payload: dict, schema: dict) -> None:
-    resolver = jsonschema.RefResolver(
-        base_uri=schema.get("$id", ""),
-        referrer=schema,
-        store=_SCHEMA_STORE,
-    )
-    validator_cls = jsonschema.validators.validator_for(schema)
-    validator = validator_cls(
-        schema,
-        resolver=resolver,
-        format_checker=jsonschema.FormatChecker(),
-    )
-    errors = list(validator.iter_errors(payload))
-    if errors:
-        msgs = "\n".join(str(e) for e in errors)
-        raise AssertionError(f"Schema validation failed:\n{msgs}")
 
 
 class TestExtendedSchemaStructure:

--- a/contracts/python/tests/test_json_schema_alignment.py
+++ b/contracts/python/tests/test_json_schema_alignment.py
@@ -1,72 +1,51 @@
 """
-Tests that verify sample payloads in examples/sample_payloads/ validate
-against the corresponding JSON Schemas in contracts/json/.
+Core schema-alignment tests: every Core sample payload in
+examples/sample_payloads/ validates against its JSON Schema in contracts/json/,
+plus targeted invariant assertions that document specific Core constraints.
 
 These tests act as living documentation: if a schema changes in a breaking way,
-the sample payloads will fail to validate, catching the regression.
+the sample payloads fail to validate, catching the regression.
+
+The registry/validation boilerplate is shared with the Extended tier in
+tests/_schema_alignment.py (the modern referencing.Registry pattern, mirroring
+conformance/run.py) — issues #113 and #114.
 """
 
 import json
-import pathlib
+
 import pytest
 
-jsonschema = pytest.importorskip("jsonschema")
+pytest.importorskip("jsonschema")
 
-REPO_ROOT = pathlib.Path(__file__).parent.parent.parent.parent
-SCHEMA_DIR = REPO_ROOT / "contracts" / "json"
-PAYLOADS_DIR = REPO_ROOT / "examples" / "sample_payloads"
+from tests._schema_alignment import (  # noqa: E402
+    CORE_SCHEMA_DIR,
+    load_core_schema as load_schema,
+    load_payload,
+    validate,
+)
 
-
-def load_schema(name: str) -> dict:
-    path = SCHEMA_DIR / f"{name}.schema.json"
-    with open(path) as f:
-        return json.load(f)
-
-
-def load_payload(name: str) -> dict:
-    path = PAYLOADS_DIR / f"{name}.json"
-    with open(path) as f:
-        return json.load(f)
-
-
-def build_store() -> dict:
-    """Build a URI → schema dict for all local schemas, so $ref resolution
-    works without network access."""
-    store = {}
-    for schema_file in SCHEMA_DIR.glob("*.schema.json"):
-        with open(schema_file) as f:
-            schema = json.load(f)
-        if "$id" in schema:
-            store[schema["$id"]] = schema
-    return store
-
-
-_SCHEMA_STORE = build_store()
-
-
-def validate(payload: dict, schema: dict) -> None:
-    """Validate payload against schema using a local-only resolver."""
-    resolver = jsonschema.RefResolver(
-        base_uri=schema.get("$id", ""),
-        referrer=schema,
-        store=_SCHEMA_STORE,
-    )
-    validator_cls = jsonschema.validators.validator_for(schema)
-    validator = validator_cls(
-        schema,
-        resolver=resolver,
-        format_checker=jsonschema.FormatChecker(),
-    )
-    errors = [e for e in validator.iter_errors(payload)]
-    if errors:
-        msgs = "\n".join(str(e) for e in errors)
-        raise AssertionError(f"Schema validation failed:\n{msgs}")
+# (dataclass name, schema stem, payload stem). The CamelCase dataclass names
+# appear here as whole tokens so scripts/generate_coverage_table.py detects the
+# schema-test artifact for every Core type (it scans this file for the token):
+# SelectableItem, ChoiceCard, RoutingDecision, Capability, CapabilityToken,
+# PolicyDecision, Frame, Handle, TraceEvent.
+CORE_TYPES = [
+    ("SelectableItem", "selectable_item", "selectable_item"),
+    ("ChoiceCard", "choice_card", "choice_card"),
+    ("RoutingDecision", "routing_decision", "routing_decision"),
+    ("Capability", "capability", "capability"),
+    ("CapabilityToken", "capability_token", "capability_token"),
+    ("PolicyDecision", "policy_decision", "policy_decision"),
+    ("Frame", "frame", "frame_with_handles"),
+    ("Handle", "handle", "handle"),
+    ("TraceEvent", "trace_event", "trace_event"),
+]
 
 
 class TestSchemaValidJSON:
-    """All schema files must be valid JSON."""
+    """All Core schema files must be valid JSON with the required metadata."""
 
-    @pytest.mark.parametrize("schema_file", sorted(SCHEMA_DIR.glob("*.schema.json")))
+    @pytest.mark.parametrize("schema_file", sorted(CORE_SCHEMA_DIR.glob("*.schema.json")))
     def test_schema_is_valid_json(self, schema_file):
         with open(schema_file) as f:
             data = json.load(f)
@@ -75,68 +54,43 @@ class TestSchemaValidJSON:
         assert "description" in data, f"{schema_file.name} must have description"
 
 
-class TestRoutingDecisionPayload:
-    """routing_decision.json validates against routing_decision schema."""
+class TestCorePayloadValidation:
+    """Each Core sample payload validates against its schema and carries the
+    schema's required fields as non-empty values."""
 
-    def test_payload_validates(self):
-        schema = load_schema("routing_decision")
-        payload = load_payload("routing_decision")
-        validate(payload, schema)
+    @pytest.mark.parametrize("class_name,schema_stem,payload_stem", CORE_TYPES)
+    def test_payload_validates(self, class_name, schema_stem, payload_stem):
+        validate(load_payload(payload_stem), load_schema(schema_stem))
 
-    def test_required_fields_present(self):
-        payload = load_payload("routing_decision")
-        assert payload.get("id"), "routing_decision payload must have non-empty id"
-        assert payload.get("choice_cards"), "routing_decision payload must have choice_cards"
-        assert payload.get("timestamp"), "routing_decision payload must have timestamp"
+    @pytest.mark.parametrize("class_name,schema_stem,payload_stem", CORE_TYPES)
+    def test_required_fields_present(self, class_name, schema_stem, payload_stem):
+        schema = load_schema(schema_stem)
+        payload = load_payload(payload_stem)
+        for field_name in schema.get("required", []):
+            assert payload.get(field_name) not in (None, "", [], {}), (
+                f"{payload_stem} payload must carry non-empty required field "
+                f"{field_name!r}"
+            )
 
 
-class TestFrameWithHandlesPayload:
-    """frame_with_handles.json validates against frame schema."""
+class TestCoreInvariants:
+    """Targeted assertions documenting specific Core constraints (preserved from
+    the per-type tests this module replaced)."""
 
-    def test_payload_validates(self):
-        schema = load_schema("frame")
-        payload = load_payload("frame_with_handles")
-        validate(payload, schema)
-
-    def test_required_fields_present(self):
-        payload = load_payload("frame_with_handles")
-        assert payload.get("frame_id"), "frame payload must have non-empty frame_id"
-        assert payload.get("capability_id"), "frame payload must have capability_id"
-        assert payload.get("summary"), "frame payload must have summary"
-        assert payload.get("created_at"), "frame payload must have created_at"
-
-    def test_no_raw_output_field(self):
+    def test_frame_has_no_raw_output_field(self):
         """Frames must not contain a 'raw_output' field (invariant I-01 / I-05)."""
         payload = load_payload("frame_with_handles")
         assert "raw_output" not in payload, (
             "Frame must not contain raw_output (invariant: LLM never sees raw tool output)"
         )
 
-
-class TestCapabilityTokenPayload:
-    """capability_token.json validates against capability_token schema."""
-
-    def test_payload_validates(self):
-        schema = load_schema("capability_token")
-        payload = load_payload("capability_token")
-        validate(payload, schema)
-
-    def test_required_fields_present(self):
-        payload = load_payload("capability_token")
-        assert payload.get("token_id"), "capability_token payload must have non-empty token_id"
-        assert payload.get("principal"), "capability_token payload must have principal"
-        assert payload.get("scope"), "capability_token payload must have non-empty scope"
-        assert payload.get("issued_at"), "capability_token payload must have issued_at"
-
-    def test_scope_is_not_empty(self):
+    def test_capability_token_scope_is_not_empty(self):
         """Invariant I-06: CapabilityTokens must be scoped."""
-        payload = load_payload("capability_token")
-        scope = payload.get("scope", [])
+        scope = load_payload("capability_token").get("scope", [])
         assert len(scope) > 0, "CapabilityToken.scope must not be empty (invariant I-06)"
 
-    def test_invariant_i06_no_expiry_no_single_use_fails(self):
+    def test_capability_token_no_expiry_no_single_use_fails(self):
         """Invariant I-06: token without expires_at and without single_use must fail."""
-        schema = load_schema("capability_token")
         invalid_payload = {
             "token_id": "tok-invalid",
             "principal": "agent-1",
@@ -144,115 +98,27 @@ class TestCapabilityTokenPayload:
             "issued_at": "2026-03-08T06:00:00Z",
         }
         with pytest.raises(AssertionError, match="Schema validation failed"):
-            validate(invalid_payload, schema)
+            validate(invalid_payload, load_schema("capability_token"))
 
-
-class TestSelectableItemPayload:
-    """selectable_item.json validates against selectable_item schema."""
-
-    def test_payload_validates(self):
-        schema = load_schema("selectable_item")
-        payload = load_payload("selectable_item")
-        validate(payload, schema)
-
-    def test_required_fields_present(self):
-        payload = load_payload("selectable_item")
-        assert payload.get("id"), "selectable_item payload must have non-empty id"
-        assert payload.get("label"), "selectable_item payload must have label"
-        assert payload.get("description"), "selectable_item payload must have description"
-
-
-class TestChoiceCardPayload:
-    """choice_card.json validates against choice_card schema."""
-
-    def test_payload_validates(self):
-        schema = load_schema("choice_card")
-        payload = load_payload("choice_card")
-        validate(payload, schema)
-
-    def test_required_fields_present(self):
-        payload = load_payload("choice_card")
-        assert payload.get("id"), "choice_card payload must have non-empty id"
-        assert payload.get("items"), "choice_card payload must have non-empty items"
-
-    def test_items_within_bounds(self):
+    def test_choice_card_items_within_bounds(self):
         """ChoiceCard schema requires 1..20 items."""
-        payload = load_payload("choice_card")
-        items = payload.get("items", [])
+        items = load_payload("choice_card").get("items", [])
         assert 1 <= len(items) <= 20, "choice_card.items must be 1..20"
 
+    def test_policy_decision_is_allow_or_deny(self):
+        assert load_payload("policy_decision")["decision"] in ("allow", "deny")
 
-class TestCapabilityPayload:
-    """capability.json validates against capability schema."""
-
-    def test_payload_validates(self):
-        schema = load_schema("capability")
-        payload = load_payload("capability")
-        validate(payload, schema)
-
-    def test_required_fields_present(self):
-        payload = load_payload("capability")
-        for f in ("id", "name", "version", "description"):
-            assert payload.get(f), f"capability payload must have non-empty {f}"
-
-
-class TestPolicyDecisionPayload:
-    """policy_decision.json validates against policy_decision schema."""
-
-    def test_payload_validates(self):
-        schema = load_schema("policy_decision")
-        payload = load_payload("policy_decision")
-        validate(payload, schema)
-
-    def test_required_fields_present(self):
-        payload = load_payload("policy_decision")
-        for f in ("decision_id", "decision", "capability_id", "principal", "timestamp"):
-            assert payload.get(f), f"policy_decision payload must have non-empty {f}"
-
-    def test_decision_is_allow_or_deny(self):
-        payload = load_payload("policy_decision")
-        assert payload["decision"] in ("allow", "deny")
-
-
-class TestHandlePayload:
-    """handle.json validates against handle schema."""
-
-    def test_payload_validates(self):
-        schema = load_schema("handle")
+    def test_handle_byte_size_non_negative(self):
         payload = load_payload("handle")
-        validate(payload, schema)
-
-    def test_required_fields_present(self):
-        payload = load_payload("handle")
-        for f in ("handle_id", "capability_id", "artifact_type", "created_at"):
-            assert payload.get(f), f"handle payload must have non-empty {f}"
-
-    def test_byte_size_non_negative(self):
-        payload = load_payload("handle")
-        if "byte_size" in payload and payload["byte_size"] is not None:
+        if payload.get("byte_size") is not None:
             assert payload["byte_size"] >= 0
 
-
-class TestTraceEventPayload:
-    """trace_event.json validates against trace_event schema."""
-
-    def test_payload_validates(self):
-        schema = load_schema("trace_event")
-        payload = load_payload("trace_event")
-        validate(payload, schema)
-
-    def test_required_fields_present(self):
-        payload = load_payload("trace_event")
-        for f in ("event_id", "event_type", "timestamp"):
-            assert payload.get(f), f"trace_event payload must have non-empty {f}"
-
-    def test_event_type_in_schema_enum(self):
+    def test_trace_event_type_in_schema_enum(self):
         """Sample event_type must be one of the values declared in the schema.
 
-        Sourced from the loaded schema so the schema's enum remains the
-        single source of truth (no drift between test and schema).
+        Sourced from the loaded schema so the schema's enum remains the single
+        source of truth (no drift between test and schema).
         """
         schema = load_schema("trace_event")
         payload = load_payload("trace_event")
-        enum_values = schema["properties"]["event_type"]["enum"]
-        assert payload["event_type"] in enum_values
+        assert payload["event_type"] in schema["properties"]["event_type"]["enum"]

--- a/contracts/python/tests/test_schema_parity.py
+++ b/contracts/python/tests/test_schema_parity.py
@@ -25,9 +25,14 @@ from datetime import datetime
 
 import pytest
 
-import weaver_contracts.core as core
-import weaver_contracts.extended as extended
-from tests._schema_alignment import load_core_schema, load_extended_schema
+# The shared helper imports jsonschema + referencing at module load, so skip
+# gracefully (as the other alignment modules do) when the dev extras are absent.
+pytest.importorskip("jsonschema")
+pytest.importorskip("referencing")
+
+import weaver_contracts.core as core  # noqa: E402
+import weaver_contracts.extended as extended  # noqa: E402
+from tests._schema_alignment import load_core_schema, load_extended_schema  # noqa: E402
 
 # Fields that back a schema's `additionalProperties: true` extension bag rather
 # than a declared property. Allowed to be absent from `properties` either way.

--- a/contracts/python/tests/test_schema_parity.py
+++ b/contracts/python/tests/test_schema_parity.py
@@ -1,0 +1,209 @@
+"""
+Mechanical dataclass <-> JSON Schema parity for Core and Extended contracts
+(issues #111, #112).
+
+AGENTS.md ("Source of truth: schemas lead") requires the Python types to mirror
+their JSON Schemas exactly — same field names, same required/optional status,
+same type shape, zero divergence. The payload-validation tests
+(test_json_schema_alignment.py / test_extended_schema_alignment.py) only check
+that *sample payloads* validate, so a dataclass could add, rename, or retype a
+field without any test failing. This module turns the mirroring rule into a
+mechanical guarantee for every type that has a schema.
+
+Authority is schema-led for both tiers now that every Extended type has a schema
+(see docs/CONTRACT_REFERENCE.md). The type-shape comparison is deliberately
+coarse — container kind plus nullability — to catch real drift without flagging
+benign annotation differences.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+import typing
+from datetime import datetime
+
+import pytest
+
+import weaver_contracts.core as core
+import weaver_contracts.extended as extended
+from tests._schema_alignment import load_core_schema, load_extended_schema
+
+# Fields that back a schema's `additionalProperties: true` extension bag rather
+# than a declared property. Allowed to be absent from `properties` either way.
+EXTENSION_BAG_FIELDS = frozenset({"metadata", "extra"})
+
+
+def _camel_to_snake(name: str) -> str:
+    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+
+def _dataclasses_in(module) -> list[type]:
+    """@dataclass types *defined* in this module (not imported into it)."""
+    return [
+        obj
+        for obj in vars(module).values()
+        if isinstance(obj, type)
+        and dataclasses.is_dataclass(obj)
+        and obj.__module__ == module.__name__
+    ]
+
+
+CORE_TYPES = [(cls, _camel_to_snake(cls.__name__), "core") for cls in _dataclasses_in(core)]
+EXTENDED_TYPES = [
+    (cls, _camel_to_snake(cls.__name__), "extended") for cls in _dataclasses_in(extended)
+]
+ALL_TYPES = CORE_TYPES + EXTENDED_TYPES
+_IDS = [cls.__name__ for cls, _stem, _tier in ALL_TYPES]
+
+
+def _load_schema(stem: str, tier: str) -> dict:
+    return load_core_schema(stem) if tier == "core" else load_extended_schema(stem)
+
+
+def _dataclass_fields(cls: type) -> set[str]:
+    return {f.name for f in dataclasses.fields(cls)}
+
+
+def _dataclass_required(cls: type) -> set[str]:
+    """Dataclass fields with no default and no default_factory are required."""
+    return {
+        f.name
+        for f in dataclasses.fields(cls)
+        if f.default is dataclasses.MISSING and f.default_factory is dataclasses.MISSING
+    }
+
+
+def _strip_optional(annotation):
+    if typing.get_origin(annotation) is typing.Union:
+        args = [a for a in typing.get_args(annotation) if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return annotation
+
+
+def _dataclass_kind(annotation) -> str | None:
+    """Coarse JSON-Schema-style kind for a Python annotation, or None if unknown."""
+    annotation = _strip_optional(annotation)
+    origin = typing.get_origin(annotation)
+    if origin in (list, typing.List):
+        return "array"
+    if origin in (dict, typing.Dict):
+        return "object"
+    if annotation is bool:
+        return "boolean"
+    if annotation is int:
+        return "integer"
+    if annotation is float:
+        return "number"
+    if annotation in (str, datetime):
+        return "string"
+    if dataclasses.is_dataclass(annotation):
+        return "object"
+    return None
+
+
+def _schema_kinds(prop: dict) -> set[str]:
+    """Non-null JSON Schema types for a property (handles $ref / anyOf / type list)."""
+    if "type" in prop:
+        types = prop["type"]
+        types = [types] if isinstance(types, str) else types
+        return {t for t in types if t != "null"}
+    if "$ref" in prop:
+        return {"object"}
+    if "anyOf" in prop:
+        out: set[str] = set()
+        for sub in prop["anyOf"]:
+            out |= _schema_kinds(sub)
+        return out
+    return set()
+
+
+@pytest.mark.parametrize("cls,stem,tier", ALL_TYPES, ids=_IDS)
+def test_every_type_has_a_schema(cls, stem, tier):
+    """Schema-led authority: every Core and Extended dataclass has a schema."""
+    schema = _load_schema(stem, tier)
+    assert schema.get("title") == cls.__name__, (
+        f"{cls.__name__}: schema title {schema.get('title')!r} should match the class name"
+    )
+
+
+@pytest.mark.parametrize("cls,stem,tier", ALL_TYPES, ids=_IDS)
+def test_field_name_parity(cls, stem, tier):
+    """Every dataclass field maps to a schema property and vice versa."""
+    schema = _load_schema(stem, tier)
+    props = set(schema.get("properties", {}))
+    fields = _dataclass_fields(cls)
+
+    # The extension bag (metadata/extra) may be modelled via additionalProperties
+    # rather than a declared property; namespaced x_* keys are extension points.
+    missing_in_schema = fields - props - EXTENSION_BAG_FIELDS
+    extra_in_schema = {p for p in (props - fields) if not p.startswith("x_")}
+
+    assert not missing_in_schema, (
+        f"{cls.__name__}: dataclass fields absent from schema properties: "
+        f"{sorted(missing_in_schema)}"
+    )
+    assert not extra_in_schema, (
+        f"{cls.__name__}: schema properties absent from dataclass: "
+        f"{sorted(extra_in_schema)}"
+    )
+
+
+@pytest.mark.parametrize("cls,stem,tier", ALL_TYPES, ids=_IDS)
+def test_required_parity(cls, stem, tier):
+    """Required/optional status matches between dataclass and schema."""
+    schema = _load_schema(stem, tier)
+    schema_required = set(schema.get("required", []))
+    dataclass_required = _dataclass_required(cls)
+    assert dataclass_required == schema_required, (
+        f"{cls.__name__}: required-field divergence — "
+        f"dataclass-only {sorted(dataclass_required - schema_required)}, "
+        f"schema-only {sorted(schema_required - dataclass_required)}"
+    )
+
+
+@pytest.mark.parametrize("cls,stem,tier", ALL_TYPES, ids=_IDS)
+def test_type_shape(cls, stem, tier):
+    """Coarse type-shape parity (container kind + scalar family) per shared field."""
+    schema = _load_schema(stem, tier)
+    props = schema.get("properties", {})
+    hints = typing.get_type_hints(cls)
+
+    mismatches = []
+    for field in dataclasses.fields(cls):
+        if field.name in EXTENSION_BAG_FIELDS or field.name not in props:
+            continue
+        dc_kind = _dataclass_kind(hints[field.name])
+        schema_kinds = _schema_kinds(props[field.name])
+        if dc_kind is None or not schema_kinds:
+            continue  # nothing meaningful to compare (e.g. enum-only / unknown)
+        ok = dc_kind in schema_kinds or (dc_kind == "integer" and "number" in schema_kinds)
+        if not ok:
+            mismatches.append(
+                f"{field.name}: dataclass {dc_kind} vs schema {sorted(schema_kinds)}"
+            )
+    assert not mismatches, f"{cls.__name__}: type-shape mismatches: {mismatches}"
+
+
+def test_parity_check_detects_drift():
+    """Self-check: the parity logic flags a dataclass field with no schema match.
+
+    Guards against the parity test silently passing because the comparison
+    became a no-op (issue #111 test plan).
+    """
+
+    @dataclasses.dataclass
+    class _Drifted:
+        token_id: str
+        principal: str
+        scope: list
+        issued_at: str
+        bogus_extra: str = "x"
+
+    schema = load_core_schema("capability_token")
+    props = set(schema.get("properties", {}))
+    fields = _dataclass_fields(_Drifted)
+    missing_in_schema = fields - props - EXTENSION_BAG_FIELDS
+    assert "bogus_extra" in missing_in_schema

--- a/contracts/python/tests/test_version_consistency.py
+++ b/contracts/python/tests/test_version_consistency.py
@@ -1,0 +1,57 @@
+"""Tests for scripts/check_version_consistency.py (issue #110).
+
+The script lives under scripts/ (stdlib-only build-time tooling). These tests
+drive its pure ``check`` / ``self_test`` helpers with fixtures and confirm the
+live repository tree is consistent.
+"""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import check_version_consistency as cvc  # noqa: E402
+
+
+def _consistent(version: str = "1.2.3") -> dict[str, str]:
+    return {
+        "pyproject.toml": f'version = "{version}"\n',
+        "well-known/contracts.json": f'{{\n  "contract_version": "{version}"\n}}\n',
+        "CHANGELOG.md": f"## [Unreleased]\n\n## [{version}] - 2026-01-01\n",
+        "README.md": f"Current contract version: **{version}**\n",
+        "docs/VERSIONING.md": f"### Current matrix (contract version {version})\n",
+        "compatibility.yaml": f'contract_versions:\n  - "{version}"\n',
+    }
+
+
+def test_self_test_passes():
+    assert cvc.self_test() == []
+
+
+def test_consistent_tree_has_no_errors():
+    assert cvc.check("1.2.3", _consistent()) == []
+
+
+def test_detects_mismatch_attributed_to_each_file():
+    for name in cvc.SOURCES:
+        broken = _consistent()
+        broken[name] = broken[name].replace("1.2.3", "9.9.9")
+        errors = cvc.check("1.2.3", broken)
+        assert any(e.startswith(name + ":") for e in errors), f"{name} drift undetected"
+
+
+def test_compatibility_allows_multiple_versions():
+    # An extra supported version must not trip the "current is present" check.
+    files = _consistent()
+    files["compatibility.yaml"] = 'contract_versions:\n  - "1.2.3"\n  - "1.1.0"\n'
+    assert cvc.check("1.2.3", files) == []
+
+
+def test_read_contract_version():
+    assert cvc.read_contract_version('CONTRACT_VERSION = "3.4.5"\n') == "3.4.5"
+
+
+def test_live_tree_is_consistent():
+    version = cvc.read_contract_version(cvc.VERSION_PY.read_text(encoding="utf-8"))
+    assert cvc.check(version, cvc._read_live_files()) == []

--- a/docs/CONTRACT_REFERENCE.md
+++ b/docs/CONTRACT_REFERENCE.md
@@ -1,6 +1,6 @@
 # Contract Field Reference
 
-A single-page field reference for every Weaver contract type — both Core (9) and Extended (7).
+A single-page field reference for every Weaver contract type — both Core (9) and Extended (23).
 
 For narrative and adoption guidance, read [ARCHITECTURE.md](ARCHITECTURE.md), [BOUNDARIES.md](BOUNDARIES.md), and [GLOSSARY.md](GLOSSARY.md). For a runnable code path, use [QUICKSTART.md](QUICKSTART.md).
 
@@ -9,7 +9,7 @@ For narrative and adoption guidance, read [ARCHITECTURE.md](ARCHITECTURE.md), [B
 ## Source of truth and authority
 
 - **Core types** — the JSON Schemas in [`contracts/json/`](../contracts/json/) are the language-agnostic source of truth. The Python dataclasses in [`contracts/python/src/weaver_contracts/core.py`](../contracts/python/src/weaver_contracts/core.py) mirror them exactly.
-- **Extended types** — the Python dataclasses in [`contracts/python/src/weaver_contracts/extended.py`](../contracts/python/src/weaver_contracts/extended.py) are the source of truth. Extended contracts have no JSON Schemas yet and may have breaking changes in MINOR versions (see [VERSIONING.md](VERSIONING.md)).
+- **Extended types** — schema-led, the same as Core: the JSON Schemas in [`contracts/json/extended/`](../contracts/json/extended/) are the source of truth and the Python dataclasses in [`contracts/python/src/weaver_contracts/extended.py`](../contracts/python/src/weaver_contracts/extended.py) mirror them exactly. Unlike Core, Extended contracts may have breaking changes in MINOR versions (see [VERSIONING.md](VERSIONING.md)). Dataclass ⟷ schema parity is enforced mechanically by `test_schema_parity.py`.
 
 If this document ever disagrees with a schema or dataclass, the schema or dataclass wins. Open an issue.
 
@@ -180,9 +180,9 @@ The token must either be single-use **or** carry an expiry. This is invariant I-
 
 ---
 
-## Extended types (7)
+## Extended types (23)
 
-Extended types are optional. None is required for spec compliance. They live in [`contracts/python/src/weaver_contracts/extended.py`](../contracts/python/src/weaver_contracts/extended.py) only — there are no JSON Schemas for Extended types yet. Per [VERSIONING.md](VERSIONING.md), Extended contracts may have breaking changes in MINOR versions.
+Extended types are optional. None is required for spec compliance. Each has a JSON Schema in [`contracts/json/extended/`](../contracts/json/extended/) (the source of truth) mirrored by a dataclass in [`contracts/python/src/weaver_contracts/extended.py`](../contracts/python/src/weaver_contracts/extended.py). Per [VERSIONING.md](VERSIONING.md), Extended contracts may have breaking changes in MINOR versions.
 
 Adopters typically attach Extended objects to their own payloads via the `metadata` field of a Core contract (Core schemas set `additionalProperties: true`), or by composing them into Extended wrappers like `ExtendedFrameMetadata`.
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -40,7 +40,9 @@ Core contracts are the minimal, stable interface required by all adopters:
 
 ### Extended Contracts
 
-Extended contracts provide optional metadata (telemetry, UI hints, risk levels, schema fingerprints, redaction notes). They are declared in `extended.py` and are not required by any Core contract.
+Extended contracts provide optional metadata (telemetry, UI hints, risk levels, schema fingerprints, redaction notes) plus the cross-project artifact and execution-boundary types. Each has a JSON Schema in `contracts/json/extended/` mirrored by a dataclass in `extended.py`, and none is required by any Core contract.
+
+**Authority:** Extended contracts are **schema-led, the same as Core** — the JSON Schema is the source of truth and the dataclass mirrors it (enforced by `test_schema_parity.py`). The difference is the stability promise below, not where the contract is defined.
 
 **Stability promise:** Extended contracts may have breaking changes in a MINOR version, provided the change is backward-compatible from a Core perspective. Extended contracts are explicitly versioned separately when they change independently.
 
@@ -102,13 +104,15 @@ This table tracks which versions of the sibling repositories are known-compatibl
 > [!IMPORTANT]
 > A cell may be `verified` or `provisional` only when backed by a real declaration recorded in `compatibility.yaml` (the `declaration` field). Unknown compatibility MUST be recorded as `unverified` — never assume or invent a version claim.
 
-### Current matrix (contract version 0.5.0)
+### Current matrix (contract version 0.7.0)
 
 | Contract Version | contextweaver | agent-kernel | ChainWeaver |
 | ----------------- | -------------- | ------------- | ------------- |
-| 0.5.0 (current) | `unverified` | `unverified` | `unverified` |
+| 0.7.0 (current) | `unverified` | `unverified` | `unverified` |
 
 All `0.x` contract versions share MAJOR version `0` and are mutually compatible (see [Semantic Versioning](#semantic-versioning) and `weaver_contracts.version.is_compatible`). No sibling repository has published a compatibility declaration yet, so every cell is `unverified`.
+
+The single source of truth for the contract version string is `weaver_contracts.version.CONTRACT_VERSION`. Every other file that states the version (this document, `README.md`, `pyproject.toml`, `well-known/contracts.json`, `CHANGELOG.md`, `compatibility.yaml`) must match it; `scripts/check_version_consistency.py` (the `validate-version-consistency` CI job) enforces this and fails on drift.
 
 ### How a sibling repository declares compatibility
 

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -88,6 +88,9 @@ python -c "import json; [json.load(open(f)) for f in __import__('glob').glob('co
 # 4. Contracts index freshness (regenerate first if you changed any schema)
 python scripts/generate_contracts_index.py --check
 
+# 4b. Contract version string consistency (single source: version.py)
+python scripts/check_version_consistency.py
+
 # 5. Markdown lint
 # See CONTRIBUTING.md "Markdown Lint" section for the canonical command.
 

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Stdlib-only check that the contract version string is consistent everywhere.
+
+``weaver_contracts.version.CONTRACT_VERSION`` is the single source of truth for
+the contract version — it already feeds the conformance badge via
+``conformance/run.py:contract_version()``. This script reads that value and
+asserts the same version appears in every other file that states it, failing
+CI / pre-commit on drift (issue #110).
+
+It is intentionally **pure and parser-free** (no YAML/TOML/JSON parser) so it
+stays within the ``scripts/`` stdlib-only rule (see ``AGENTS.md``); it matches
+targeted patterns, mirroring ``scripts/validate_compatibility.py``. The version
+itself is never changed here — this only enforces consistency.
+
+Run directly to check the live tree (and the validator's own self-test)::
+
+    python scripts/check_version_consistency.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+VERSION_PY = (
+    REPO_ROOT / "contracts" / "python" / "src" / "weaver_contracts" / "version.py"
+)
+
+# name -> (path relative to repo root, regex template). ``{v}`` is replaced by
+# the escaped canonical version; each template must match iff that file states
+# the version. compatibility.yaml may legitimately list several supported
+# versions, so its pattern asserts the current version is *present*, not unique.
+SOURCES: dict[str, tuple[str, str]] = {
+    "pyproject.toml": (
+        "contracts/python/pyproject.toml",
+        r'(?m)^version = "{v}"',
+    ),
+    "well-known/contracts.json": (
+        "well-known/contracts.json",
+        r'"contract_version": "{v}"',
+    ),
+    "CHANGELOG.md": (
+        "CHANGELOG.md",
+        r"(?m)^## \[{v}\]",
+    ),
+    "README.md": (
+        "README.md",
+        r"Current contract version: \*\*{v}\*\*",
+    ),
+    "docs/VERSIONING.md": (
+        "docs/VERSIONING.md",
+        r"Current matrix \(contract version {v}\)",
+    ),
+    "compatibility.yaml": (
+        "compatibility.yaml",
+        r'(?m)^  - "{v}"',
+    ),
+}
+
+
+def read_contract_version(version_py_text: str) -> str:
+    """Extract ``CONTRACT_VERSION`` from the text of ``version.py``."""
+    match = re.search(r'CONTRACT_VERSION\s*=\s*"([^"]+)"', version_py_text)
+    if not match:
+        raise ValueError("CONTRACT_VERSION not found in version.py")
+    return match.group(1)
+
+
+def check(version: str, files: dict[str, str]) -> list[str]:
+    """Return human-readable errors (empty == consistent).
+
+    ``files`` maps each :data:`SOURCES` name to that file's text, keeping this a
+    pure function the self-test can drive with in-memory fixtures.
+    """
+    errors: list[str] = []
+    escaped = re.escape(version)
+    for name, (_path, template) in SOURCES.items():
+        if name not in files:
+            errors.append(f"{name}: file content not provided")
+            continue
+        pattern = template.replace("{v}", escaped)
+        if re.search(pattern, files[name]) is None:
+            errors.append(
+                f"{name}: expected contract version {version!r} "
+                f"(pattern {pattern!r} not found) — update it to match "
+                "CONTRACT_VERSION in version.py"
+            )
+    return errors
+
+
+def _read_live_files() -> dict[str, str]:
+    return {
+        name: (REPO_ROOT / rel).read_text(encoding="utf-8")
+        for name, (rel, _template) in SOURCES.items()
+    }
+
+
+def self_test() -> list[str]:
+    """Assert the checker accepts a consistent tree and rejects per-file drift.
+
+    Each bad case mutates exactly one file, so a rejection is attributable to
+    that file rather than to an incidental error. Returns failures (empty == ok).
+    """
+    version = "9.9.9"
+    consistent = {
+        "pyproject.toml": 'version = "9.9.9"\n',
+        "well-known/contracts.json": '{\n  "contract_version": "9.9.9"\n}\n',
+        "CHANGELOG.md": "## [Unreleased]\n\n## [9.9.9] - 2026-01-01\n",
+        "README.md": "Current contract version: **9.9.9**\n",
+        "docs/VERSIONING.md": "### Current matrix (contract version 9.9.9)\n",
+        "compatibility.yaml": 'contract_versions:\n  - "9.9.9"\n',
+    }
+
+    failures: list[str] = []
+    good_errors = check(version, consistent)
+    if good_errors:
+        failures.append(f"consistent fixture was rejected: {good_errors}")
+    for name in SOURCES:
+        broken = dict(consistent)
+        broken[name] = broken[name].replace("9.9.9", "0.0.0")
+        errors = check(version, broken)
+        if not any(e.startswith(name + ":") for e in errors):
+            failures.append(f"drift in {name!r} was not detected")
+    return failures
+
+
+def main(argv: list[str] | None = None) -> int:
+    problems = self_test()
+    for problem in problems:
+        print(f"FAIL (self-test): {problem}", file=sys.stderr)
+    if problems:
+        return 1
+
+    version = read_contract_version(VERSION_PY.read_text(encoding="utf-8"))
+    errors = check(version, _read_live_files())
+    if errors:
+        print(
+            f"FAIL: contract version {version!r} (from version.py) is inconsistent:",
+            file=sys.stderr,
+        )
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print(f"OK: contract version {version} is consistent across {len(SOURCES)} files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What changed

Implements the schema-alignment / parity cluster (#110, #111, #112, #113, #114) in one PR.

**Tests / tooling**
- **#113** — New `contracts/python/tests/_schema_alignment.py` shared helper that builds one `referencing.Registry` over all Core + Extended schemas (mirroring `conformance/run.py:load_schemas`). Both alignment modules now use it, removing the deprecated `jsonschema.RefResolver`. The suite runs clean under `-W error::DeprecationWarning`.
- **#114** — Removed the duplicated `build_store()` / `validate()` boilerplate from both alignment modules. Core positive-validation is now table-driven with the dataclass names present as tokens, so `scripts/generate_coverage_table.py` detects every Core schema test (`contracts/COVERAGE.md` regenerated — Core "Schema Test" cells flip `--` → `OK`). All targeted negative/invariant assertions preserved.
- **#111 / #112** — New `contracts/python/tests/test_schema_parity.py`: mechanical dataclass ⟷ schema parity (field names, required/optional status, coarse type shape) for all 9 Core and 23 Extended types, plus a self-check proving the comparison detects drift.
- **#110** — New stdlib-only `scripts/check_version_consistency.py` + `contracts/python/tests/test_version_consistency.py`, wired into a new `validate-version-consistency` CI job and a `version-consistency` pre-commit hook. `weaver_contracts.version.CONTRACT_VERSION` is the single source of truth.

**Docs / drift fixes**
- **#112** — `docs/CONTRACT_REFERENCE.md` and `docs/VERSIONING.md` now document Extended as **schema-led** (same authority as Core; MINOR-breaking is a stability promise, not a different source of truth). Fixed the stale `Extended (7)` / "no JSON Schemas yet" claims to `Extended (23)`.
- **#110** — Corrected the stale contract version `0.5.0` → `0.7.0` in `README.md`, `docs/VERSIONING.md`, and `compatibility.yaml`.
- Updated `AGENTS.md`, `docs/agent-context/workflows.md`, and `CHANGELOG.md` (`[Unreleased]`).

## Why

The five issues share the same two test modules and the dataclass↔schema-alignment concern, and the issue bodies cross-reference each other as a sequence (#112 → "ISSUE 2" = #111; #114 → "ISSUE 4" = #113). Doing them together avoids touching the same files twice (e.g. the `RefResolver` migration and the consolidation land once).

## How verified

- `pytest` — **452 passed**, **94.67%** coverage (≥ 80% gate).
- `pytest -W error::DeprecationWarning` (alignment + parity + version) — **246 passed** (confirms #113).
- `mypy src/` — **Success: no issues found**.
- `check_schema_fields.py`, `generate_contracts_index.py --check`, `generate_coverage_table.py --check`, `check_version_consistency.py`, `validate_compatibility` self-test + validate — **all OK**.
- `markdownlint` (full doc set) and `yamllint` (ci.yml, pre-commit, compatibility.yaml) — **clean**.

## Scope / cross-repo impact

Docs-and-contracts scope respected: **no Core or Extended contract surface changed**, so the six-artifact rule is not triggered and **no version bump** is required. New tests/tooling are never imported by `weaver_contracts`. **No cross-repo impact** (contextweaver, agent-kernel, ChainWeaver) — this is test/tooling/docs hardening only.

## Risks / caveats

- 6 `test_conformance.py` tests fail **in the sandbox used to author this** because `cryptography` can't import there (`_cffi_backend` / Rust bindings missing). `conformance/` is unchanged by this PR and the failures are independent of these changes; they should pass in CI where `cryptography` is functional.
- `#112` declares schema-led authority for Extended. If maintainers intended the dataclass to remain the Extended source of truth, the doc wording (and the parity test's direction framing) is the only thing to revisit — no contract behavior changes either way.

Closes #110, #111, #112, #113, #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5cBjoQggFVG7yB8vrqW6m

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5cBjoQggFVG7yB8vrqW6m)_