### PR TITLE
contracts: conformance-suite hardening sweep + ConformanceResult contract (v0.8.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,13 +373,20 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # Mirror the package `python-tests` matrix (#152): the reference impl
+        # exercises the same crypto/JCS/jsonschema path as the conformance
+        # runner, so run it on every supported interpreter.
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install package with dev dependencies
         working-directory: contracts/python
@@ -388,11 +395,16 @@ jobs:
       - name: "Run the reference implementation (issue #76)"
         run: python examples/reference_impl/reference_impl.py
 
+      # The badge is a committed, deterministic artifact; regenerate and
+      # staleness-check it once (on the baseline interpreter) rather than on
+      # every matrix leg.
       - name: "Regenerate scoreboard badge from a real conformance result (#77)"
+        if: matrix.python-version == '3.11'
         run: |
           python conformance/run.py \
             --emit-result /tmp/conformance-result.json \
             --emit-badge docs/badges/weaver-spec.json
 
       - name: Fail if the committed self-cert badge is stale
+        if: matrix.python-version == '3.11'
         run: git diff --exit-code docs/badges/weaver-spec.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          # Matches the package `python-tests` job: 3.14 may still resolve as a
+          # prerelease on the runner, so allow it rather than fail to set up.
+          allow-prereleases: true
 
       - name: Install package with dev dependencies
         working-directory: contracts/python

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -18,13 +18,21 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # Mirror the package `python-tests` matrix (#152). The runner leans on
+        # jsonschema / referencing / jcs / cryptography, whose behaviour can vary
+        # by interpreter, so the security-relevant path is exercised on every
+        # supported version rather than a single one.
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install conformance dependencies
         run: pip install jsonschema referencing PyYAML jcs cryptography

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -33,6 +33,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          # Matches the package `python-tests` job: 3.14 may still resolve as a
+          # prerelease on the runner, so allow it rather than fail to set up.
+          allow-prereleases: true
 
       - name: Install conformance dependencies
         run: pip install jsonschema referencing PyYAML jcs cryptography

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,69 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
 
 ## [Unreleased]
 
+---
+
+## [0.8.0] - 2026-07-05
+
 ### Added
 
+- **Conformance-suite hardening sweep.** A single cycle of build-time/CI
+  conformance improvements. Only one new **Extended** contract is added, which
+  bumps `CONTRACT_VERSION` 0.7.0 → 0.8.0 (MINOR, per the Extended-contract
+  workflow); the rest is CI tooling, tests, fixtures, and docs — never imported
+  by `weaver_contracts` and never published.
+  - **`ConformanceResult` Extended contract (#116).** The machine-readable
+    result emitted by `conformance/run.py` is now a schematized interchange
+    shape (`contracts/json/extended/conformance_result.schema.json` + a
+    `ConformanceResult` dataclass in `extended.py` + a sample payload +
+    roundtrip/alignment tests), so the self-certification badge, the scoreboard,
+    and siblings that read it share one validated contract. It is CI tooling
+    output, not a Weaver runtime contract; the runner still does not import the
+    package (the schema-parity test keeps the two in lockstep). The runner now
+    validates its own emitted result against the schema in tests.
+  - **Structured failure records (#145).** The emitted result gains a
+    `failure_records` array alongside the flat `failure_detail` strings — each
+    record carries a `kind` plus, where known, `payload` / `schema` / `keyword`
+    / `path` / `invariant_id`, so an agent can map a failure to the offending
+    fixture/field. The human stderr output and exit codes are unchanged.
+  - **Result freshness/expiry policy (#150).** `conformance/run.py:is_result_fresh()`
+    flags a published result whose `generated_at` is older than 90 days or whose
+    `contract_version` is not the current MAJOR, using only existing result
+    fields. Documented in `docs/SELF_CERTIFICATION.md`; the scoreboard is
+    unaffected because it re-verifies each sibling's live bundle every run.
+  - **Adversarial TraceBundle fixtures (#133).** Negative corpus fixtures for a
+    signature envelope missing `kid` and one declaring a non-registry
+    `canonicalization` (caught at the schema gate via the bundle's `$ref` to
+    `capability_token_signature`, so no runner code path was needed), plus a
+    unit test that tampering a nested `Frame` after signing breaks verification.
+  - **Validator caching + validation-at-scale guidance (#130).** The runner
+    compiles one `Draft202012Validator` per schema `$id` and reuses it, with a
+    regression guard asserting compilations scale with schemas, not payload
+    count; documented as the compile-once/reuse pattern in `docs/CONFORMANCE.md`.
+  - **External-bundle input hardening (#158).** `--bundle` mode now rejects an
+    oversized (> 5 MiB) or non-object input with a clear `input:` failure instead
+    of a traceback; the 5 MiB cap is shared with the scoreboard's network fetch.
+  - **Extend-via-data guard (#137).** The runner now raises on an
+    `invariants.yaml` `applies_to` that matches no handling branch (was a silent
+    no-op), a consistency test asserts every corpus schema name and every
+    trace_bundle-scoped invariant assertion resolves, and `docs/CONFORMANCE.md`
+    documents the "extend via data, not new code paths" constraint.
+  - **Trust-model documentation (#156).** A new "Trust model" section in
+    `docs/SIGNING.md` states what a verified signature does and does not attest
+    (integrity + origin only; not correctness, freshness/replay, or
+    confidentiality), roots trust in keyring distribution, and reconciles the
+    strict verifier's "unknown key → reject" with the runner's "unknown `kid` →
+    skipped, not failed". Cross-linked from `SECURITY.md` and
+    `docs/SELF_CERTIFICATION.md`.
+
+### Changed
+
+- **Conformance runner runs across the full Python matrix (#152).** The reusable
+  `.github/workflows/conformance.yml` and the `reference-impl` job in `ci.yml`
+  now run on Python 3.10–3.14 (matching the package `python-tests` matrix)
+  instead of only 3.11, so the crypto/JCS/jsonschema path is exercised on every
+  supported interpreter. `run()` and `verify_external_bundle()` now also return
+  the structured failure records described above (internal API, never published).
 - Mechanical dataclass ⟷ JSON Schema parity test (`contracts/python/tests/test_schema_parity.py`)
   covering every Core and Extended type — field names, required/optional status, and a coarse
   type shape — turning the "schemas lead, Python mirrors exactly" rule into an enforced guarantee
@@ -19,9 +80,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). The
   single source of truth for the contract version, and any drift in `README.md`, `pyproject.toml`,
   `well-known/contracts.json`, `CHANGELOG.md`, `docs/VERSIONING.md`, or `compatibility.yaml` fails
   CI (#110).
-
-### Changed
-
 - Consolidated the schema-alignment test boilerplate onto a shared
   `contracts/python/tests/_schema_alignment.py` helper and migrated both alignment modules off the
   deprecated `jsonschema.RefResolver` to the modern `referencing.Registry` pattern used by the

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ examples/
 
 The spec and contracts follow semantic versioning. See [docs/VERSIONING.md](docs/VERSIONING.md) for the full compatibility promise.
 
-Current contract version: **0.7.0**
+Current contract version: **0.8.0**
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,6 +37,7 @@ It does **not** cover the sibling runtime repositories (`contextweaver`, `agent-
 - The `weaver_contracts` package has **no runtime dependencies** beyond the Python standard library. This minimises supply chain risk.
 - JSON Schemas should be loaded from trusted sources; do not load schemas from untrusted user input without validation.
 - Contract tokens (`CapabilityToken`) contain authorization scope. Treat them with the same care as bearer tokens.
+- Before relying on a signed `CapabilityToken` or `TraceBundle`, read the trust model in [`docs/SIGNING.md`](docs/SIGNING.md#trust-model): a verified signature attests integrity and origin only — not correctness, freshness/replay protection, or confidentiality — and its trust is rooted in how you distribute the verifier keyring.
 
 ### Framework alignment
 

--- a/compatibility.yaml
+++ b/compatibility.yaml
@@ -20,7 +20,7 @@ schema_version: 1
 # weaver-spec contract versions this manifest reasons about. All 0.x versions
 # share MAJOR 0 and are mutually compatible (see docs/VERSIONING.md).
 contract_versions:
-  - "0.7.0"
+  - "0.8.0"
 
 repositories:
   - name: contextweaver

--- a/conformance/corpus.yaml
+++ b/conformance/corpus.yaml
@@ -51,6 +51,11 @@ negative:
   - {payload: conformance/negative/trace_event/bad_event_type.json, schema: trace_event, by: schema, violates: "enum:event_type"}
   - {payload: conformance/negative/trace_event/missing_timestamp.json, schema: trace_event, by: schema, violates: "required:timestamp"}
   - {payload: conformance/negative/trace_event/empty_event_id.json, schema: trace_event, by: schema, violates: "minLength:event_id"}
+  # TraceBundle — adversarial signature envelopes (#133). Caught at the schema
+  # gate via the bundle's $ref to capability_token_signature, so no runner code
+  # path is needed — the envelope is rejected before crypto verification.
+  - {payload: conformance/negative/trace_bundle/sig_missing_kid.json, schema: trace_bundle, by: schema, violates: "required:kid"}
+  - {payload: conformance/negative/trace_bundle/sig_wrong_canonicalization.json, schema: trace_bundle, by: schema, violates: "enum:canonicalization"}
   # TraceBundle — schema-valid but invariant-violating (exercises #74 checks)
   - {payload: conformance/negative/trace_bundle/i01_frame_carries_raw_output.json, schema: trace_bundle, by: invariant, violates: I-01}
   - {payload: conformance/negative/trace_bundle/i02_policy_decision_without_trace_event.json, schema: trace_bundle, by: invariant, violates: I-02}

--- a/conformance/negative/trace_bundle/sig_missing_kid.json
+++ b/conformance/negative/trace_bundle/sig_missing_kid.json
@@ -1,0 +1,74 @@
+{
+  "bundle_id": "tb-neg-sig-missing-kid-001",
+  "routing_decision": {
+    "id": "rd-conf-001",
+    "choice_cards": [
+      {
+        "id": "card-retrieval",
+        "context_hint": "Select a retrieval action.",
+        "items": [
+          {
+            "id": "search-docs",
+            "label": "Search documentation",
+            "description": "Full-text search across the docs index.",
+            "capability_id": "org.myapp.search_docs"
+          }
+        ]
+      }
+    ],
+    "selected_item_id": "search-docs",
+    "selected_card_id": "card-retrieval",
+    "timestamp": "2026-03-08T06:00:00Z"
+  },
+  "policy_decisions": [
+    {
+      "decision_id": "pd-conf-001",
+      "decision": "allow",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-session-9c2e",
+      "token_id": "tok-conf-001",
+      "timestamp": "2026-03-08T06:00:01Z"
+    }
+  ],
+  "frames": [
+    {
+      "frame_id": "frame-conf-001",
+      "capability_id": "org.myapp.search_docs",
+      "summary": "Found 2 documentation pages matching the query.",
+      "handle_refs": [
+        "handle-conf-001"
+      ],
+      "created_at": "2026-03-08T06:00:05Z"
+    }
+  ],
+  "handles": [
+    {
+      "handle_id": "handle-conf-001",
+      "capability_id": "org.myapp.search_docs",
+      "artifact_type": "application/json",
+      "created_at": "2026-03-08T06:00:05Z",
+      "expires_at": "2026-03-09T06:00:05Z"
+    }
+  ],
+  "trace_events": [
+    {
+      "event_id": "te-conf-001",
+      "event_type": "capability_executed",
+      "timestamp": "2026-03-08T06:00:05Z",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-session-9c2e",
+      "decision_id": "pd-conf-001",
+      "frame_id": "frame-conf-001",
+      "handle_id": "handle-conf-001",
+      "outcome": "success"
+    }
+  ],
+  "canonicalization": "JCS",
+  "created_at": "2026-03-08T06:00:06Z",
+  "signature": {
+    "alg": "ed25519",
+    "sig": "LRB1K8fbJPQNdTbKjrEkzFQWmoiXok-KYARdrSuRJhMJTIOSONgK0gK5W2tdDW5s54z9QycbEwQAMONBX81JDw",
+    "canonicalization": "JCS",
+    "signed_at": "2026-03-08T06:00:06Z"
+  }
+}

--- a/conformance/negative/trace_bundle/sig_wrong_canonicalization.json
+++ b/conformance/negative/trace_bundle/sig_wrong_canonicalization.json
@@ -1,0 +1,75 @@
+{
+  "bundle_id": "tb-neg-sig-wrong-canon-001",
+  "routing_decision": {
+    "id": "rd-conf-001",
+    "choice_cards": [
+      {
+        "id": "card-retrieval",
+        "context_hint": "Select a retrieval action.",
+        "items": [
+          {
+            "id": "search-docs",
+            "label": "Search documentation",
+            "description": "Full-text search across the docs index.",
+            "capability_id": "org.myapp.search_docs"
+          }
+        ]
+      }
+    ],
+    "selected_item_id": "search-docs",
+    "selected_card_id": "card-retrieval",
+    "timestamp": "2026-03-08T06:00:00Z"
+  },
+  "policy_decisions": [
+    {
+      "decision_id": "pd-conf-001",
+      "decision": "allow",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-session-9c2e",
+      "token_id": "tok-conf-001",
+      "timestamp": "2026-03-08T06:00:01Z"
+    }
+  ],
+  "frames": [
+    {
+      "frame_id": "frame-conf-001",
+      "capability_id": "org.myapp.search_docs",
+      "summary": "Found 2 documentation pages matching the query.",
+      "handle_refs": [
+        "handle-conf-001"
+      ],
+      "created_at": "2026-03-08T06:00:05Z"
+    }
+  ],
+  "handles": [
+    {
+      "handle_id": "handle-conf-001",
+      "capability_id": "org.myapp.search_docs",
+      "artifact_type": "application/json",
+      "created_at": "2026-03-08T06:00:05Z",
+      "expires_at": "2026-03-09T06:00:05Z"
+    }
+  ],
+  "trace_events": [
+    {
+      "event_id": "te-conf-001",
+      "event_type": "capability_executed",
+      "timestamp": "2026-03-08T06:00:05Z",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-session-9c2e",
+      "decision_id": "pd-conf-001",
+      "frame_id": "frame-conf-001",
+      "handle_id": "handle-conf-001",
+      "outcome": "success"
+    }
+  ],
+  "canonicalization": "JCS",
+  "created_at": "2026-03-08T06:00:06Z",
+  "signature": {
+    "alg": "ed25519",
+    "kid": "conformance-test-ed25519-2026-01",
+    "sig": "LRB1K8fbJPQNdTbKjrEkzFQWmoiXok-KYARdrSuRJhMJTIOSONgK0gK5W2tdDW5s54z9QycbEwQAMONBX81JDw",
+    "canonicalization": "PKCS",
+    "signed_at": "2026-03-08T06:00:06Z"
+  }
+}

--- a/conformance/run.py
+++ b/conformance/run.py
@@ -61,6 +61,13 @@ FORBIDDEN_FRAME_KEYS = frozenset({"raw_output", "raw", "raw_result", "tool_outpu
 
 SIGNATURE_ALG_REGISTRY = frozenset({"ed25519", "es256"})
 
+# Cap on an external bundle accepted by --bundle / the scoreboard. The external
+# path ingests semi-trusted input (a sibling's published bundle, fetched on a
+# schedule), so an oversized or malformed file must fail with a clear message
+# rather than exhaust memory or surface a raw traceback (#158). scoreboard.py
+# reuses this so the file path and the network fetch path share one limit.
+MAX_BUNDLE_BYTES = 5 * 1024 * 1024  # 5 MiB
+
 
 # ---------------------------------------------------------------------------
 # Schema loading
@@ -84,11 +91,37 @@ def load_schemas() -> tuple[dict[str, dict], Registry]:
     return schemas_by_stem, registry
 
 
-def schema_errors(payload: dict, schema: dict, registry: Registry) -> list[str]:
-    """Return a sorted list of validation error messages (empty == valid)."""
+# Compiled validators are cached so a corpus run (or an adopter validating many
+# payloads) compiles each schema once and reuses it, rather than recompiling per
+# payload. See docs/CONFORMANCE.md "Validating at scale".
+_VALIDATOR_CACHE: dict[str, "Draft202012Validator"] = {}
+
+
+def _validator_for(schema: dict, registry: Registry) -> Draft202012Validator:
+    """Return a compiled validator for ``schema``, compiling once and reusing.
+
+    Keyed by the schema's ``$id`` — stable and immutable per docs/SCHEMA_HOSTING.md,
+    so the same ``$id`` always maps to the same schema content and thus a
+    behaviour-identical validator (unlike ``id(schema)``, which a fresh
+    ``load_schemas()`` would change and which an object could later reuse). A
+    schema without an ``$id`` is compiled fresh each call rather than cached. All
+    validators in this repo resolve ``$ref`` against the single registry built by
+    :func:`load_schemas`, so the registry is not part of the cache key.
+    """
+    schema_id = schema.get("$id")
+    if schema_id is not None and schema_id in _VALIDATOR_CACHE:
+        return _VALIDATOR_CACHE[schema_id]
     validator = Draft202012Validator(
         schema, registry=registry, format_checker=Draft202012Validator.FORMAT_CHECKER
     )
+    if schema_id is not None:
+        _VALIDATOR_CACHE[schema_id] = validator
+    return validator
+
+
+def schema_errors(payload: dict, schema: dict, registry: Registry) -> list[str]:
+    """Return a sorted list of validation error messages (empty == valid)."""
+    validator = _validator_for(schema, registry)
     errors = sorted(validator.iter_errors(payload), key=lambda e: list(e.absolute_path))
     out = []
     for err in errors:
@@ -107,9 +140,7 @@ def schema_error_details(
     checked against the *reason* it is supposed to fail, not merely that it
     fails somehow.
     """
-    validator = Draft202012Validator(
-        schema, registry=registry, format_checker=Draft202012Validator.FORMAT_CHECKER
-    )
+    validator = _validator_for(schema, registry)
     details = []
     for err in validator.iter_errors(payload):
         loc = "/".join(str(p) for p in err.absolute_path) or "<root>"
@@ -135,6 +166,28 @@ def negative_schema_reason_met(violates: str, details: list[tuple[str, str, str]
         if target in loc or target in msg:
             return True
     return False
+
+
+class _Failures:
+    """Collects failures as both human strings and structured records (#145).
+
+    ``messages`` preserves the exact stderr/human output the runner has always
+    produced (so existing consumers and tests are unaffected); ``records`` is the
+    additive machine-readable view an agent can map to the offending
+    fixture/field — ``kind`` plus, where known, ``payload`` / ``schema`` /
+    ``keyword`` / ``path`` / ``invariant_id``. The two stay 1:1 and carry the
+    same ``message``.
+    """
+
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+        self.records: list[dict] = []
+
+    def add(self, kind: str, message: str, **fields: Optional[str]) -> None:
+        self.messages.append(message)
+        record = {"kind": kind, "message": message}
+        record.update({k: v for k, v in fields.items() if v is not None})
+        self.records.append(record)
 
 
 # ---------------------------------------------------------------------------
@@ -304,19 +357,21 @@ def check_trace_bundle(
 # Runner
 # ---------------------------------------------------------------------------
 
-def run(keyring_path: Optional[Path]) -> tuple[int, list[str]]:
+def run(keyring_path: Optional[Path]) -> tuple[int, list[str], list[dict]]:
     """Run the full corpus + invariants + bundle checks.
 
-    Returns ``(checks_run, failures)``. Reporting and exit-code handling are the
-    caller's responsibility (see :func:`main`), so the result can also be
-    serialized via ``--emit-result`` / ``--emit-badge``.
+    Returns ``(checks_run, failures, failure_records)``. ``failures`` is the
+    human-readable list (unchanged); ``failure_records`` is the structured view
+    (#145). Reporting and exit-code handling are the caller's responsibility
+    (see :func:`main`), so the result can also be serialized via
+    ``--emit-result`` / ``--emit-badge``.
     """
     schemas_by_stem, registry = load_schemas()
     corpus = yaml.safe_load((CONF_DIR / "corpus.yaml").read_text(encoding="utf-8"))
     invariants_doc = yaml.safe_load((CONF_DIR / "invariants.yaml").read_text(encoding="utf-8"))
     keyring = load_keyring(keyring_path)
 
-    failures: list[str] = []
+    fail = _Failures()
     checks = 0
 
     def load(rel: str) -> dict:
@@ -327,7 +382,11 @@ def run(keyring_path: Optional[Path]) -> tuple[int, list[str]]:
         checks += 1
         errs = schema_errors(load(entry["payload"]), schemas_by_stem[entry["schema"]], registry)
         if errs:
-            failures.append(f"POSITIVE {entry['payload']} should validate but did not: {errs}")
+            fail.add(
+                "positive",
+                f"POSITIVE {entry['payload']} should validate but did not: {errs}",
+                payload=entry["payload"], schema=entry["schema"],
+            )
 
     # 2. Negative corpus must be rejected.
     for entry in corpus["negative"]:
@@ -337,27 +396,41 @@ def run(keyring_path: Optional[Path]) -> tuple[int, list[str]]:
         if entry["by"] == "schema":
             details = schema_error_details(payload, schema, registry)
             if not details:
-                failures.append(
-                    f"NEGATIVE {entry['payload']} should fail schema ({entry['violates']}) but validated"
+                fail.add(
+                    "negative",
+                    f"NEGATIVE {entry['payload']} should fail schema ({entry['violates']}) but validated",
+                    payload=entry["payload"], schema=entry["schema"], keyword=entry["violates"],
                 )
             elif not negative_schema_reason_met(entry["violates"], details):
                 observed = sorted({kw for kw, _, _ in details})
-                failures.append(
+                fail.add(
+                    "negative",
                     f"NEGATIVE {entry['payload']} should fail by {entry['violates']!r} "
-                    f"but failed by {observed} instead"
+                    f"but failed by {observed} instead",
+                    payload=entry["payload"], schema=entry["schema"], keyword=entry["violates"],
                 )
         elif entry["by"] == "invariant":
             # Must be schema-valid first, then rejected by the named invariant.
             if schema_errors(payload, schema, registry):
-                failures.append(f"NEGATIVE {entry['payload']} expected schema-valid but failed schema")
+                fail.add(
+                    "negative",
+                    f"NEGATIVE {entry['payload']} expected schema-valid but failed schema",
+                    payload=entry["payload"], schema=entry["schema"],
+                )
                 continue
             check = BUNDLE_INVARIANTS.get(_assertion_for(invariants_doc, entry["violates"]))
             if check is None or not check(payload):
-                failures.append(
-                    f"NEGATIVE {entry['payload']} should violate {entry['violates']} but passed"
+                fail.add(
+                    "negative",
+                    f"NEGATIVE {entry['payload']} should violate {entry['violates']} but passed",
+                    payload=entry["payload"], invariant_id=entry["violates"],
                 )
         else:  # pragma: no cover - guarded by corpus authoring
-            failures.append(f"NEGATIVE {entry['payload']} has unknown `by`: {entry['by']!r}")
+            fail.add(
+                "negative",
+                f"NEGATIVE {entry['payload']} has unknown `by`: {entry['by']!r}",
+                payload=entry["payload"],
+            )
 
     # 3. Invariant assertions over positive targets / schemas.
     positive_by_schema: dict[str, list[dict]] = {}
@@ -371,20 +444,37 @@ def run(keyring_path: Optional[Path]) -> tuple[int, list[str]]:
             checks += 1
             v = core_required_surface_stable(inv["baseline"], schemas_by_stem)
             if v:
-                failures.append(f"INVARIANT {inv['id']} failed: {v}")
+                fail.add("invariant", f"INVARIANT {inv['id']} failed: {v}", invariant_id=inv["id"])
         elif applies_to == ["capability_token"]:
             for token in positive_by_schema.get("capability_token", []):
                 checks += 1
                 v = capability_token_scoped(token)
                 if v:
-                    failures.append(f"INVARIANT {inv['id']} failed on a capability_token: {v}")
+                    fail.add(
+                        "invariant",
+                        f"INVARIANT {inv['id']} failed on a capability_token: {v}",
+                        schema="capability_token", invariant_id=inv["id"],
+                    )
         elif applies_to == ["trace_bundle"]:
             check = BUNDLE_INVARIANTS[assertion]
             for bundle in positive_by_schema.get("trace_bundle", []):
                 checks += 1
                 v = check(bundle)
                 if v:
-                    failures.append(f"INVARIANT {inv['id']} failed on {bundle.get('bundle_id')!r}: {v}")
+                    fail.add(
+                        "invariant",
+                        f"INVARIANT {inv['id']} failed on {bundle.get('bundle_id')!r}: {v}",
+                        payload=bundle.get("bundle_id"), invariant_id=inv["id"],
+                    )
+        else:
+            # Extend via data, not silent no-ops (#137): an invariant whose
+            # applies_to matches no branch here would otherwise be skipped
+            # without a trace, quietly weakening the suite. Fail loudly so a new
+            # target must register a real code path.
+            raise ValueError(
+                f"invariant {inv['id']!r} has unsupported applies_to {applies_to!r}; "
+                "register a handling branch in run.py before adding it to invariants.yaml"
+            )
 
     # 4. TraceBundle integrity + signature (#74) over every positive bundle.
     for bundle in positive_by_schema.get("trace_bundle", []):
@@ -393,54 +483,89 @@ def run(keyring_path: Optional[Path]) -> tuple[int, list[str]]:
         for note in notes:
             print(f"  bundle {bundle.get('bundle_id')!r}: {note}")
         if errs:
-            failures.append(f"TRACEBUNDLE {bundle.get('bundle_id')!r}: {errs}")
+            fail.add(
+                "tracebundle",
+                f"TRACEBUNDLE {bundle.get('bundle_id')!r}: {errs}",
+                payload=bundle.get("bundle_id"),
+            )
 
-    return checks, failures
+    return checks, fail.messages, fail.records
 
 
 # ---------------------------------------------------------------------------
 # External-bundle mode (#51 scoreboard reuses this)
 # ---------------------------------------------------------------------------
 
+def load_external_bundle(path: Path) -> tuple[Optional[dict], Optional[str]]:
+    """Read and parse an external bundle file defensively (#158).
+
+    Returns ``(bundle, None)`` on success, or ``(None, reason)`` when the file is
+    oversized, unreadable, not JSON, or not a JSON object. Because the
+    external-bundle path ingests semi-trusted input, every failure mode is a
+    clear message rather than a raw traceback. At most :data:`MAX_BUNDLE_BYTES`
+    (+1 sentinel) is read before parsing, so a giant file cannot exhaust memory —
+    the same idiom the scoreboard uses for network fetches.
+    """
+    try:
+        with path.open("rb") as fh:
+            raw = fh.read(MAX_BUNDLE_BYTES + 1)
+    except OSError as exc:
+        return None, f"cannot read bundle file: {exc}"
+    if len(raw) > MAX_BUNDLE_BYTES:
+        return None, f"bundle file exceeds the {MAX_BUNDLE_BYTES}-byte limit"
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return None, f"bundle is not valid JSON: {exc}"
+    if not isinstance(parsed, dict):
+        return None, f"bundle must be a JSON object, got {type(parsed).__name__}"
+    return parsed, None
+
+
 def verify_external_bundle(
     bundle: dict,
     schemas_by_stem: dict[str, dict],
     registry: Registry,
     keyring: dict[str, dict],
-) -> tuple[int, list[str], list[str]]:
+) -> tuple[int, list[str], list[dict], list[str]]:
     """Conformance-check a single externally supplied TraceBundle.
 
     Validates it against the ``trace_bundle`` schema, runs the TraceBundle
     integrity + signature checks (#74), and asserts I-01/I-02. Returns
-    ``(checks_run, failures, notes)``. This is what the scoreboard (#51) runs
-    against each sibling's published bundle.
+    ``(checks_run, failures, failure_records, notes)`` — ``failures`` is the
+    human-readable list (unchanged) and ``failure_records`` the structured view
+    (#145). This is what the scoreboard (#51) runs against each sibling's
+    published bundle.
     """
     checks = 0
-    failures: list[str] = []
+    fail = _Failures()
     notes: list[str] = []
 
     schema = schemas_by_stem.get("trace_bundle")
     if schema is None:  # pragma: no cover - extended schema is always present
-        return 0, ["Extended schema 'trace_bundle' not found"], notes
+        fail.add("schema", "Extended schema 'trace_bundle' not found", schema="trace_bundle")
+        return 0, fail.messages, fail.records, notes
 
     checks += 1
     errs = schema_errors(bundle, schema, registry)
     if errs:
-        failures.extend(f"schema: {e}" for e in errs)
+        for e in errs:
+            fail.add("schema", f"schema: {e}", schema="trace_bundle", path=e.split(":", 1)[0])
         # A schema-invalid bundle can't be meaningfully invariant-checked.
-        return checks, failures, notes
+        return checks, fail.messages, fail.records, notes
 
     checks += 1
     integrity_errs, integrity_notes = check_trace_bundle(bundle, schemas_by_stem, registry, keyring)
-    failures.extend(integrity_errs)
+    for e in integrity_errs:
+        fail.add("tracebundle", e, payload=bundle.get("bundle_id"))
     notes.extend(integrity_notes)
 
     for name, check in BUNDLE_INVARIANTS.items():
         checks += 1
         for v in check(bundle):
-            failures.append(f"{name}: {v}")
+            fail.add("invariant", f"{name}: {v}", payload=bundle.get("bundle_id"), invariant_id=name)
 
-    return checks, failures, notes
+    return checks, fail.messages, fail.records, notes
 
 
 # ---------------------------------------------------------------------------
@@ -463,6 +588,57 @@ def contract_version() -> str:
     return match.group(1) if match else "unknown"
 
 
+# A published conformance result is trustworthy only while it is recent and
+# targets the current contract MAJOR. The scoreboard re-verifies each sibling's
+# live bundle on every run, so it never relies on a stale result; this policy
+# governs a *self-published* result JSON that a third party might display. See
+# docs/SELF_CERTIFICATION.md "Freshness and validity" (#150).
+RESULT_MAX_AGE_DAYS = 90
+
+
+def is_result_fresh(
+    result: dict,
+    *,
+    now: Optional[datetime] = None,
+    max_age_days: int = RESULT_MAX_AGE_DAYS,
+) -> tuple[bool, list[str]]:
+    """Return ``(fresh, reasons)`` for a published conformance result (#150).
+
+    A result is fresh only when its ``generated_at`` is within ``max_age_days``
+    and its ``contract_version`` shares the current contract MAJOR. ``reasons``
+    lists why it is not fresh (empty when fresh). Uses only fields already in the
+    result — no new contract surface.
+    """
+    reasons: list[str] = []
+    now = now or datetime.now(timezone.utc)
+
+    current_major = contract_version().split(".")[0]
+    stated = str(result.get("contract_version", ""))
+    stated_major = stated.split(".")[0] if stated else ""
+    if stated_major != current_major:
+        reasons.append(
+            f"contract_version {stated!r} is not the current MAJOR {current_major!r}"
+        )
+
+    raw = result.get("generated_at")
+    generated_at = None
+    if isinstance(raw, str):
+        try:
+            generated_at = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        except ValueError:
+            generated_at = None
+    if generated_at is None:
+        reasons.append("generated_at is missing or unparseable")
+    else:
+        if generated_at.tzinfo is None:  # treat a naive timestamp as UTC
+            generated_at = generated_at.replace(tzinfo=timezone.utc)
+        age_days = (now - generated_at).days
+        if age_days > max_age_days:
+            reasons.append(f"result is {age_days} days old (limit {max_age_days})")
+
+    return (not reasons, reasons)
+
+
 def build_result(
     status: str,
     checks: int,
@@ -470,9 +646,16 @@ def build_result(
     *,
     mode: str = "corpus",
     target: Optional[str] = None,
+    failure_records: Optional[list[dict]] = None,
 ) -> dict:
     """Build the machine-readable conformance result consumed by the badge (#77)
-    and the scoreboard (#51). This is CI tooling output, not a Weaver contract."""
+    and the scoreboard (#51). This is CI tooling output, not a Weaver runtime
+    contract, but it is a stable inter-repo interchange shape validated against
+    ``contracts/json/extended/conformance_result.schema.json`` (#116).
+
+    ``failure_detail`` stays the flat human-readable list; ``failure_records`` is
+    the structured per-failure view (#145) — empty when omitted so existing
+    callers need no change."""
     return {
         "result_version": "1",
         "contract_version": contract_version(),
@@ -482,6 +665,7 @@ def build_result(
         "checks_run": checks,
         "failures": len(failures),
         "failure_detail": failures,
+        "failure_records": failure_records or [],
         "generated_at": _now_z(),
         "runner": "weaver-spec conformance/run.py",
     }
@@ -556,22 +740,31 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     if args.bundle is not None:
         schemas_by_stem, registry = load_schemas()
-        bundle = json.loads(args.bundle.read_text(encoding="utf-8"))
-        checks, failures, notes = verify_external_bundle(
-            bundle, schemas_by_stem, registry, keyring
-        )
+        bundle, load_error = load_external_bundle(args.bundle)
+        if load_error is not None:
+            # Oversized / malformed / non-object input: fail cleanly (#158), not
+            # with a traceback, and never reach schema validation.
+            checks, failures, records, notes = (
+                0, [f"input: {load_error}"], [{"kind": "input", "message": load_error}], [],
+            )
+        else:
+            assert bundle is not None  # load_error is None => bundle is set
+            checks, failures, records, notes = verify_external_bundle(
+                bundle, schemas_by_stem, registry, keyring
+            )
         for note in notes:
             print(f"  bundle: {note}")
         exit_code = _report(checks, failures, f"Bundle conformance ({args.bundle})")
         mode, target = "bundle", str(args.bundle)
     else:
-        checks, failures = run(args.keyring)
+        checks, failures, records = run(args.keyring)
         exit_code = _report(checks, failures, "Conformance")
         mode, target = "corpus", None
 
     if args.emit_result is not None or args.emit_badge is not None:
         result = build_result(
-            "pass" if not failures else "fail", checks, failures, mode=mode, target=target
+            "pass" if not failures else "fail", checks, failures,
+            mode=mode, target=target, failure_records=records,
         )
         if args.emit_result is not None:
             _write_json(args.emit_result, result)

--- a/conformance/run.py
+++ b/conformance/run.py
@@ -637,7 +637,10 @@ def is_result_fresh(
             # A result dated in the future is clock-skewed or malformed, not
             # fresh — don't let a negative age slip past the age ceiling.
             reasons.append(f"generated_at is in the future ({raw})")
-        elif age.days > max_age_days:
+        elif age > timedelta(days=max_age_days):
+            # Compare the full timedelta, not the truncated ``age.days``: a result
+            # 90 days and a few hours old is past the "within 90 days" window
+            # (docs/SELF_CERTIFICATION.md) and must not read as fresh.
             reasons.append(f"result is {age.days} days old (limit {max_age_days})")
 
     return (not reasons, reasons)

--- a/conformance/run.py
+++ b/conformance/run.py
@@ -39,7 +39,7 @@ import base64
 import json
 import re
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -632,9 +632,13 @@ def is_result_fresh(
     else:
         if generated_at.tzinfo is None:  # treat a naive timestamp as UTC
             generated_at = generated_at.replace(tzinfo=timezone.utc)
-        age_days = (now - generated_at).days
-        if age_days > max_age_days:
-            reasons.append(f"result is {age_days} days old (limit {max_age_days})")
+        age = now - generated_at
+        if age < timedelta(0):
+            # A result dated in the future is clock-skewed or malformed, not
+            # fresh — don't let a negative age slip past the age ceiling.
+            reasons.append(f"generated_at is in the future ({raw})")
+        elif age.days > max_age_days:
+            reasons.append(f"result is {age.days} days old (limit {max_age_days})")
 
     return (not reasons, reasons)
 
@@ -743,9 +747,12 @@ def main(argv: Optional[list[str]] = None) -> int:
         bundle, load_error = load_external_bundle(args.bundle)
         if load_error is not None:
             # Oversized / malformed / non-object input: fail cleanly (#158), not
-            # with a traceback, and never reach schema validation.
+            # with a traceback, and never reach schema validation. Keep the
+            # structured record's message identical to the failure_detail entry
+            # (the 1:1 invariant documented on _Failures).
+            input_message = f"input: {load_error}"
             checks, failures, records, notes = (
-                0, [f"input: {load_error}"], [{"kind": "input", "message": load_error}], [],
+                0, [input_message], [{"kind": "input", "message": input_message}], [],
             )
         else:
             assert bundle is not None  # load_error is None => bundle is set

--- a/conformance/scoreboard.py
+++ b/conformance/scoreboard.py
@@ -53,8 +53,9 @@ STATUS_ICON = {"pass": "✅ pass", "fail": "❌ fail", "not-submitted": "⚪ not
 
 # Cap on a fetched sibling bundle. The scoreboard fetches whatever a registered
 # sibling publishes, on a schedule in CI; an oversized response must not be able
-# to exhaust memory before we even attempt to parse it.
-MAX_BUNDLE_BYTES = 5 * 1024 * 1024  # 5 MiB
+# to exhaust memory before we even attempt to parse it. Shared with the runner's
+# file-based --bundle path (#158) so both ingestion paths enforce one limit.
+MAX_BUNDLE_BYTES = run.MAX_BUNDLE_BYTES
 
 
 class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
@@ -110,7 +111,7 @@ def fetch_json(url: str, timeout: float) -> tuple[Optional[dict], str]:
 
 def self_row() -> Row:
     """Conformance-check this repo against its own corpus."""
-    checks, failures = run.run(run.DEFAULT_KEYRING)
+    checks, failures, _records = run.run(run.DEFAULT_KEYRING)
     status = "pass" if not failures else "fail"
     detail = "reference corpus" if not failures else f"{len(failures)} failure(s)"
     return Row(repo=SELF_REPO, status=status, checks=checks, detail=detail,
@@ -137,7 +138,7 @@ def sibling_row(entry: dict, schemas, registry, keyring, timeout: float) -> Row:
     payload, note = fetch_json(url, timeout)
     if payload is None:
         return Row(repo=repo, status="not-submitted", checks=0, detail=note, url=url)
-    checks, failures, notes = run.verify_external_bundle(payload, schemas, registry, keyring)
+    checks, failures, _records, notes = run.verify_external_bundle(payload, schemas, registry, keyring)
     status = "pass" if not failures else "fail"
     if failures:
         detail = f"{len(failures)} failure(s): {failures[0]}"

--- a/contracts/COVERAGE.md
+++ b/contracts/COVERAGE.md
@@ -17,12 +17,12 @@ CI runs the same script with `--check` and fails if this file is stale.
 
 ## Summary
 
-- Total contract types: **32**
-- JSON Schemas: **32 / 32**
-- Python classes: **32 / 32**
-- Sample payloads: **32 / 32**
-- Roundtrip tests: **32 / 32**
-- Schema validation tests: **32 / 32**
+- Total contract types: **33**
+- JSON Schemas: **33 / 33**
+- Python classes: **33 / 33**
+- Sample payloads: **33 / 33**
+- Roundtrip tests: **33 / 33**
+- Schema validation tests: **33 / 33**
 
 ## Coverage table
 
@@ -60,6 +60,7 @@ CI runs the same script with `--check` and fails if this file is stale.
 | Extended | `ExecutionFeedback` | OK | OK | OK | OK | OK |
 | Extended | `TraceBundle` | OK | OK | OK | OK | OK |
 | Extended | `FailureCaseArtifact` | OK | OK | OK | OK | OK |
+| Extended | `ConformanceResult` | OK | OK | OK | OK | OK |
 
 ## Legend
 

--- a/contracts/json/extended/conformance_result.schema.json
+++ b/contracts/json/extended/conformance_result.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://weaver-spec.dev/contracts/v0/extended/conformance_result.schema.json",
+  "title": "ConformanceResult",
+  "description": "Extended. The machine-readable result emitted by the conformance runner (conformance/run.py). It is build-time CI tooling output, not a Weaver runtime contract, but it is a stable inter-repo interchange shape: the self-certification badge (docs/SELF_CERTIFICATION.md) and the public scoreboard (docs/SCOREBOARD.md) consume it, so schematizing it keeps producers and consumers from drifting. See docs/CONFORMANCE.md.",
+  "type": "object",
+  "required": [
+    "result_version",
+    "contract_version",
+    "mode",
+    "target",
+    "status",
+    "checks_run",
+    "failures",
+    "generated_at",
+    "runner"
+  ],
+  "properties": {
+    "result_version": {
+      "type": "string",
+      "const": "1",
+      "description": "Version of this result format. Bumped only on an intentional shape change."
+    },
+    "contract_version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The weaver-spec CONTRACT_VERSION the run was performed against."
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["corpus", "bundle"],
+      "description": "`corpus` when the built-in corpus was run; `bundle` when a single external TraceBundle was checked."
+    },
+    "target": {
+      "type": ["string", "null"],
+      "description": "The bundle path/URL in `bundle` mode; null in `corpus` mode."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pass", "fail"],
+      "description": "Overall verdict: `pass` iff no checks failed."
+    },
+    "checks_run": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of conformance checks executed."
+    },
+    "failures": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Count of failed checks (0 iff status is `pass`)."
+    },
+    "failure_detail": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Human-readable failure messages (empty when status is `pass`)."
+    },
+    "failure_records": {
+      "type": "array",
+      "description": "Structured, machine-mappable view of each failure (#145): an agent can map a failure to the offending fixture/field without parsing the human strings. Empty when status is `pass`.",
+      "items": {
+        "type": "object",
+        "required": ["kind", "message"],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": ["positive", "negative", "invariant", "schema", "tracebundle", "input"],
+            "description": "Category of the failing check."
+          },
+          "message": {
+            "type": "string",
+            "description": "The same human-readable message as the matching `failure_detail` entry."
+          },
+          "payload": {
+            "type": "string",
+            "description": "Repo-relative fixture path or bundle id the failure concerns, when applicable."
+          },
+          "schema": {
+            "type": "string",
+            "description": "Schema stem the check validated against, when applicable."
+          },
+          "keyword": {
+            "type": "string",
+            "description": "Declared/observed JSON Schema keyword for a schema-level failure, when applicable."
+          },
+          "path": {
+            "type": "string",
+            "description": "Location within the payload the failure concerns, when applicable."
+          },
+          "invariant_id": {
+            "type": "string",
+            "description": "Invariant id or named check for an invariant-level failure, when applicable."
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when the result was produced. Used by the freshness policy (docs/SELF_CERTIFICATION.md)."
+    },
+    "runner": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the tool that produced the result."
+    }
+  },
+  "additionalProperties": true
+}

--- a/contracts/python/pyproject.toml
+++ b/contracts/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "weaver_contracts"
-version = "0.7.0"
+version = "0.8.0"
 description = "Minimal Python contracts for the Weaver Stack (contextweaver, agent-kernel, ChainWeaver)"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/contracts/python/src/weaver_contracts/extended.py
+++ b/contracts/python/src/weaver_contracts/extended.py
@@ -968,3 +968,57 @@ class FailureCaseArtifact:
             raise ValueError(
                 f"FailureCaseArtifact.sensitivity must be one of {_SENSITIVITY_LEVELS}"
             )
+
+
+# ---------------------------------------------------------------------------
+# ConformanceResult — the conformance runner's machine-readable output (#116)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ConformanceResult:
+    """The machine-readable result emitted by the conformance runner.
+
+    Build-time CI tooling output — not a Weaver runtime contract — but a stable
+    inter-repo interchange shape consumed by the self-certification badge and the
+    public scoreboard, so it is schematized like any Extended type. ``failure_detail``
+    is the flat human-readable list; ``failure_records`` is the structured
+    per-failure view (#145). See docs/CONFORMANCE.md and docs/SELF_CERTIFICATION.md.
+
+    This dataclass mirrors ``conformance/run.py:build_result()``; the runner does
+    not import ``weaver_contracts`` (it must run with only its own deps), so the
+    two are kept in lockstep by the schema-parity test rather than by a shared
+    import.
+    """
+
+    result_version: str
+    contract_version: str
+    mode: str
+    target: Optional[str]
+    status: str
+    checks_run: int
+    failures: int
+    generated_at: str
+    runner: str
+    failure_detail: List[str] = field(default_factory=list)
+    failure_records: List[Dict[str, Any]] = field(default_factory=list)
+
+    _MODES = frozenset({"corpus", "bundle"})
+    _STATUSES = frozenset({"pass", "fail"})
+
+    def __post_init__(self) -> None:
+        if self.result_version != "1":
+            raise ValueError("ConformanceResult.result_version must be '1'")
+        if not self.contract_version:
+            raise ValueError("ConformanceResult.contract_version must be non-empty")
+        if self.mode not in self._MODES:
+            raise ValueError(f"ConformanceResult.mode must be one of {self._MODES}")
+        if self.status not in self._STATUSES:
+            raise ValueError(f"ConformanceResult.status must be one of {self._STATUSES}")
+        if self.checks_run < 0:
+            raise ValueError("ConformanceResult.checks_run must be >= 0")
+        if self.failures < 0:
+            raise ValueError("ConformanceResult.failures must be >= 0")
+        if not self.generated_at:
+            raise ValueError("ConformanceResult.generated_at must be non-empty")
+        if not self.runner:
+            raise ValueError("ConformanceResult.runner must be non-empty")

--- a/contracts/python/src/weaver_contracts/version.py
+++ b/contracts/python/src/weaver_contracts/version.py
@@ -3,7 +3,7 @@ Contract version constants and compatibility helpers.
 """
 
 # The current contract version. Must match pyproject.toml [project] version.
-CONTRACT_VERSION = "0.7.0"
+CONTRACT_VERSION = "0.8.0"
 
 # The JSON Schema $id version prefix (corresponds to MAJOR version).
 SCHEMA_VERSION_PREFIX = "v0"

--- a/contracts/python/tests/test_conformance.py
+++ b/contracts/python/tests/test_conformance.py
@@ -105,9 +105,11 @@ from datetime import datetime, timedelta, timezone  # noqa: E402
 
 
 def test_result_freshness_accepts_recent_current_major():
-    now = datetime(2026, 7, 5, tzinfo=timezone.utc)
-    result = conf.build_result("pass", 47, [])  # generated_at ~= now, current version
-    fresh, reasons = conf.is_result_fresh(result, now=now)
+    # Just-produced result: generated_at ~= real now and version == current, so
+    # it is fresh. Uses the default `now` (real clock) rather than a pinned one
+    # so the freshly-stamped generated_at is never treated as future.
+    result = conf.build_result("pass", 47, [])
+    fresh, reasons = conf.is_result_fresh(result)
     assert fresh, reasons
 
 
@@ -135,6 +137,17 @@ def test_result_freshness_flags_missing_generated_at():
     fresh, reasons = conf.is_result_fresh(result)
     assert not fresh
     assert any("generated_at" in r for r in reasons)
+
+
+def test_result_freshness_flags_future_timestamp():
+    # A future-dated result is clock-skewed/malformed, not fresh: a negative age
+    # must not slip past the age ceiling.
+    now = datetime(2026, 7, 5, tzinfo=timezone.utc)
+    result = conf.build_result("pass", 47, [])
+    result["generated_at"] = "2026-08-01T00:00:00Z"  # after `now`
+    fresh, reasons = conf.is_result_fresh(result, now=now)
+    assert not fresh
+    assert any("future" in r for r in reasons)
 
 
 def test_main_emits_result_and_badge(tmp_path):
@@ -225,6 +238,18 @@ def test_main_bundle_mode_oversized_input_is_reported(tmp_path, capsys):
     assert conf.main(["--bundle", str(path)]) == 1
     err = capsys.readouterr().err
     assert "input:" in err and "limit" in err
+
+
+def test_input_failure_message_is_1to1_in_result(tmp_path):
+    # The structured record's message must equal the failure_detail entry (the
+    # _Failures 1:1 invariant), including the "input:" prefix.
+    path = tmp_path / "bad.json"
+    path.write_text("[1, 2, 3]")  # valid JSON, not an object
+    result_path = tmp_path / "result.json"
+    assert conf.main(["--bundle", str(path), "--emit-result", str(result_path)]) == 1
+    result = json.loads(result_path.read_text())
+    assert result["failure_detail"] == [r["message"] for r in result["failure_records"]]
+    assert result["failure_detail"][0].startswith("input:")
 
 
 # ---------------------------------------------------------------------------

--- a/contracts/python/tests/test_conformance.py
+++ b/contracts/python/tests/test_conformance.py
@@ -150,6 +150,20 @@ def test_result_freshness_flags_future_timestamp():
     assert any("future" in r for r in reasons)
 
 
+def test_result_freshness_flags_just_past_window_by_hours():
+    # A result 90 days *and a few hours* old is past the "within 90 days" window
+    # and must not read as fresh. Guards the full-timedelta comparison against a
+    # regression to the truncating ``age.days`` check, which would round 90d6h
+    # down to 90 and wrongly accept it.
+    now = datetime(2026, 7, 5, tzinfo=timezone.utc)
+    result = conf.build_result("pass", 47, [])
+    generated = now - timedelta(days=90, hours=6)
+    result["generated_at"] = generated.strftime("%Y-%m-%dT%H:%M:%SZ")
+    fresh, reasons = conf.is_result_fresh(result, now=now)
+    assert not fresh
+    assert any("days old" in r for r in reasons)
+
+
 def test_main_emits_result_and_badge(tmp_path):
     result_path = tmp_path / "result.json"
     badge_path = tmp_path / "badge.json"

--- a/contracts/python/tests/test_conformance.py
+++ b/contracts/python/tests/test_conformance.py
@@ -37,8 +37,9 @@ def _load(rel: str) -> dict:
 # ---------------------------------------------------------------------------
 
 def test_full_suite_passes():
-    checks, failures = conf.run(conf.DEFAULT_KEYRING)
+    checks, failures, records = conf.run(conf.DEFAULT_KEYRING)
     assert failures == []
+    assert records == []
     assert checks > 0
 
 
@@ -53,23 +54,30 @@ def test_main_corpus_exit_zero():
 def test_verify_external_bundle_passes_signed_fixture():
     bundle = _load("conformance/fixtures/trace_bundle_signed_valid.json")
     keyring = conf.load_keyring(conf.DEFAULT_KEYRING)
-    checks, failures, _notes = conf.verify_external_bundle(bundle, SCHEMAS, REGISTRY, keyring)
+    checks, failures, records, _notes = conf.verify_external_bundle(bundle, SCHEMAS, REGISTRY, keyring)
     assert checks > 0
     assert failures == []
+    assert records == []
 
 
 def test_verify_external_bundle_flags_i01_violation():
     bundle = _load("conformance/negative/trace_bundle/i01_frame_carries_raw_output.json")
-    checks, failures, _notes = conf.verify_external_bundle(bundle, SCHEMAS, REGISTRY, {})
+    checks, failures, records, _notes = conf.verify_external_bundle(bundle, SCHEMAS, REGISTRY, {})
     assert any("frames_have_no_raw_output" in f for f in failures)
+    # #145: the same failure is available as a structured record an agent can map.
+    assert any(
+        r["kind"] == "invariant" and r.get("invariant_id") == "frames_have_no_raw_output"
+        for r in records
+    )
 
 
 def test_verify_external_bundle_rejects_schema_invalid_bundle():
     # Missing the required trace_events array: rejected at the schema gate.
     bundle = {"bundle_id": "b", "routing_decision": {}, "policy_decisions": [],
               "frames": [], "handles": []}
-    _checks, failures, _notes = conf.verify_external_bundle(bundle, SCHEMAS, REGISTRY, {})
+    _checks, failures, records, _notes = conf.verify_external_bundle(bundle, SCHEMAS, REGISTRY, {})
     assert any(f.startswith("schema:") for f in failures)
+    assert any(r["kind"] == "schema" for r in records)
 
 
 def test_build_result_and_shields_endpoint_pass():
@@ -89,6 +97,46 @@ def test_build_shields_endpoint_fail():
     assert endpoint["isError"] is True
 
 
+# ---------------------------------------------------------------------------
+# Result freshness / expiry policy (#150)
+# ---------------------------------------------------------------------------
+
+from datetime import datetime, timedelta, timezone  # noqa: E402
+
+
+def test_result_freshness_accepts_recent_current_major():
+    now = datetime(2026, 7, 5, tzinfo=timezone.utc)
+    result = conf.build_result("pass", 47, [])  # generated_at ~= now, current version
+    fresh, reasons = conf.is_result_fresh(result, now=now)
+    assert fresh, reasons
+
+
+def test_result_freshness_flags_stale():
+    now = datetime(2026, 7, 5, tzinfo=timezone.utc)
+    result = conf.build_result("pass", 47, [])
+    result["generated_at"] = "2026-01-01T00:00:00Z"  # > 90 days before `now`
+    fresh, reasons = conf.is_result_fresh(result, now=now)
+    assert not fresh
+    assert any("days old" in r for r in reasons)
+
+
+def test_result_freshness_flags_wrong_major():
+    now = datetime(2026, 7, 5, tzinfo=timezone.utc)
+    result = conf.build_result("pass", 47, [])
+    result["contract_version"] = "1.0.0"  # different MAJOR than current 0.x
+    fresh, reasons = conf.is_result_fresh(result, now=now)
+    assert not fresh
+    assert any("MAJOR" in r for r in reasons)
+
+
+def test_result_freshness_flags_missing_generated_at():
+    result = conf.build_result("pass", 47, [])
+    del result["generated_at"]
+    fresh, reasons = conf.is_result_fresh(result)
+    assert not fresh
+    assert any("generated_at" in r for r in reasons)
+
+
 def test_main_emits_result_and_badge(tmp_path):
     result_path = tmp_path / "result.json"
     badge_path = tmp_path / "badge.json"
@@ -97,9 +145,167 @@ def test_main_emits_result_and_badge(tmp_path):
     result = json.loads(result_path.read_text())
     assert result["status"] == "pass"
     assert result["mode"] == "corpus"
+    assert result["failure_records"] == []
     badge = json.loads(badge_path.read_text())
     assert badge["label"] == "weaver-compatible"
     assert badge["color"] == "brightgreen"
+
+
+def test_emitted_result_validates_against_schema():
+    # #116: the runner's own output must satisfy the ConformanceResult schema, so
+    # the badge/scoreboard consumers have a validated contract.
+    schema = SCHEMAS["conformance_result"]
+    passing = conf.build_result("pass", 47, [], mode="corpus", target=None)
+    assert conf.schema_errors(passing, schema, REGISTRY) == []
+
+
+def test_emitted_result_with_structured_failures_validates():
+    # #116 + #145: a failing result carrying structured failure_records also
+    # validates against the schema.
+    schema = SCHEMAS["conformance_result"]
+    records = [
+        {"kind": "schema", "message": "schema: <root>: boom", "schema": "frame", "path": "<root>"},
+        {"kind": "invariant", "message": "INVARIANT I-01 failed", "invariant_id": "I-01"},
+    ]
+    failing = conf.build_result(
+        "fail", 47, ["schema: <root>: boom", "INVARIANT I-01 failed"],
+        mode="bundle", target="path/to/bundle.json", failure_records=records,
+    )
+    assert conf.schema_errors(failing, schema, REGISTRY) == []
+    assert failing["failure_records"] == records
+
+
+# ---------------------------------------------------------------------------
+# External-bundle input hardening (#158)
+# ---------------------------------------------------------------------------
+
+def test_load_external_bundle_accepts_valid_object(tmp_path):
+    path = tmp_path / "b.json"
+    path.write_text(json.dumps({"bundle_id": "b"}))
+    bundle, error = conf.load_external_bundle(path)
+    assert error is None
+    assert bundle == {"bundle_id": "b"}
+
+
+def test_load_external_bundle_rejects_oversized(tmp_path):
+    path = tmp_path / "big.json"
+    # A valid-JSON string padded past the limit: rejected on size, before parsing.
+    path.write_text('{"x": "' + "a" * (conf.MAX_BUNDLE_BYTES + 10) + '"}')
+    bundle, error = conf.load_external_bundle(path)
+    assert bundle is None
+    assert error is not None and "limit" in error
+
+
+def test_load_external_bundle_rejects_non_object(tmp_path):
+    path = tmp_path / "arr.json"
+    path.write_text("[1, 2, 3]")  # valid JSON, but not a bundle object
+    bundle, error = conf.load_external_bundle(path)
+    assert bundle is None
+    assert error is not None and "JSON object" in error
+
+
+def test_load_external_bundle_rejects_malformed_json(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text("{not json")
+    bundle, error = conf.load_external_bundle(path)
+    assert bundle is None
+    assert error is not None and "not valid JSON" in error
+
+
+def test_main_bundle_mode_fails_gracefully_on_malformed_input(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text("[1, 2, 3]")
+    # Exit non-zero with a clear failure, not a traceback.
+    assert conf.main(["--bundle", str(path)]) == 1
+
+
+def test_main_bundle_mode_oversized_input_is_reported(tmp_path, capsys):
+    path = tmp_path / "big.json"
+    path.write_text('{"x": "' + "a" * (conf.MAX_BUNDLE_BYTES + 10) + '"}')
+    assert conf.main(["--bundle", str(path)]) == 1
+    err = capsys.readouterr().err
+    assert "input:" in err and "limit" in err
+
+
+# ---------------------------------------------------------------------------
+# Validator caching / performance regression guard (#130)
+# ---------------------------------------------------------------------------
+
+def test_validator_is_compiled_once_and_reused():
+    # Same schema -> the very same compiled validator object, not a rebuild.
+    v1 = conf._validator_for(SCHEMAS["frame"], REGISTRY)
+    v2 = conf._validator_for(SCHEMAS["frame"], REGISTRY)
+    assert v1 is v2
+
+
+def test_full_run_compiles_far_fewer_validators_than_checks():
+    # Regression guard: with caching, the number of distinct compiled validators
+    # scales with the number of *schemas*, not the number of checks. If a future
+    # change reintroduces per-payload construction this bound breaks loudly
+    # (this is a structural guard, not a flaky wall-clock benchmark).
+    conf._VALIDATOR_CACHE.clear()
+    checks, failures, _records = conf.run(conf.DEFAULT_KEYRING)
+    assert failures == []
+    assert 0 < len(conf._VALIDATOR_CACHE) < checks
+
+
+# ---------------------------------------------------------------------------
+# Extend-via-data guard: corpus/invariants map to real schemas/checks (#137)
+# ---------------------------------------------------------------------------
+
+INVARIANTS_DOC = yaml.safe_load((REPO_ROOT / "conformance" / "invariants.yaml").read_text())
+_KNOWN_APPLIES_TO = (["core_schemas"], ["capability_token"], ["trace_bundle"])
+
+
+@pytest.mark.parametrize(
+    "entry",
+    CORPUS["positive"] + CORPUS["negative"],
+    ids=lambda e: e["payload"],
+)
+def test_corpus_schema_names_resolve(entry):
+    # Every corpus entry must name a schema the runner actually loaded — a typo
+    # or a schema rename would otherwise KeyError deep in a run (or, worse for a
+    # sibling manifest, skip silently).
+    assert entry["schema"] in SCHEMAS, f"unknown schema {entry['schema']!r}"
+
+
+def test_trace_bundle_invariant_assertions_are_registered():
+    # Every trace_bundle-scoped invariant must bind to a real named check in
+    # BUNDLE_INVARIANTS, so invariants.yaml can't reference a check that no
+    # longer exists.
+    for inv in INVARIANTS_DOC["invariants"]:
+        if inv["applies_to"] == ["trace_bundle"]:
+            assert inv["assertion"] in conf.BUNDLE_INVARIANTS, (
+                f"invariant {inv['id']} names unregistered check {inv['assertion']!r}"
+            )
+
+
+def test_every_invariant_applies_to_a_known_branch():
+    # Guards the run() dispatch: an applies_to with no branch now raises rather
+    # than silently skipping (#137). This asserts the shipped manifest stays
+    # within the supported set.
+    for inv in INVARIANTS_DOC["invariants"]:
+        assert inv["applies_to"] in _KNOWN_APPLIES_TO, (
+            f"invariant {inv['id']} has unsupported applies_to {inv['applies_to']!r}"
+        )
+
+
+def test_run_raises_on_unsupported_applies_to(monkeypatch, tmp_path):
+    # Directly exercise the fail-loud path: an invariant targeting an unknown
+    # scope must raise, not no-op. Keep the real invariants (the negative corpus
+    # resolves I-01/I-02 by id) and append one bogus entry.
+    doc = yaml.safe_load((REPO_ROOT / "conformance" / "invariants.yaml").read_text())
+    doc["invariants"].append(
+        {"id": "I-XX", "applies_to": ["nonexistent"], "assertion": "whatever"}
+    )
+    (tmp_path / "invariants.yaml").write_text(yaml.safe_dump(doc))
+    # Copy the real corpus alongside so run() gets past the corpus stage.
+    (tmp_path / "corpus.yaml").write_text(
+        (REPO_ROOT / "conformance" / "corpus.yaml").read_text()
+    )
+    monkeypatch.setattr(conf, "CONF_DIR", tmp_path)
+    with pytest.raises(ValueError, match="unsupported applies_to"):
+        conf.run(conf.DEFAULT_KEYRING)
 
 
 # ---------------------------------------------------------------------------
@@ -213,6 +419,17 @@ def test_signed_fixture_cryptographically_verifies():
 def test_tampered_bundle_fails_verification():
     bundle = _load("conformance/fixtures/trace_bundle_signed_valid.json")
     bundle["bundle_id"] = "tampered-after-signing"  # changes the canonical form
+    keyring = conf.load_keyring(conf.DEFAULT_KEYRING)
+    errs, _ = conf.check_trace_bundle(bundle, SCHEMAS, REGISTRY, keyring)
+    assert any("verification FAILED" in e for e in errs)
+
+
+def test_tampered_nested_frame_fails_verification():
+    # #133: tampering a nested artifact (not just a top-level scalar) after
+    # signing must still break the signature, since the whole bundle is in the
+    # JCS canonical form. Guards the integrity check against nested mutation.
+    bundle = _load("conformance/fixtures/trace_bundle_signed_valid.json")
+    bundle["frames"][0]["summary"] = "Rewritten after the bundle was signed."
     keyring = conf.load_keyring(conf.DEFAULT_KEYRING)
     errs, _ = conf.check_trace_bundle(bundle, SCHEMAS, REGISTRY, keyring)
     assert any("verification FAILED" in e for e in errs)

--- a/contracts/python/tests/test_extended.py
+++ b/contracts/python/tests/test_extended.py
@@ -22,6 +22,7 @@ from weaver_contracts.extended import (
     ArtifactSafetyReport,
     CapabilityTokenSignature,
     CompiledFlow,
+    ConformanceResult,
     EvaluationArtifact,
     ExecutionCandidate,
     ExecutionFeedback,
@@ -1480,3 +1481,73 @@ class TestFailureCaseArtifact:
         data = json.loads(json.dumps(asdict(fc)))
         for key, value in p.items():
             assert data[key] == value, f"{name}: {key!r} not preserved on round-trip"
+
+
+class TestConformanceResult:
+    def _kwargs(self, **overrides):
+        base = dict(
+            result_version="1",
+            contract_version="0.8.0",
+            mode="corpus",
+            target=None,
+            status="pass",
+            checks_run=47,
+            failures=0,
+            generated_at="2026-07-05T12:00:00Z",
+            runner="weaver-spec conformance/run.py",
+        )
+        base.update(overrides)
+        return base
+
+    def test_valid_from_payload(self):
+        p = load_payload("conformance_result")
+        r = ConformanceResult(
+            result_version=p["result_version"],
+            contract_version=p["contract_version"],
+            mode=p["mode"],
+            target=p["target"],
+            status=p["status"],
+            checks_run=p["checks_run"],
+            failures=p["failures"],
+            generated_at=p["generated_at"],
+            runner=p["runner"],
+            failure_detail=p.get("failure_detail", []),
+            failure_records=p.get("failure_records", []),
+        )
+        assert r.status == "pass"
+        assert r.mode == "corpus"
+        assert r.target is None
+        assert r.failure_records == []
+
+    def test_bad_result_version_raises(self):
+        with pytest.raises(ValueError, match="result_version must be '1'"):
+            ConformanceResult(**self._kwargs(result_version="2"))
+
+    def test_bad_mode_raises(self):
+        with pytest.raises(ValueError, match="mode must be one of"):
+            ConformanceResult(**self._kwargs(mode="offline"))
+
+    def test_bad_status_raises(self):
+        with pytest.raises(ValueError, match="status must be one of"):
+            ConformanceResult(**self._kwargs(status="maybe"))
+
+    def test_negative_counts_raise(self):
+        with pytest.raises(ValueError, match="checks_run must be >= 0"):
+            ConformanceResult(**self._kwargs(checks_run=-1))
+        with pytest.raises(ValueError, match="failures must be >= 0"):
+            ConformanceResult(**self._kwargs(failures=-1))
+
+    def test_serialization_roundtrips(self):
+        r = ConformanceResult(
+            **self._kwargs(
+                mode="bundle",
+                target="path/to/bundle.json",
+                status="fail",
+                failures=1,
+                failure_detail=["schema: <root>: boom"],
+                failure_records=[{"kind": "schema", "message": "schema: <root>: boom"}],
+            )
+        )
+        data = json.loads(json.dumps(asdict(r)))
+        assert data["mode"] == "bundle"
+        assert data["failure_records"][0]["kind"] == "schema"

--- a/contracts/python/tests/test_extended_schema_alignment.py
+++ b/contracts/python/tests/test_extended_schema_alignment.py
@@ -55,6 +55,7 @@ EXTENDED_TYPES = [
     ("ExecutionFeedback", "execution_feedback"),
     ("TraceBundle", "trace_bundle"),
     ("FailureCaseArtifact", "failure_case_artifact"),
+    ("ConformanceResult", "conformance_result"),
 ]
 
 
@@ -394,6 +395,41 @@ class TestExtendedNegativeCases:
             "property_name": "p",
             "status": "candidate",
             "severity": "extreme",
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_conformance_result_bad_status_fails(self):
+        # #116: status is constrained to pass|fail.
+        schema = load_extended_schema("conformance_result")
+        bad = {
+            "result_version": "1",
+            "contract_version": "0.8.0",
+            "mode": "corpus",
+            "target": None,
+            "status": "maybe",
+            "checks_run": 1,
+            "failures": 0,
+            "generated_at": "2026-07-05T12:00:00Z",
+            "runner": "weaver-spec conformance/run.py",
+        }
+        with pytest.raises(AssertionError, match="Schema validation failed"):
+            validate(bad, schema)
+
+    def test_conformance_result_bad_failure_record_fails(self):
+        # #145: each failure_record needs a kind from the enum and a message.
+        schema = load_extended_schema("conformance_result")
+        bad = {
+            "result_version": "1",
+            "contract_version": "0.8.0",
+            "mode": "corpus",
+            "target": None,
+            "status": "fail",
+            "checks_run": 1,
+            "failures": 1,
+            "failure_records": [{"kind": "not-a-kind", "message": "x"}],
+            "generated_at": "2026-07-05T12:00:00Z",
+            "runner": "weaver-spec conformance/run.py",
         }
         with pytest.raises(AssertionError, match="Schema validation failed"):
             validate(bad, schema)

--- a/contracts/python/tests/test_scoreboard.py
+++ b/contracts/python/tests/test_scoreboard.py
@@ -132,7 +132,7 @@ def test_sibling_row_pass_surfaces_signature_status(monkeypatch):
     monkeypatch.setattr(
         sb.run,
         "verify_external_bundle",
-        lambda *a: (3, [], ["signature cryptographically verified (kid 'k')"]),
+        lambda *a: (3, [], [], ["signature cryptographically verified (kid 'k')"]),
     )
     row = sb.sibling_row({"repo": "x", "url": "https://x.dev/b.json"}, {}, None, {}, 1.0)
     assert row.status == "pass"
@@ -142,7 +142,7 @@ def test_sibling_row_pass_surfaces_signature_status(monkeypatch):
 
 def test_sibling_row_fail_reports_first_failure(monkeypatch):
     monkeypatch.setattr(sb, "fetch_json", lambda url, timeout: ({"bundle_id": "b"}, "fetched"))
-    monkeypatch.setattr(sb.run, "verify_external_bundle", lambda *a: (2, ["boom", "second"], []))
+    monkeypatch.setattr(sb.run, "verify_external_bundle", lambda *a: (2, ["boom", "second"], [], []))
     row = sb.sibling_row({"repo": "x", "url": "https://x.dev/b.json"}, {}, None, {}, 1.0)
     assert row.status == "fail"
     assert row.detail == "2 failure(s): boom"

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -18,7 +18,7 @@ Schema cannot express.
 | Positive corpus | [`conformance/corpus.yaml`](../conformance/corpus.yaml) `positive` | Each payload **must** validate against its schema. |
 | Negative corpus | `conformance/corpus.yaml` `negative` | Each payload **must** be rejected — by JSON Schema (`by: schema`) or, for schema-valid payloads, by an invariant (`by: invariant`). |
 | Invariants | [`conformance/invariants.yaml`](../conformance/invariants.yaml) | Executable assertions for **I-01, I-02, I-04, I-06** (see [INVARIANTS.md](INVARIANTS.md)). |
-| TraceBundle integrity | runner (`#74`) | Recomputes the RFC 8785 (JCS) canonical form excluding `signature`; validates the detached-signature envelope; cryptographically verifies the signature when the signing key is in the supplied keyring. |
+| TraceBundle integrity | runner (`#74`) | Recomputes the RFC 8785 (JCS) canonical form excluding `signature`; validates the detached-signature envelope; cryptographically verifies the signature when the signing key is in the supplied keyring. Adversarial envelopes — a missing `kid`, a non-registry `canonicalization`, or a nested artifact tampered after signing — are rejected (`#133`). |
 
 `invariants.yaml` is intentionally a **named-check registry**, not an embedded
 expression language: each block binds an invariant `id` to a real Python check
@@ -92,7 +92,11 @@ python conformance/run.py --bundle path/to/bundle.json
 ```
 
 This is the engine the [scoreboard](SCOREBOARD.md) runs against each sibling's
-published bundle.
+published bundle. Because that input is semi-trusted (it comes from another
+repo), the external path is hardened (#158): a bundle larger than **5 MiB** or
+that is not a JSON object is rejected with a clear `input:` failure rather than
+a traceback, and at most that many bytes are read before parsing. The scoreboard
+enforces the same limit on the bundles it fetches over the network.
 
 ## Machine-readable result and badge
 
@@ -106,9 +110,47 @@ python conformance/run.py \
   --emit-badge weaver-compatible.json
 ```
 
-The result is CI tooling output, not a Weaver contract. See
+The result is CI tooling output, not a Weaver runtime contract, but it is a
+stable interchange shape: it validates against
+[`contracts/json/extended/conformance_result.schema.json`](../contracts/json/extended/conformance_result.schema.json)
+(`#116`), so the badge, the scoreboard, and any sibling reading it share one
+schema and cannot drift. Alongside the flat `failure_detail` strings the result
+carries `failure_records` — a structured per-failure view (`kind`, `message`,
+and, where known, `payload` / `schema` / `keyword` / `path` / `invariant_id`)
+that an agent can map straight to the offending fixture or field (`#145`). See
 [SELF_CERTIFICATION.md](SELF_CERTIFICATION.md) for the badge flow and
 [SCOREBOARD.md](SCOREBOARD.md) for the public per-repo scoreboard.
+
+## Validating at scale
+
+Compiling a JSON Schema validator is far more expensive than running one.
+Adopters that validate many payloads — a kernel firewalling every tool call, a
+batch validating a corpus — should **compile once and reuse**, not build a
+validator per payload. The runner does this internally: `load_schemas()` builds
+the schema registry once, and `_validator_for()` caches one compiled
+`Draft202012Validator` per schema `$id`, so validating N payloads against the
+same schema compiles it once, not N times. Mirror that pattern in your own
+integration rather than constructing a validator inside a per-payload loop.
+
+## Extending the conformance suite
+
+The runner is deliberately a single, data-driven file. Extend it through
+**data, not new code paths**:
+
+- **A new positive or negative payload** is a new entry in
+  [`corpus.yaml`](../conformance/corpus.yaml) plus a fixture file — no runner
+  change. A schema-level negative declares `by: schema` and the `violates`
+  keyword/target; an invariant-level negative declares `by: invariant` and the
+  invariant `id`.
+- **A new invariant** registers a named check in `BUNDLE_INVARIANTS` (or the
+  relevant dispatch in `run()`) and adds a block to
+  [`invariants.yaml`](../conformance/invariants.yaml) binding the `id` to that
+  named check. Avoid bespoke per-fixture branches.
+
+A consistency test (`test_conformance.py`) enforces this: every `corpus.yaml`
+schema name must resolve to a loaded schema, and every `trace_bundle`-scoped
+invariant assertion must resolve to a registered check — so a typo or an
+orphaned entry fails CI rather than silently skipping a check.
 
 ## Related
 

--- a/docs/CONTRACT_REFERENCE.md
+++ b/docs/CONTRACT_REFERENCE.md
@@ -1,6 +1,6 @@
 # Contract Field Reference
 
-A single-page field reference for every Weaver contract type — both Core (9) and Extended (23).
+A single-page field reference for every Weaver contract type — both Core (9) and Extended (24).
 
 For narrative and adoption guidance, read [ARCHITECTURE.md](ARCHITECTURE.md), [BOUNDARIES.md](BOUNDARIES.md), and [GLOSSARY.md](GLOSSARY.md). For a runnable code path, use [QUICKSTART.md](QUICKSTART.md).
 

--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -20,6 +20,12 @@ The LLM context window must never receive raw tool output unless an explicit, au
 
 **What "default" means:** Without explicit opt-in configuration, the firewall is always active. An implementation may expose a `raw_passthrough` mode for trusted internal pipelines, but this must be explicitly declared in the `CapabilityToken` and recorded in the audit log.
 
+> [!NOTE]
+> A structural wire representation for this override — and a corresponding
+> conformance check that exempts a correctly declared-and-audited passthrough
+> without weakening the default check — is **proposed, not yet accepted**, in
+> [ADR 003](adr/003-raw-passthrough-override.md) ([#117](https://github.com/dgenio/weaver-spec/issues/117)). Until it is accepted, any `Frame` carrying raw output is treated as an I-01 violation by the conformance suite.
+
 ---
 
 ### I-02: Every Execution Is Authorized and Auditable

--- a/docs/SELF_CERTIFICATION.md
+++ b/docs/SELF_CERTIFICATION.md
@@ -24,26 +24,35 @@ conformance result, so it cannot disagree with what the suite actually checks.
      --emit-badge weaver-compatible.json
    ```
 
-   The result is CI tooling output (not a Weaver contract). Its shape:
+   The result is CI tooling output (not a Weaver runtime contract), but it is a
+   stable interchange shape validated against
+   [`contracts/json/extended/conformance_result.schema.json`](../contracts/json/extended/conformance_result.schema.json)
+   (#116). Its shape:
 
    ```json
    {
      "result_version": "1",
-     "contract_version": "0.6.0",
+     "contract_version": "0.8.0",
      "mode": "corpus",
      "target": null,
      "status": "pass",
-     "checks_run": 40,
+     "checks_run": 47,
      "failures": 0,
      "failure_detail": [],
-     "generated_at": "2026-06-03T12:00:00Z",
+     "failure_records": [],
+     "generated_at": "2026-07-05T12:00:00Z",
      "runner": "weaver-spec conformance/run.py"
    }
    ```
 
    `failures` is the failure *count*; `failure_detail` is the list of failure
-   messages (empty when `status` is `pass`). `target` is `null` in `corpus` mode
-   and the bundle URL/path in `bundle` mode.
+   messages (empty when `status` is `pass`). `failure_records` is the structured
+   per-failure view (#145): each entry carries a `kind`
+   (`positive`/`negative`/`invariant`/`schema`/`tracebundle`/`input`) and the
+   same `message`, plus — where known — `payload`, `schema`, `keyword`, `path`,
+   and `invariant_id`, so an agent can map a failure to the offending
+   fixture/field without parsing the human strings. `target` is `null` in
+   `corpus` mode and the bundle URL/path in `bundle` mode.
 
 3. **Display the badge.** Host the emitted endpoint JSON and reference it via the
    [shields.io endpoint](https://shields.io/badges/endpoint-badge):
@@ -54,6 +63,32 @@ conformance result, so it cannot disagree with what the suite actually checks.
 
    This repo's own badge lives at [`docs/badges/weaver-spec.json`](badges/weaver-spec.json)
    and is regenerated (and checked for staleness) by the `reference-impl` CI job.
+
+## Freshness and validity
+
+A conformance result is a point-in-time attestation, so a published result is
+trustworthy only while it stays current (#150):
+
+> [!IMPORTANT]
+> A published result is **valid** only when both hold:
+>
+> - its `generated_at` is within **90 days** of now, and
+> - its `contract_version` shares the **current contract MAJOR**.
+>
+> A result that is older than the window, or that attests against a superseded
+> MAJOR, MUST NOT be displayed as current — regenerate it. Display a badge only
+> for a result that still satisfies both conditions.
+
+The reference checker is `conformance/run.py:is_result_fresh(result)`, which
+returns `(fresh, reasons)` using only the result's existing `generated_at` and
+`contract_version` fields — no extra contract surface. The 90-day window is a
+deliberately generous default (roughly a release cadence); tighten it in your
+own pipeline if you publish more often.
+
+The public [scoreboard](scoreboard.md) is unaffected by staleness because it
+**re-verifies each sibling's live bundle on every run** rather than trusting a
+previously published result — so a stale result can never reach it. The policy
+above governs a result JSON that a third party hosts and displays directly.
 
 ## Consistency with the scoreboard
 
@@ -68,4 +103,5 @@ construction.
 
 - [CONFORMANCE.md](CONFORMANCE.md) — what the suite verifies.
 - [SCOREBOARD.md](SCOREBOARD.md) — publishing a bundle for the public scoreboard.
+- [SIGNING.md](SIGNING.md#trust-model) — what a verified signature does and does not attest.
 - [examples/reference_impl/](../examples/reference_impl/) — zero-to-passing example.

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -116,6 +116,52 @@ adoption.
 
 ---
 
+## Trust model
+
+> [!IMPORTANT]
+> This section states what a verified signature does and does not guarantee. It
+> is normative for adopters reasoning about the signing/conformance path (#156).
+
+**What a valid signature attests.** A signature that verifies proves exactly
+two things: (1) **integrity** — the JCS-canonical form of the payload (with
+`x_weaver_signature` / `signature` removed) has not changed since signing; and
+(2) **origin** — it was produced by the private key whose public key the
+verifier holds under `kid`. Nothing more.
+
+**What it does NOT attest.**
+
+- **Correctness or safety.** A signed `TraceBundle` or `CapabilityToken` is
+  authentic, not *correct*. Signing says who produced the bytes, not that the
+  decision they encode was sound.
+- **Freshness / replay.** A detached signature carries no nonce or expiry of its
+  own. `signed_at` is informational and unverified. A captured signed payload
+  stays verifiable forever; bound freshness at the payload layer (a
+  `CapabilityToken`'s `expires_at` / `single_use`, invariant I-06) or with a
+  transport nonce, not via the signature.
+- **Confidentiality.** Signing is integrity + authentication, never encryption
+  (see below).
+
+**Trust is rooted in keyring distribution.** Verification is only as trustworthy
+as the mapping from `kid` to public key. Distributing and rotating that keyring
+is the adopter's responsibility (see *What is out of scope*); a signature
+verified against an attacker-controlled keyring proves nothing.
+
+**Unknown key means "not verified", not "trusted".** The strict verifier in
+[Verifying a signature](#verifying-a-signature) returns `False` for a `kid` that
+is absent from the keyring — an unknown key is a verification *failure* for a
+verifier that must decide accept/reject. The conformance runner
+(`conformance/run.py:check_trace_bundle`) instead reports an unknown `kid` as
+**skipped** — it validates the signature *envelope* (shape, algorithm registry,
+canonicalization) but records that cryptographic verification did not run,
+because the runner is a **conformance report**, not an authorization gate: it
+must not claim provenance it did not check, and it must not fail a bundle merely
+because the report host lacks the signer's key. Both behaviours share the same
+rule — **an unknown key is never treated as verified** — they differ only in
+what an unverifiable signature means for the caller: reject (a gate) versus
+report-as-unchecked (a scoreboard). See
+[CONFORMANCE.md](CONFORMANCE.md#signature-verification-74) and
+[SELF_CERTIFICATION.md](SELF_CERTIFICATION.md).
+
 ## What is out of scope
 
 - **Key management.** Issuing `kid` values, rotating keys, distributing

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -104,11 +104,11 @@ This table tracks which versions of the sibling repositories are known-compatibl
 > [!IMPORTANT]
 > A cell may be `verified` or `provisional` only when backed by a real declaration recorded in `compatibility.yaml` (the `declaration` field). Unknown compatibility MUST be recorded as `unverified` — never assume or invent a version claim.
 
-### Current matrix (contract version 0.7.0)
+### Current matrix (contract version 0.8.0)
 
 | Contract Version | contextweaver | agent-kernel | ChainWeaver |
 | ----------------- | -------------- | ------------- | ------------- |
-| 0.7.0 (current) | `unverified` | `unverified` | `unverified` |
+| 0.8.0 (current) | `unverified` | `unverified` | `unverified` |
 
 All `0.x` contract versions share MAJOR version `0` and are mutually compatible (see [Semantic Versioning](#semantic-versioning) and `weaver_contracts.version.is_compatible`). No sibling repository has published a compatibility declaration yet, so every cell is `unverified`.
 

--- a/docs/adr/003-raw-passthrough-override.md
+++ b/docs/adr/003-raw-passthrough-override.md
@@ -1,0 +1,120 @@
+# ADR 003: Wire representation and conformance check for the `raw_passthrough` override
+
+**Status:** proposed <!-- proposed | accepted | rejected | superseded by ADR NNN (NNN-short-title.md) -->
+
+---
+
+## Context
+
+[I-01](../INVARIANTS.md#i-01-llm-never-sees-raw-tool-output-by-default) and
+[I-05](../INVARIANTS.md#i-05-contextweaver-receives-frames-not-raw-output) forbid
+raw tool output reaching the LLM *by default*, with one carve-out: an explicit,
+auditable `raw_passthrough` mode "declared in the `CapabilityToken` and recorded
+in the audit log." This carve-out is the single highest-risk path in the spec.
+
+Today it exists only in prose. The conformance suite models the **forbidden**
+case — `conformance/run.py:frames_have_no_raw_output` rejects any `Frame`
+carrying a raw-output key (`raw_output`, `raw`, `raw_result`, `tool_output`) —
+but there is **no structural marker** for a *sanctioned* passthrough and **no
+positive fixture** exercising it. As a result:
+
+- Implementers have no defined wire shape for declaring an authorized
+  passthrough, so each would invent its own.
+- The conformance suite cannot distinguish "raw output leaked (violation)" from
+  "raw output passed through under an audited, explicit override (allowed)."
+
+Issue [#117](https://github.com/dgenio/weaver-spec/issues/117) asks for positive
+and negative conformance fixtures for the override. The negative case is already
+covered (`conformance/negative/trace_bundle/i01_frame_carries_raw_output.json`).
+The positive case cannot be added without first deciding a wire representation
+**and** teaching the I-01 conformance check to exempt a correctly-declared
+passthrough — which changes how the spec's most security-critical invariant is
+enforced. Per [CONTRIBUTING.md](../../CONTRIBUTING.md#adr-process-for-breaking-contract-changes),
+a change that broadens what a contract/check accepts requires an ADR. This ADR
+records the proposal so it can be reviewed before any enforcement change lands.
+
+## Decision
+
+> [!NOTE]
+> This ADR is **proposed**, not accepted. No enforcement change has been made;
+> the conformance check still flags every raw-output-bearing `Frame`. The
+> proposal below is what a follow-up implementation PR would land if accepted.
+
+Proposed wire representation — additive and namespaced, mirroring the existing
+`x_weaver_signature` convention (ADR 001):
+
+1. **Declaration on the `Frame`.** A sanctioned passthrough `Frame` carries a
+   namespaced object `x_weaver_raw_passthrough` alongside the raw-output key,
+   e.g.:
+
+   ```json
+   {
+     "frame_id": "frame-...",
+     "capability_id": "org.myapp.trusted_pipe",
+     "summary": "...",
+     "created_at": "...",
+     "raw_output": "...",
+     "x_weaver_raw_passthrough": {
+       "authorized_by": "tok-...",
+       "decision_id": "pd-..."
+     }
+   }
+   ```
+
+2. **Authorization on the `CapabilityToken`.** The authorizing token declares
+   the mode via a namespaced marker (`metadata.x_weaver_raw_passthrough: true`
+   or a reserved scope entry), so the declaration is rooted in the credential
+   I-01/I-05 name — not self-asserted by the Frame alone.
+
+3. **Audit record.** A `TraceEvent` records the passthrough (referencing the
+   same `frame_id` / `decision_id`), satisfying "recorded in the audit log."
+
+Proposed conformance change — **additive, does not weaken `FORBIDDEN_FRAME_KEYS`**:
+
+- Keep `frames_have_no_raw_output` as the default I-01 check unchanged.
+- Add a new named check that treats a raw-output-bearing `Frame` as compliant
+  **only when** all three of the above are present and internally consistent
+  (Frame declaration ↔ token authorization ↔ audit TraceEvent). Absent any of
+  them, it remains a violation.
+- Add a positive corpus fixture (declared + audited passthrough → allowed) and
+  keep the existing unauthorized fixture (raw output, no declaration →
+  violation).
+
+## Consequences
+
+- **Positive:** the spec's highest-risk conditional becomes conformance-checked
+  and interoperable; implementers get one defined shape instead of ad-hoc ones;
+  the exemption is gated on an explicit, audited, three-part declaration rather
+  than on loosening what counts as raw output.
+- **Negative / risk:** it broadens what the I-01 check accepts, so a bug in the
+  exemption logic could mask a real leak. This is why it is gated behind this
+  ADR and a dedicated review rather than bundled into unrelated work. The
+  exemption must fail closed (any missing/ inconsistent part → violation).
+- Extended/opt-in: contracts that never use passthrough are unaffected.
+
+## Affected Contracts
+
+No Core **schema** change is required (Core schemas already allow namespaced
+`x_*` extension keys via `additionalProperties: true`); the change is to the
+normative prose in `INVARIANTS.md` and to the conformance check.
+
+| Contract | Change type | Description |
+| ---------- | ------------- | ------------- |
+| `frame.schema.json` | none (extension key) | `x_weaver_raw_passthrough` rides on the existing `additionalProperties: true`; no field added to `required` or `properties`. |
+| `capability_token.schema.json` | none (extension key) | Authorization marker rides on `metadata` / namespaced extension; no schema change. |
+| `trace_event.schema.json` | none | Existing event types/fields suffice to record the passthrough. |
+
+## Migration Path
+
+No migration for existing payloads: they contain no `x_weaver_raw_passthrough`
+and remain valid and (for Frames) still subject to the unchanged default check.
+Adopters that need passthrough opt in by emitting the three-part declaration
+above once this ADR is accepted and the check ships.
+
+## Cross-Repo Impact
+
+| Repository | Impact | Coordination required? |
+| ------------ | -------- | ------------------------ |
+| contextweaver | Consumes Frames; would learn to recognize the passthrough marker as the sanctioned exception when ingesting. | yes (if accepted) |
+| agent-kernel | Owns the firewall; would emit the token authorization + Frame declaration + audit TraceEvent when passthrough is configured. | yes (if accepted) |
+| ChainWeaver | None directly; passthrough is a kernel/contextweaver concern. | no |

--- a/docs/badges/weaver-spec.json
+++ b/docs/badges/weaver-spec.json
@@ -2,6 +2,6 @@
   "color": "brightgreen",
   "isError": false,
   "label": "weaver-compatible",
-  "message": "v0.7.0",
+  "message": "v0.8.0",
   "schemaVersion": 1
 }

--- a/examples/sample_payloads/conformance_result.json
+++ b/examples/sample_payloads/conformance_result.json
@@ -1,0 +1,13 @@
+{
+  "result_version": "1",
+  "contract_version": "0.8.0",
+  "mode": "corpus",
+  "target": null,
+  "status": "pass",
+  "checks_run": 47,
+  "failures": 0,
+  "failure_detail": [],
+  "failure_records": [],
+  "generated_at": "2026-07-05T12:00:00Z",
+  "runner": "weaver-spec conformance/run.py"
+}

--- a/well-known/contracts.json
+++ b/well-known/contracts.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "contract_version": "0.7.0",
+  "contract_version": "0.8.0",
   "core": [
     {
       "name": "capability",
@@ -94,6 +94,13 @@
       "$id": "https://weaver-spec.dev/contracts/v0/extended/compiled_flow.schema.json",
       "path": "contracts/json/extended/compiled_flow.schema.json",
       "sha256": "0dc2a8ddfc9b3b8d33f85d442661fe696639e56184c2d89d812ab9cbf0082829"
+    },
+    {
+      "name": "conformance_result",
+      "version": "v0",
+      "$id": "https://weaver-spec.dev/contracts/v0/extended/conformance_result.schema.json",
+      "path": "contracts/json/extended/conformance_result.schema.json",
+      "sha256": "ec5a1a97e240327026c0dc97371002ad540aba2ca80ad453911925e6df7c30ba"
     },
     {
       "name": "evaluation_artifact",


### PR DESCRIPTION
## Description

A coherent sweep of build-time conformance-suite hardening plus one new Extended
contract, closing eight backlog issues that all touch the same surface
(`conformance/run.py`, its corpus/fixtures, and the docs that describe it).

Implemented (closed by this PR):

- **#152** — the reusable `conformance.yml` workflow and the `reference-impl` job now run the full Python **3.10–3.14** matrix (were pinned to 3.11) so the crypto/JCS/jsonschema path is exercised on every supported interpreter. The deterministic self-cert badge regeneration + staleness gate stay on a single leg.
- **#130** — the runner compiles one validator per schema `$id` and reuses it (compile-once/reuse); a regression guard asserts compilations scale with schemas, not payload count; documented in `docs/CONFORMANCE.md`.
- **#158** — `--bundle` / external ingestion rejects oversized (> 5 MiB) or non-object input with a clear `input:` failure instead of a traceback; the cap is shared with the scoreboard's network fetch.
- **#133** — adversarial negative fixtures (signature envelope missing `kid`; non-registry `canonicalization`) caught at the schema gate via the bundle's `$ref`, plus a nested-`Frame`-tamper unit test.
- **#137** — the runner now raises on an `invariants.yaml` `applies_to` that matches no branch (was a silent no-op); a consistency test asserts every corpus schema name and trace_bundle invariant assertion resolves; "Extending the conformance suite" documented.
- **#116 + #145** — the runner's machine-readable result is promoted to a schematized Extended contract (`ConformanceResult`) and gains a structured `failure_records` array (kind/payload/schema/keyword/path/invariant_id) alongside the flat strings, so an agent can map a failure to the offending fixture/field. Human output and exit codes unchanged.
- **#150** — `is_result_fresh()` (90-day + current-MAJOR) plus a documented freshness/validity policy in `docs/SELF_CERTIFICATION.md`.
- **#156** — a "Trust model" section in `docs/SIGNING.md` (integrity + origin only; not correctness/replay/confidentiality; trust rooted in keyring distribution) reconciling the strict verifier's "unknown key → reject" with the runner's "unknown `kid` → skipped, not failed"; cross-linked from `SECURITY.md` and `SELF_CERTIFICATION.md`.

Deferred (proposed, **not** implemented — see below):

- **#117** — the sanctioned `raw_passthrough` override. Its negative case is already covered by the existing `i01_frame_carries_raw_output.json` fixture; the only net-new work is a positive case that requires a **new wire format** and an **I-01 conformance-check exemption** — i.e. broadening how the spec's most security-critical invariant is enforced. Rather than bundle an unreviewed enforcement change, this PR records the design as a **Proposed** [ADR 003](docs/adr/003-raw-passthrough-override.md) (docs-only, no enforcement change) and leaves #117 open pending review.

## Why

These issues were a single self-audit backlog batch all targeting the conformance subsystem. Grouping them keeps each reviewable in one place and lets the result-schema work (#116/#145) and the freshness policy (#150) land together with the runner changes they depend on. `CONTRIBUTING.md` requires an ADR before loosening a constraint, which is why #117's enforcement change is proposed separately rather than implemented here.

## How verified

- `pytest --cov` — **592 passed** (+72 new), total coverage 94% (fail-under 80%).
- `mypy src/` — clean (strict).
- `python conformance/run.py` — 47 checks pass.
- `python examples/reference_impl/reference_impl.py` — passes against the bumped version.
- `scripts/check_schema_fields.py`, `generate_contracts_index.py --check`, `check_version_consistency.py` (0.8.0 consistent across 6 files), `generate_coverage_table.py --check` — all OK.
- `markdownlint` (repo glob) and `yamllint -c .yamllint.yml -s` on touched files — clean.

## Type of change

- [ ] Docs only (no contract changes)
- [x] Additive contract change (new optional field or new type — non-breaking) — new **Extended** `ConformanceResult`; no Core change.
- [ ] Breaking contract change (requires ADR)
- [x] CI / tooling change

## Six-artifact checklist

No **Core** contract was touched, so the Core-specific line items are N/A. The equivalent artifacts for the additive **Extended** type were all updated:

- [ ] JSON Schema updated (`contracts/json/`) — N/A for Core; **new Extended** `contracts/json/extended/conformance_result.schema.json`.
- [ ] Python dataclass updated (`contracts/python/src/weaver_contracts/core.py`) — N/A for Core; **`ConformanceResult`** added to `extended.py`.
- [ ] Sample payload (`examples/sample_payloads/`) — N/A for Core; **added** `conformance_result.json`.
- [ ] Roundtrip test (`test_roundtrip_examples.py`) — N/A for Core; covered by new tests in `test_extended.py` + `test_extended_schema_alignment.py`.
- [x] CHANGELOG entry added (`CHANGELOG.md`) — new `## [0.8.0]` section.
- [x] Version bumped (`version.py` + `pyproject.toml`) — 0.7.0 → 0.8.0 (MINOR, per the Extended-contract workflow), propagated to all six version-tracked files + regenerated index/coverage/badge.

## Deprecations

- [x] `docs/DEPRECATIONS.md` updated — N/A (no deprecation in this PR).

## Invariants

- [x] I have verified that invariants I-01 through I-07 in `docs/INVARIANTS.md` are not violated. The ADR 003 note is a **proposal**; no enforcement was changed, and the I-01 conformance check still flags every raw-output-bearing `Frame`.

## Cross-repo impact

- [ ] **contextweaver** — needs coordinated update
- [ ] **agent-kernel** — needs coordinated update
- [ ] **ChainWeaver** — needs coordinated update
- [x] No cross-repo impact — `ConformanceResult` is Extended/opt-in and the rest is build-time CI tooling never imported by `weaver_contracts`. (Note: ADR 003, *if accepted later*, would carry contextweaver/agent-kernel impact — tracked there, not here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Stoe2TM3famkHX2xz3woaT)_