### PR TITLE
chore(deps): harden spec tooling and Action supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+updates:
+  # The specification itself is not bot-managed. Only the reference Python
+  # contract package and CI/tooling dependencies receive routine maintenance.
+  - package-ecosystem: pip
+    directory: "/contracts/python"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+    groups:
+      python-tooling-nonmajor:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: [minor, patch]
+      python-tooling-security-nonmajor:
+        applies-to: security-updates
+        patterns: ["*"]
+        update-types: [minor, patch]
+    labels: [dependencies]
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+    groups:
+      actions-nonmajor:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: [minor, patch]
+      actions-security:
+        applies-to: security-updates
+        patterns: ["*"]
+    labels: [dependencies]
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
-
       - name: Validate schema required fields
         run: python scripts/check_schema_fields.py
-
       - name: Validate sample payloads are valid JSON
         run: |
           python -c "
@@ -44,36 +41,26 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
-
       - name: Install PyYAML
         run: pip install pyyaml
-
       - name: Validate compatibility.yaml structure and matrix consistency
         run: |
           python << 'PYEOF'
           import sys
           from pathlib import Path
-
           import yaml
-
           sys.path.insert(0, "scripts")
           from validate_compatibility import self_test, validate
-
-          # The validator's own rejection paths are guarded by a self-test, so a
-          # future edit that weakens a check fails CI even though the live
-          # manifest still parses.
           problems = self_test()
           for problem in problems:
               print(f"FAIL (self-test): {problem}", file=sys.stderr)
           if problems:
               sys.exit(1)
-
           manifest = yaml.safe_load(Path("compatibility.yaml").read_text(encoding="utf-8"))
           versioning_md = Path("docs/VERSIONING.md").read_text(encoding="utf-8")
           errors = validate(manifest, versioning_md)
@@ -81,12 +68,8 @@ jobs:
               for e in errors:
                   print(f"FAIL: {e}", file=sys.stderr)
               sys.exit(1)
-
           count = len(manifest["repositories"])
-          print(
-              f"OK: compatibility.yaml valid — {count} repositories, status vocabulary "
-              "and version consistency enforced; validator self-test passed."
-          )
+          print(f"OK: compatibility.yaml valid — {count} repositories, status vocabulary and version consistency enforced; validator self-test passed.")
           PYEOF
 
   validate-meta-package:
@@ -95,41 +78,29 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
-
       - name: Install PyYAML and build
         run: pip install pyyaml build
-
       - name: Check weaver-stack pins are consistent with compatibility.yaml
         run: |
           python << 'PYEOF'
           import sys
           import tomllib
           from pathlib import Path
-
           import yaml
-
           sys.path.insert(0, "scripts")
           from validate_meta_package import self_test, validate
-
-          # The validator's own rejection paths are guarded by a self-test, so a
-          # future edit that weakens a check fails CI even though the live pair
-          # still passes.
           problems = self_test()
           for problem in problems:
               print(f"FAIL (self-test): {problem}", file=sys.stderr)
           if problems:
               sys.exit(1)
-
           manifest = yaml.safe_load(Path("compatibility.yaml").read_text(encoding="utf-8"))
-          pyproject = tomllib.loads(
-              Path("packaging/weaver-stack/pyproject.toml").read_text(encoding="utf-8")
-          )
+          pyproject = tomllib.loads(Path("packaging/weaver-stack/pyproject.toml").read_text(encoding="utf-8"))
           errors = validate(manifest, pyproject)
           for e in errors:
               print(f"FAIL: {e}", file=sys.stderr)
@@ -137,7 +108,6 @@ jobs:
               sys.exit(1)
           print("OK: weaver-stack meta-package is consistent with compatibility.yaml.")
           PYEOF
-
       - name: Build the meta-package (sdist + wheel)
         working-directory: packaging/weaver-stack
         run: python -m build
@@ -148,13 +118,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
-
       - name: Check well-known/contracts.json is up to date
         run: python scripts/generate_contracts_index.py --check
 
@@ -164,13 +132,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
-
       - name: Check the contract version string is consistent everywhere
         run: python scripts/check_version_consistency.py
 
@@ -180,16 +146,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
-
       - name: Install jsonschema
         run: pip install jsonschema referencing
-
       - name: Validate inline JSON payloads against schemas
         run: |
           python << 'PYEOF'
@@ -198,29 +161,16 @@ jobs:
           from jsonschema import Draft202012Validator
           from referencing import Registry, Resource
           from referencing.jsonschema import DRAFT202012
-
           schemas_by_name = {}
           registry = Registry()
           for p in Path('contracts/json').rglob('*.schema.json'):
               name = p.stem.removesuffix('.schema')
               schema = json.loads(p.read_text(encoding='utf-8'))
               schemas_by_name[name] = schema
