### PR TITLE
chore(deps): harden contract-package compatibility policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 version: 2
 updates:
-  # The specification itself is not bot-managed. Only the reference Python
-  # contract package and CI/tooling dependencies receive routine maintenance.
+  # The normative specification is never bot-managed. The reference Python
+  # package is a published library, so routine releases are compatibility-test
+  # inputs rather than reasons to rewrite its public dependency contract.
   - package-ecosystem: pip
     directory: "/contracts/python"
     schedule:
@@ -9,21 +10,14 @@ updates:
       day: monday
       time: "06:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 3
-    cooldown:
-      default-days: 7
+    open-pull-requests-limit: 0
     groups:
-      python-tooling-nonmajor:
-        applies-to: version-updates
-        patterns: ["*"]
-        update-types: [minor, patch]
-      python-tooling-security-nonmajor:
+      python-security:
         applies-to: security-updates
         patterns: ["*"]
-        update-types: [minor, patch]
     labels: [dependencies]
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "fix(deps)"
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/workflows/python-next.yml
+++ b/.github/workflows/python-next.yml
@@ -1,0 +1,33 @@
+name: Python Next Canary
+
+on:
+  schedule:
+    - cron: "45 6 * * 3"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "contracts/python/**"
+      - ".github/workflows/python-next.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  python-next:
+    name: weaver-contracts on Python 3.15 pre-release
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.15"
+          allow-prereleases: true
+      - name: Install contract package
+        working-directory: contracts/python
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Test contract package
+        working-directory: contracts/python
+        run: pytest -q


### PR DESCRIPTION
For the published `weaver-contracts` reference package:

- make Python Dependabot security-only so routine releases do not rewrite a library compatibility contract
- leave the normative specification outside bot dependency management
- add a non-gating Python 3.15 pre-release canary
- keep GitHub Actions update automation unchanged

The existing Python 3.10–3.14 contract-package matrix remains gating compatibility evidence.