### PR TITLE
ci: prepare immutable canonical schema hosting on GitHub Pages

### DIFF
--- a/.github/workflows/schema-pages.yml
+++ b/.github/workflows/schema-pages.yml
@@ -1,0 +1,48 @@
+name: Schema Pages
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "contracts/json/**"
+      - "well-known/contracts.json"
+      - "scripts/build_schema_site.py"
+      - ".github/workflows/schema-pages.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: schema-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build canonical schema site
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Build immutable schema paths
+        run: python scripts/build_schema_site.py --output _site
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: _site
+          include-hidden-files: true
+
+  deploy:
+    name: Deploy canonical schema site
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      actions: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/contracts/python/tests/test_schema_site.py
+++ b/contracts/python/tests/test_schema_site.py
@@ -1,0 +1,77 @@
+"""Regression tests for scripts/build_schema_site.py (#213)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import build_schema_site as schema_site  # noqa: E402
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_build_schema_site_publishes_every_canonical_id(tmp_path: Path):
+    output = tmp_path / "site"
+    copied = schema_site.build(output)
+
+    index = json.loads((REPO_ROOT / "well-known" / "contracts.json").read_text())
+    entries = index["core"] + index["extended"]
+
+    assert copied == len(entries)
+    for entry in entries:
+        parsed = urlsplit(entry["$id"])
+        assert parsed.scheme == "https"
+        assert parsed.netloc == schema_site.CANONICAL_HOST
+
+        hosted = output / parsed.path.lstrip("/")
+        assert hosted.is_file(), entry["$id"]
+        assert _sha256(hosted) == entry["sha256"]
+
+
+def test_build_schema_site_publishes_discovery_index_and_nojekyll(tmp_path: Path):
+    output = tmp_path / "site"
+    schema_site.build(output)
+
+    canonical_index = (REPO_ROOT / "well-known" / "contracts.json").read_bytes()
+    assert (output / ".well-known" / "contracts.json").read_bytes() == canonical_index
+    assert (output / "well-known" / "contracts.json").read_bytes() == canonical_index
+    assert (output / ".nojekyll").is_file()
+
+
+def test_build_rejects_hash_drift(tmp_path: Path):
+    repo = tmp_path / "repo"
+    (repo / "well-known").mkdir(parents=True)
+    (repo / "contracts" / "json").mkdir(parents=True)
+    schema = repo / "contracts" / "json" / "x.schema.json"
+    schema.write_text('{"$id":"https://weaver-spec.dev/contracts/v0/x.schema.json"}\n')
+
+    index = {
+        "schema_version": 1,
+        "contract_version": "0.0.0",
+        "core": [
+            {
+                "name": "x",
+                "version": "v0",
+                "$id": "https://weaver-spec.dev/contracts/v0/x.schema.json",
+                "path": "contracts/json/x.schema.json",
+                "sha256": "0" * 64,
+            }
+        ],
+        "extended": [],
+    }
+    (repo / "well-known" / "contracts.json").write_text(json.dumps(index))
+
+    try:
+        schema_site.build(tmp_path / "site", repo_root=repo)
+    except ValueError as exc:
+        assert "schema hash mismatch" in str(exc)
+    else:
+        raise AssertionError("hash drift must fail the schema-site build")

--- a/scripts/build_schema_site.py
+++ b/scripts/build_schema_site.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Build the static site used to serve canonical Weaver JSON Schema IDs.
+
+This is stdlib-only build-time tooling. It copies every schema listed in the
+content-addressed contract index to the path encoded by its canonical ``$id``
+and verifies the published bytes against the index before writing them.
+
+The generated directory is intended for GitHub Pages (or any static host). It
+is never imported by ``weaver_contracts`` and does not define contract
+semantics; ``well-known/contracts.json`` remains the source of truth.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+from pathlib import Path
+from urllib.parse import urlsplit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INDEX_PATH = REPO_ROOT / "well-known" / "contracts.json"
+CANONICAL_HOST = "weaver-spec.dev"
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _entries(index: dict[str, object]):
+    for tier in ("core", "extended"):
+        values = index.get(tier, [])
+        if not isinstance(values, list):
+            raise ValueError(f"index field {tier!r} must be a list")
+        for entry in values:
+            if not isinstance(entry, dict):
+                raise ValueError(f"index field {tier!r} contains a non-object entry")
+            yield tier, entry
+
+
+def build(output: Path, repo_root: Path = REPO_ROOT) -> int:
+    index_path = repo_root / "well-known" / "contracts.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+
+    if output.exists():
+        shutil.rmtree(output)
+    output.mkdir(parents=True)
+
+    copied = 0
+    seen_destinations: set[Path] = set()
+
+    for tier, entry in _entries(index):
+        for required in ("$id", "path", "sha256"):
+            if required not in entry or not isinstance(entry[required], str):
+                raise ValueError(f"{tier} entry missing string field {required!r}: {entry!r}")
+
+        schema_id = entry["$id"]
+        parsed = urlsplit(schema_id)
+        if parsed.scheme != "https" or parsed.netloc != CANONICAL_HOST:
+            raise ValueError(f"unexpected canonical schema host in $id: {schema_id}")
+        if parsed.query or parsed.fragment:
+            raise ValueError(f"canonical schema $id must not contain query/fragment: {schema_id}")
+        if not parsed.path.startswith("/contracts/"):
+            raise ValueError(f"canonical schema $id must live under /contracts/: {schema_id}")
+
+        source = (repo_root / entry["path"]).resolve()
+        if repo_root.resolve() not in source.parents:
+            raise ValueError(f"schema source escapes repository: {entry['path']}")
+        if not source.is_file():
+            raise ValueError(f"schema source does not exist: {entry['path']}")
+
+        actual_hash = _sha256(source)
+        if actual_hash != entry["sha256"]:
+            raise ValueError(
+                f"schema hash mismatch for {entry['path']}: "
+                f"index={entry['sha256']} actual={actual_hash}"
+            )
+
+        destination = output / parsed.path.lstrip("/")
+        if destination in seen_destinations:
+            raise ValueError(f"duplicate canonical destination: {parsed.path}")
+        seen_destinations.add(destination)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, destination)
+        copied += 1
+
+    # Publish both the conventional hidden endpoint and the repository-shaped
+    # endpoint. The hidden path is useful for machine discovery; the non-hidden
+    # path preserves the existing checked-in layout and is easier to inspect.
+    for relative in (Path(".well-known/contracts.json"), Path("well-known/contracts.json")):
+        destination = output / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(index_path, destination)
+
+    # GitHub Pages/Jekyll must not transform schema JSON.
+    (output / ".nojekyll").write_text("", encoding="utf-8")
+
+    return copied
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=REPO_ROOT / "_site",
+        help="Static-site output directory (default: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    count = build(args.output)
+    print(f"Built schema site with {count} canonical schema(s) at {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_schema_site.py
+++ b/scripts/build_schema_site.py
@@ -24,12 +24,10 @@ INDEX_PATH = REPO_ROOT / "well-known" / "contracts.json"
 CANONICAL_HOST = "weaver-spec.dev"
 
 
-def _sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
+def _indexed_sha256(path: Path) -> str:
+    """Hash schema bytes exactly as generate_contracts_index.py does."""
+    normalized = path.read_bytes().replace(b"\r\n", b"\n")
+    return hashlib.sha256(normalized).hexdigest()
 
 
 def _entries(index: dict[str, object]):
@@ -74,7 +72,7 @@ def build(output: Path, repo_root: Path = REPO_ROOT) -> int:
         if not source.is_file():
             raise ValueError(f"schema source does not exist: {entry['path']}")
 
-        actual_hash = _sha256(source)
+        actual_hash = _indexed_sha256(source)
         if actual_hash != entry["sha256"]:
             raise ValueError(
                 f"schema hash mismatch for {entry['path']}: "


### PR DESCRIPTION
## Summary

Moves #213 from design to repository-side implementation.

- adds a stdlib-only `scripts/build_schema_site.py` builder that reads `well-known/contracts.json`, verifies every source schema against its recorded SHA-256, and publishes each file at the exact path encoded by its canonical `$id`;
- publishes both `.well-known/contracts.json` and `well-known/contracts.json` plus `.nojekyll`;
- adds regression tests proving every canonical `$id` path is emitted byte-for-byte with the indexed hash and that hash drift fails closed;
- adds a SHA-pinned GitHub Pages workflow using the current GitHub Pages artifact/deploy actions.

## Why

The canonical `$id` URLs currently identify `https://weaver-spec.dev/...` resources that are not served. A specification should not require adopters to preload a local registry merely because its canonical URLs are unresolved.

## Security / integrity properties

The builder does **not** invent hosted content. It refuses to publish when a source file's bytes differ from the content-addressed `well-known/contracts.json` index. Deployment artifacts are generated from `main`; Pages actions are pinned to immutable commit SHAs.

## Remaining external infrastructure gate

This PR intentionally stays **draft** until GitHub Pages is configured to deploy from Actions and the `weaver-spec.dev` custom domain/DNS points at the Pages deployment. The GitHub connector cannot change the external DNS/Pages domain configuration.

After that infrastructure step:

1. run `Schema Pages` manually or merge a schema/index change;
2. verify every `$id` resolves over HTTPS and hashes match;
3. add a scheduled liveness/hash check;
4. update `docs/SCHEMA_HOSTING.md` to state the URLs are live;
5. unblock SchemaStore work in #125.

## Related

Closes the repository-side build/deployment portion of #213. Offline distribution remains #115 and should stay supported even after live hosting.