-              registry = registry.with_resource(
-                  uri=schema['$id'],
-                  resource=Resource(contents=schema, specification=DRAFT202012),
-              )
-
+              registry = registry.with_resource(uri=schema['$id'], resource=Resource(contents=schema, specification=DRAFT202012))
           fence = chr(96) * 3
-          pattern = re.compile(
-              r'<!-- schema: (\S+) -->\s*' + fence + r'json\s*(.*?)\s*' + fence,
-              re.DOTALL,
-          )
-
-          md_files = sorted(
-              set(glob.glob('examples/**/*.md', recursive=True))
-              | set(glob.glob('docs/**/*.md', recursive=True))
-          )
-
+          pattern = re.compile(r'<!-- schema: (\S+) -->\s*' + fence + r'json\s*(.*?)\s*' + fence, re.DOTALL)
+          md_files = sorted(set(glob.glob('examples/**/*.md', recursive=True)) | set(glob.glob('docs/**/*.md', recursive=True)))
           failures = []
           total = 0
           for f in md_files:
@@ -236,15 +186,10 @@ jobs:
                   except json.JSONDecodeError as e:
                       failures.append(f'{f} ({schema_name}): JSON parse error: {e}')
                       continue
-                  v = Draft202012Validator(
-                      schemas_by_name[schema_name],
-                      registry=registry,
-                      format_checker=Draft202012Validator.FORMAT_CHECKER,
-                  )
+                  v = Draft202012Validator(schemas_by_name[schema_name], registry=registry, format_checker=Draft202012Validator.FORMAT_CHECKER)
                   for err in sorted(v.iter_errors(payload), key=lambda e: list(e.absolute_path)):
                       path = '/'.join(str(x) for x in err.absolute_path) or '<root>'
                       failures.append(f'{f} ({schema_name}) at {path}: {err.message}')
-
           print(f'Validated {total} inline payload(s) across {len(md_files)} Markdown file(s).')
           if failures:
               for line in failures:
@@ -265,32 +210,24 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-
       - name: Import smoke test with no third-party dependencies
         working-directory: contracts/python
         run: |
-          # weaver_contracts is stdlib-only at runtime: a bare install (no
-          # [dev] extras) must import cleanly on every supported Python.
           pip install .
           python -c "import weaver_contracts; print(weaver_contracts.__name__, 'imported OK')"
-
       - name: Install package with dev dependencies
         working-directory: contracts/python
         run: pip install -e ".[dev]"
-
       - name: Run type checks
         working-directory: contracts/python
         run: mypy src/
-
       - name: Run tests with coverage
         working-directory: contracts/python
         run: pytest --cov --cov-report=term-missing -v
@@ -301,16 +238,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
-
       - name: Install markdownlint-cli
         run: npm install -g markdownlint-cli
-
       - name: Lint Markdown files
         run: |
           markdownlint \
@@ -327,16 +261,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
-
       - name: Install yamllint
         run: pip install yamllint==1.35.1
-
       - name: Lint issue templates and workflows
         run: |
           yamllint -c .yamllint.yml \
@@ -352,13 +283,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
-
       - name: Check contracts/COVERAGE.md is up to date
         run: python scripts/generate_coverage_table.py --check
 
