### PR TITLE
ci: build a hash-verified static host for canonical schema IDs

### DIFF
--- a/.github/workflows/schema-site.yml
+++ b/.github/workflows/schema-site.yml
@@ -1,0 +1,68 @@
+name: Schema Site
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "contracts/json/**"
+      - "well-known/contracts.json"
+      - "scripts/build_schema_site.py"
+      - "scripts/generate_contracts_index.py"
+      - "tests/test_schema_site.py"
+      - ".github/workflows/schema-site.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "contracts/json/**"
+      - "well-known/contracts.json"
+      - "scripts/build_schema_site.py"
+      - "scripts/generate_contracts_index.py"
+      - "tests/test_schema_site.py"
+      - ".github/workflows/schema-site.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "schema-site-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build immutable schema site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+      - name: Verify the content-addressed contract index
+        run: python scripts/generate_contracts_index.py --check
+      - name: Test schema-site generation
+        run: python tests/test_schema_site.py
+      - name: Build schema site
+        run: python scripts/build_schema_site.py --output _schema_site
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: _schema_site
+          include-hidden-files: true
+
+  deploy:
+    name: Deploy schema site
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/schema-site.yml
+++ b/.github/workflows/schema-site.yml
@@ -20,6 +20,12 @@ on:
       - "tests/test_schema_site.py"
       - ".github/workflows/schema-site.yml"
   workflow_dispatch:
+    inputs:
+      deploy:
+        description: "Deploy the generated artifact to GitHub Pages (requires Pages/custom-domain setup)"
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -53,7 +59,7 @@ jobs:
 
   deploy:
     name: Deploy schema site
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' && inputs.deploy
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/scripts/build_schema_site.py
+++ b/scripts/build_schema_site.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Build the static site that serves canonical weaver-spec JSON Schema $id URLs.
+
+The content-addressed ``well-known/contracts.json`` index is the source of truth.
+For every indexed schema this script:
+
+1. validates that the $id uses the canonical HTTPS host and contract path;
+2. verifies the source file bytes against the index SHA-256;
+3. verifies the source schema's own $id matches the index entry;
+4. copies normalized LF bytes to the URL path implied by the $id;
+5. publishes the contract index at ``/.well-known/contracts.json``.
+
+The generated output is deterministic and contains no timestamps. It is suitable
+for GitHub Pages or another static host. The script is stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import html
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlparse
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INDEX_PATH = REPO_ROOT / "well-known" / "contracts.json"
+CANONICAL_HOST = "weaver-spec.dev"
+CANONICAL_PREFIX = "/contracts/"
+
+
+def _normalized_bytes(raw: bytes) -> bytes:
+    """Match the index generator's cross-platform LF normalization."""
+    return raw.replace(b"\r\n", b"\n")
+
+
+def _sha256(raw: bytes) -> str:
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _load_index() -> dict[str, Any]:
+    value = json.loads(INDEX_PATH.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise RuntimeError("well-known/contracts.json must contain a JSON object")
+    return value
+
+
+def _entries(index: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    for tier in ("core", "extended"):
+        values = index.get(tier)
+        if not isinstance(values, list):
+            raise RuntimeError(f"contracts index field {tier!r} must be a list")
+        for entry in values:
+            if not isinstance(entry, dict):
+                raise RuntimeError(f"contracts index {tier!r} entry must be an object")
+            yield entry
+
+
+def _relative_url_path(schema_id: str) -> Path:
+    parsed = urlparse(schema_id)
+    if parsed.scheme != "https":
+        raise RuntimeError(f"schema $id must use https: {schema_id}")
+    if parsed.netloc != CANONICAL_HOST:
+        raise RuntimeError(
+            f"schema $id must use canonical host {CANONICAL_HOST!r}: {schema_id}"
+        )
+    if parsed.params or parsed.query or parsed.fragment:
+        raise RuntimeError(f"schema $id must not contain params/query/fragment: {schema_id}")
+    if not parsed.path.startswith(CANONICAL_PREFIX):
+        raise RuntimeError(
+            f"schema $id path must start with {CANONICAL_PREFIX!r}: {schema_id}"
+        )
+
+    relative = Path(parsed.path.lstrip("/"))
+    if relative.is_absolute() or ".." in relative.parts:
+        raise RuntimeError(f"unsafe schema $id path: {schema_id}")
+    return relative
+
+
+def _source_for(entry: dict[str, Any]) -> tuple[Path, bytes, str, str]:
+    required = ("name", "$id", "path", "sha256")
+    missing = [key for key in required if not isinstance(entry.get(key), str) or not entry[key]]
+    if missing:
+        raise RuntimeError(f"contract entry missing non-empty string field(s): {', '.join(missing)}")
+
+    source = (REPO_ROOT / entry["path"]).resolve()
+    try:
+        source.relative_to(REPO_ROOT)
+    except ValueError as exc:
+        raise RuntimeError(f"contract source escapes repository: {entry['path']}") from exc
+    if not source.is_file():
+        raise RuntimeError(f"contract source does not exist: {entry['path']}")
+
+    normalized = _normalized_bytes(source.read_bytes())
+    actual_hash = _sha256(normalized)
+    expected_hash = entry["sha256"].lower()
+    if actual_hash != expected_hash:
+        raise RuntimeError(
+            f"contract hash mismatch for {entry['path']}: "
+            f"index={expected_hash} source={actual_hash}"
+        )
+
+    schema = json.loads(normalized)
+    if not isinstance(schema, dict):
+        raise RuntimeError(f"schema must contain a JSON object: {entry['path']}")
+    if schema.get("$id") != entry["$id"]:
+        raise RuntimeError(
+            f"schema $id mismatch for {entry['path']}: "
+            f"index={entry['$id']!r} source={schema.get('$id')!r}"
+        )
+
+    return source, normalized, entry["$id"], entry["name"]
+
+
+def _safe_clean_output(output: Path) -> Path:
+    output = output.resolve()
+    filesystem_root = Path(output.anchor).resolve()
+    if output in {filesystem_root, REPO_ROOT.resolve()}:
+        raise RuntimeError(f"refusing to replace unsafe output directory: {output}")
+    if output.exists():
+        if output.is_symlink():
+            raise RuntimeError(f"refusing to replace symlink output directory: {output}")
+        shutil.rmtree(output)
+    output.mkdir(parents=True, exist_ok=True)
+    return output
+
+
+def build_site(output: Path) -> int:
+    """Build *output* and return the number of published schemas."""
+    index = _load_index()
+    output = _safe_clean_output(output)
+    destinations: set[Path] = set()
+    rows: list[tuple[str, str]] = []
+
+    for entry in _entries(index):
+        _source, normalized, schema_id, name = _source_for(entry)
+        relative = _relative_url_path(schema_id)
+        if relative in destinations:
+            raise RuntimeError(f"duplicate hosted schema path: {relative.as_posix()}")
+        destinations.add(relative)
+
+        destination = output / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(normalized)
+        rows.append((name, schema_id))
+
+    well_known = output / ".well-known"
+    well_known.mkdir(parents=True, exist_ok=True)
+    index_bytes = _normalized_bytes(INDEX_PATH.read_bytes())
+    (well_known / "contracts.json").write_bytes(index_bytes)
+
+    # Preserve the canonical schema namespace even if the external brand changes.
+    (output / "CNAME").write_text(f"{CANONICAL_HOST}\n", encoding="utf-8")
+
+    version = html.escape(str(index.get("contract_version", "unknown")))
+    links = "\n".join(
+        f'<li><a href="{html.escape(urlparse(schema_id).path)}">{html.escape(name)}</a></li>'
+        for name, schema_id in sorted(rows)
+    )
+    index_html = f"""<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Schema host</title></head>
+<body>
+<h1>Schema host</h1>
+<p>Contract version: <code>{version}</code></p>
+<p>Machine-readable index: <a href="/.well-known/contracts.json">/.well-known/contracts.json</a></p>
+<ul>
+{links}
+</ul>
+</body>
+</html>
+"""
+    (output / "index.html").write_text(index_html, encoding="utf-8", newline="\n")
+
+    return len(rows)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=REPO_ROOT / "_schema_site",
+        help="Directory to replace with the generated static site.",
+    )
+    args = parser.parse_args()
+
+    try:
+        count = build_site(args.output)
+    except (OSError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Built {count} hosted schema(s) in {args.output.resolve()}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_schema_site.py
+++ b/tests/test_schema_site.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Tests for scripts/build_schema_site.py."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import build_schema_site  # noqa: E402
+
+
+class SchemaSiteTests(unittest.TestCase):
+    def test_build_publishes_every_indexed_schema_at_its_id_path(self) -> None:
+        index = json.loads(
+            build_schema_site.INDEX_PATH.read_text(encoding="utf-8")
+        )
+        entries = list(build_schema_site._entries(index))
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "site"
+            count = build_schema_site.build_site(output)
+
+            self.assertEqual(count, len(entries))
+            for entry in entries:
+                relative = build_schema_site._relative_url_path(entry["$id"])
+                hosted = output / relative
+                self.assertTrue(hosted.is_file(), relative.as_posix())
+                digest = hashlib.sha256(hosted.read_bytes()).hexdigest()
+                self.assertEqual(digest, entry["sha256"])
+
+            self.assertEqual(
+                (output / ".well-known" / "contracts.json").read_bytes(),
+                build_schema_site.INDEX_PATH.read_bytes().replace(b"\r\n", b"\n"),
+            )
+            self.assertEqual(
+                (output / "CNAME").read_text(encoding="utf-8"),
+                "weaver-spec.dev\n",
+            )
+            self.assertTrue((output / "index.html").is_file())
+
+    def test_build_is_byte_deterministic(self) -> None:
+        def snapshot(root: Path) -> dict[str, bytes]:
+            return {
+                path.relative_to(root).as_posix(): path.read_bytes()
+                for path in sorted(root.rglob("*"))
+                if path.is_file()
+            }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            first = Path(temp_dir) / "first"
+            second = Path(temp_dir) / "second"
+            build_schema_site.build_site(first)
+            build_schema_site.build_site(second)
+            self.assertEqual(snapshot(first), snapshot(second))
+
+    def test_rejects_noncanonical_ids(self) -> None:
+        bad_ids = (
+            "http://weaver-spec.dev/contracts/v0/frame.schema.json",
+            "https://example.invalid/contracts/v0/frame.schema.json",
+            "https://weaver-spec.dev/not-contracts/frame.schema.json",
+            "https://weaver-spec.dev/contracts/v0/frame.schema.json?mutable=1",
+            "https://weaver-spec.dev/contracts/../secret.schema.json",
+        )
+        for schema_id in bad_ids:
+            with self.subTest(schema_id=schema_id):
+                with self.assertRaises(RuntimeError):
+                    build_schema_site._relative_url_path(schema_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the repository-owned half of #213 without pretending the external host is already live.

### What this PR adds

- `scripts/build_schema_site.py`
  - uses `well-known/contracts.json` as the source of truth;
  - verifies every schema's recorded SHA-256 before publication;
  - verifies each source schema `$id` matches the index;
  - rejects non-HTTPS, wrong-host, query/fragment, traversal, and duplicate publication paths;
  - writes each schema to the exact URL path implied by its canonical `$id`;
  - publishes the index at `/.well-known/contracts.json`;
  - emits deterministic output plus a `CNAME` preserving `weaver-spec.dev` as the historical schema namespace.
- `tests/test_schema_site.py`
  - proves all indexed schemas are published at the expected paths and hashes;
  - proves independent builds are byte-identical;
  - exercises rejection of invalid `$id` forms.
- `.github/workflows/schema-site.yml`
  - validates the content-addressed index;
  - runs the site tests;
  - builds and uploads a Pages-compatible artifact on PRs;
  - deploys only on `main` pushes;
  - includes hidden files so `/.well-known/contracts.json` is actually present;
  - pins GitHub Actions to immutable commit SHAs.

## Why draft

The repository code can be reviewed/tested now, but production activation still depends on GitHub Pages/custom-domain/DNS settings that are outside the current connector. `docs/SCHEMA_HOSTING.md` must continue saying the host is unresolved until the deployed URLs and hashes are verified in reality.

## Related

- #213 canonical schema hosting
- #115 offline schema bundle
- #125 SchemaStore discovery
- dgenio/contextweaver#848 downstream false-live-host wording
- #204 naming review — existing `$id` URLs remain compatibility identifiers regardless of future external branding

## Non-goals

- Claiming `weaver-spec.dev` is live in this PR.
- Changing any published schema `$id`.
- Making network resolution required for conformance.
- Renaming the standard or package namespace.
