### PR TITLE
docs: link the Weaver Stack overview article (Towards AI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **Canonical specs and shared contracts for the Weaver Stack.**
 
 [![Weaver-compatible](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/dgenio/weaver-spec/main/docs/badges/weaver-spec.json)](docs/SELF_CERTIFICATION.md)
+[![Read the Weaver Stack overview on Towards AI](https://img.shields.io/badge/Read_the_overview-Towards_AI-black?logo=medium&logoColor=white)](https://pub.towardsai.net/the-weaver-stack-one-contract-layer-for-safe-llm-agents-7f733cad5eac)
 
 > **Part of the [Weaver Stack](docs/WEAVER_STACK.md)**
 >


### PR DESCRIPTION
## Description

Visitors landing on `weaver-spec` see the contracts but not the narrative — why the
stack exists and how its layers compose. That story now lives in a published overview
article, yet nothing in the repo pointed to it.

This PR adds a **Read the overview on Towards AI** badge to the README badge row,
linking the Weaver Stack pillar article so the narrative context is one click from the
front door.

Scope: README badge row only — no code, contract, or other doc changes.

---

## Type of change

- [x] Docs only (no contract changes)
- [ ] Additive contract change (new optional field or new type — non-breaking)
- [ ] Breaking contract change (requires ADR — see [CONTRIBUTING.md](CONTRIBUTING.md))
- [ ] CI / tooling change

---

## Six-artifact checklist

N/A — no Core contract touched (README navigation badge only).

- [x] JSON Schema updated (`contracts/json/`) — N/A
- [x] Python dataclass updated (`contracts/python/src/weaver_contracts/core.py`) — N/A
- [x] Sample payload updated (`examples/sample_payloads/`) — N/A
- [x] Roundtrip test updated (`contracts/python/tests/test_roundtrip_examples.py`) — N/A
- [x] CHANGELOG entry added (`CHANGELOG.md`) — N/A (nav badge, no contract/behavior change)
- [x] Version bumped (`version.py` + `pyproject.toml`) — N/A

---

## Deprecations

- [x] `docs/DEPRECATIONS.md` updated — or N/A (no deprecation in this PR)

---

## Invariants

- [x] I have verified that invariants I-01 through I-07 in `docs/INVARIANTS.md` are not violated by this change.

---

## Cross-repo impact

- [ ] **contextweaver** — needs coordinated update
- [ ] **agent-kernel** — needs coordinated update
- [ ] **ChainWeaver** — needs coordinated update
- [x] No cross-repo impact

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