@@ -376,38 +305,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Mirror the package `python-tests` matrix (#152): the reference impl
-        # exercises the same crypto/JCS/jsonschema path as the conformance
-        # runner, so run it on every supported interpreter.
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
-          # Matches the package `python-tests` job: 3.14 may still resolve as a
-          # prerelease on the runner, so allow it rather than fail to set up.
           allow-prereleases: true
-
       - name: Install package with dev dependencies
         working-directory: contracts/python
         run: pip install -e ".[dev]"
-
       - name: "Run the reference implementation (issue #76)"
         run: python examples/reference_impl/reference_impl.py
-
-      # The badge is a committed, deterministic artifact; regenerate and
-      # staleness-check it once (on the baseline interpreter) rather than on
-      # every matrix leg.
       - name: "Regenerate scoreboard badge from a real conformance result (#77)"
         if: matrix.python-version == '3.11'
         run: |
           python conformance/run.py \
             --emit-result /tmp/conformance-result.json \
             --emit-badge docs/badges/weaver-spec.json
-
       - name: Fail if the committed self-cert badge is stale
         if: matrix.python-version == '3.11'
         run: git diff --exit-code docs/badges/weaver-spec.json

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -21,20 +21,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Mirror the package `python-tests` matrix (#152). The runner leans on
-        # jsonschema / referencing / jcs / cryptography, whose behaviour can vary
-        # by interpreter, so the security-relevant path is exercised on every
-        # supported version rather than a single one.
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
-          # Matches the package `python-tests` job: 3.14 may still resolve as a
-          # prerelease on the runner, so allow it rather than fail to set up.
           allow-prereleases: true
 
       - name: Install conformance dependencies

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -15,54 +15,42 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
       - name: Check internal Markdown links
         run: |
           python - << 'EOF'
-          import os
           import re
           import sys
           from pathlib import Path
 
           repo_root = Path(".")
           md_files = list(repo_root.rglob("*.md"))
-          # Skip .git and node_modules
           md_files = [f for f in md_files if ".git" not in f.parts and "node_modules" not in f.parts]
-          # PR template links resolve repo-root-relative when GitHub populates the PR body,
-          # not file-relative, so skip it from file-system link checking.
           md_files = [f for f in md_files if f.name != "pull_request_template.md"]
-
-          # Match [text](path) links — only relative, non-URL links
           link_re = re.compile(r'\[([^\]]*)\]\(([^)]+)\)')
           errors = []
-
           for md_file in sorted(md_files):
               content = md_file.read_text()
               for match in link_re.finditer(content):
                   link = match.group(2)
-                  # Skip external URLs, anchors-only, and mailto
                   if link.startswith(("http://", "https://", "mailto:", "#")):
                       continue
-                  # Strip anchor fragment
                   path_part = link.split("#")[0]
                   if not path_part:
                       continue
-                  # Resolve relative to the file's directory
                   resolved = (md_file.parent / path_part).resolve()
                   if not resolved.exists():
                       errors.append(f"{md_file}: broken link -> {link}")
-
           if errors:
               print("Broken internal links found:", file=sys.stderr)
               for e in errors:
                   print(f"  {e}", file=sys.stderr)
               sys.exit(1)
-          else:
-              print(f"All internal links OK ({len(md_files)} files checked)")
+          print(f"All internal links OK ({len(md_files)} files checked)")
           EOF

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
@@ -28,7 +28,7 @@ jobs:
         run: python -m build
 
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: contracts/python/dist/
@@ -41,39 +41,33 @@ jobs:
       name: pypi
       url: https://pypi.org/project/weaver_contracts/
     permissions:
-      id-token: write       # required for OIDC Trusted Publisher
-      attestations: write   # required for PEP 740 SLSA build provenance attestations
+      id-token: write
+      attestations: write
 
     steps:
       - name: Download dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
-          # Emit a Sigstore-signed SLSA build provenance attestation alongside
-          # the package (PEP 740). Adopters verify with `sigstore verify`.
           attestations: true
 
   build-meta:
     name: Build meta-package distribution
     runs-on: ubuntu-latest
-    # The meta-package versions independently of weaver_contracts, so it is
-    # released under its own `weaver-stack-vX.Y.Z` tag. Guard on that prefix so
-    # a weaver_contracts release does not also (re)build/publish weaver-stack at
-    # an unchanged version (which PyPI would reject as a duplicate upload).
     if: ${{ github.event_name == 'release' && startsWith(github.event.release.tag_name, 'weaver-stack-v') }}
     permissions:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
@@ -85,7 +79,7 @@ jobs:
         run: python -m build
 
       - name: Upload meta-package dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist-meta
           path: packaging/weaver-stack/dist/
@@ -94,25 +88,22 @@ jobs:
     name: Publish meta-package to PyPI
     needs: build-meta
     runs-on: ubuntu-latest
-    # Same guard as build-meta: only publish on a `weaver-stack-v*` release tag.
     if: ${{ github.event_name == 'release' && startsWith(github.event.release.tag_name, 'weaver-stack-v') }}
     environment:
       name: pypi
       url: https://pypi.org/project/weaver-stack/
     permissions:
-      id-token: write       # required for OIDC Trusted Publisher
-      attestations: write   # required for PEP 740 SLSA build provenance attestations
+      id-token: write
+      attestations: write
 
     steps:
       - name: Download meta-package dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dist-meta
           path: dist/
 
       - name: Publish weaver-stack to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
-          # weaver-stack needs its own PyPI Trusted Publisher (OIDC) configured
-          # for this workflow before the first release.
           attestations: true

--- a/.github/workflows/scoreboard.yml
+++ b/.github/workflows/scoreboard.yml
@@ -9,7 +9,6 @@ name: Scoreboard
 
 on:
   schedule:
-    # Weekly, Mondays 06:00 UTC.
     - cron: "0 6 * * 1"
   workflow_dispatch:
 
@@ -20,10 +19,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
@@ -37,7 +36,7 @@ jobs:
         run: cat docs/scoreboard.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload scoreboard artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: conformance-scoreboard
           path: |


### PR DESCRIPTION
## What changed

- add Dependabot only for the reference Python contract package and GitHub Actions; specification/schema evolution remains human-driven
- group routine non-major/security updates with cooldowns and small PR limits
- leave breaking majors separate
- SHA-pin CI, reusable conformance, link-check, scoreboard, artifact, and PyPI publishing Actions

## Why

`weaver-spec` is a specification repository first. Automation should maintain tooling and the reference package without turning normative schema/spec changes into dependency-bot work. Immutable Action pins reduce workflow supply-chain risk while Dependabot can still advance those pins reviewably.