### PR TITLE
ci: bind PyPI publications to immutable release tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,38 +4,133 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing immutable release tag to retry (vX.Y.Z or weaver-stack-vX.Y.Z)
+        required: true
+        type: string
+
+# A publication is a retryable operation over an immutable release identity,
+# never an instruction to build whatever happens to be on main.
+env:
+  RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.tag }}
 
 jobs:
-  build:
-    name: Build distribution
+  validate-request:
+    name: Validate immutable release identity
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      target: ${{ steps.identity.outputs.target }}
+
+    steps:
+      - name: Check out the exact requested tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Prove checkout is an existing immutable tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          git show-ref --verify --quiet "refs/tags/${RELEASE_TAG}" || {
+            echo "ERROR: ${RELEASE_TAG} is not an existing Git tag" >&2
+            exit 1
+          }
+          tag_sha="$(git rev-list -n 1 "${RELEASE_TAG}")"
+          head_sha="$(git rev-parse HEAD)"
+          test "${tag_sha}" = "${head_sha}" || {
+            echo "ERROR: checkout HEAD ${head_sha} does not match tag ${RELEASE_TAG} -> ${tag_sha}" >&2
+            exit 1
+          }
+          echo "Validated immutable tag ${RELEASE_TAG} at ${head_sha}"
+
+      - name: Resolve package target
+        id: identity
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [[ "${RELEASE_TAG}" == weaver-stack-v* ]]; then
+            target=stack
+          elif [[ "${RELEASE_TAG}" == v* ]]; then
+            target=contracts
+          elif [[ "${EVENT_NAME}" == workflow_dispatch ]]; then
+            echo "ERROR: manual recovery requires vX.Y.Z or weaver-stack-vX.Y.Z" >&2
+            exit 1
+          else
+            # Other GitHub Release families are not Python-package releases.
+            # Succeed without granting either publish path authority.
+            target=none
+          fi
+          echo "target=${target}" >> "${GITHUB_OUTPUT}"
+          echo "Resolved ${RELEASE_TAG} -> ${target}"
+
+      - name: Set up Python
+        if: steps.identity.outputs.target != 'none'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Validate tag family and package version
+        if: steps.identity.outputs.target != 'none'
+        run: python scripts/validate_release_tag.py --tag "${RELEASE_TAG}" --target "${{ steps.identity.outputs.target }}"
+
+  build-contracts:
+    name: Build and test weaver_contracts from tag
+    needs: validate-request
+    if: needs.validate-request.outputs.target == 'contracts'
     runs-on: ubuntu-latest
     permissions:
       contents: read
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Check out exact contract release tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 1
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
-      - name: Install build
-        run: pip install build
+      - name: Install release build and test tooling
+        run: |
+          python -m pip install build twine
+          python -m pip install -e "contracts/python[dev]"
+
+      - name: Revalidate tag and package metadata on build checkout
+        run: python scripts/validate_release_tag.py --tag "${RELEASE_TAG}" --target contracts
+
+      - name: Test exact tagged contract source
+        run: |
+          python -m pytest contracts/python/tests
+          python conformance/run.py
 
       - name: Build package
         working-directory: contracts/python
         run: python -m build
 
-      - name: Upload dist artifact
+      - name: Validate distribution metadata
+        run: python -m twine check contracts/python/dist/*
+
+      - name: Upload contract distribution
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: dist
+          name: dist-contracts-${{ env.RELEASE_TAG }}
           path: contracts/python/dist/
+          if-no-files-found: error
 
-  publish:
-    name: Publish to PyPI
-    needs: build
+  publish-contracts:
+    name: Publish weaver_contracts to PyPI
+    needs: [validate-request, build-contracts]
+    if: needs.validate-request.outputs.target == 'contracts' && needs.build-contracts.result == 'success'
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -45,50 +140,65 @@ jobs:
       attestations: write
 
     steps:
-      - name: Download dist artifact
+      - name: Download exact tagged contract distribution
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: dist
+          name: dist-contracts-${{ env.RELEASE_TAG }}
           path: dist/
 
-      - name: Publish to PyPI
+      - name: Publish to PyPI with provenance attestations
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           attestations: true
 
   build-meta:
-    name: Build meta-package distribution
+    name: Build and validate weaver-stack from tag
+    needs: validate-request
+    if: needs.validate-request.outputs.target == 'stack'
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'release' && startsWith(github.event.release.tag_name, 'weaver-stack-v') }}
     permissions:
       contents: read
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Check out exact meta-package release tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 1
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
-      - name: Install build
-        run: pip install build
+      - name: Install release build tooling
+        run: python -m pip install build twine pyyaml
 
-      - name: Build the weaver-stack meta-package
+      - name: Revalidate tag and package metadata on build checkout
+        run: python scripts/validate_release_tag.py --tag "${RELEASE_TAG}" --target stack
+
+      - name: Validate compatibility-derived meta-package pins
+        run: python scripts/validate_meta_package.py
+
+      - name: Build meta-package
         working-directory: packaging/weaver-stack
         run: python -m build
 
-      - name: Upload meta-package dist artifact
+      - name: Validate distribution metadata
+        run: python -m twine check packaging/weaver-stack/dist/*
+
+      - name: Upload meta-package distribution
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: dist-meta
+          name: dist-meta-${{ env.RELEASE_TAG }}
           path: packaging/weaver-stack/dist/
+          if-no-files-found: error
 
   publish-meta:
-    name: Publish meta-package to PyPI
-    needs: build-meta
+    name: Publish weaver-stack to PyPI
+    needs: [validate-request, build-meta]
+    if: needs.validate-request.outputs.target == 'stack' && needs.build-meta.result == 'success'
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'release' && startsWith(github.event.release.tag_name, 'weaver-stack-v') }}
     environment:
       name: pypi
       url: https://pypi.org/project/weaver-stack/
@@ -97,13 +207,13 @@ jobs:
       attestations: write
 
     steps:
-      - name: Download meta-package dist artifact
+      - name: Download exact tagged meta-package distribution
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: dist-meta
+          name: dist-meta-${{ env.RELEASE_TAG }}
           path: dist/
 
-      - name: Publish weaver-stack to PyPI
+      - name: Publish weaver-stack to PyPI with provenance attestations
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           attestations: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -155,10 +155,30 @@ jobs:
       name: pypi
       url: https://pypi.org/project/weaver_contracts/
     permissions:
+      contents: read
       id-token: write
       attestations: write
 
     steps:
+      - name: Re-check immutable contract tag before OIDC publication
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Prove contract tag still targets verified commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag_sha="$(git rev-list -n 1 "${RELEASE_TAG}")"
+          verified_sha="${{ needs.validate-request.outputs.commit_sha }}"
+          test "${tag_sha}" = "${verified_sha}" || {
+            echo "ERROR: ${RELEASE_TAG} moved after validation: expected ${verified_sha}, now ${tag_sha}" >&2
+            exit 1
+          }
+
       - name: Download exact tagged contract distribution
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -226,10 +246,30 @@ jobs:
       name: pypi
       url: https://pypi.org/project/weaver-stack/
     permissions:
+      contents: read
       id-token: write
       attestations: write
 
     steps:
+      - name: Re-check immutable meta-package tag before OIDC publication
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Prove meta-package tag still targets verified commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag_sha="$(git rev-list -n 1 "${RELEASE_TAG}")"
+          verified_sha="${{ needs.validate-request.outputs.commit_sha }}"
+          test "${tag_sha}" = "${verified_sha}" || {
+            echo "ERROR: ${RELEASE_TAG} moved after validation: expected ${verified_sha}, now ${tag_sha}" >&2
+            exit 1
+          }
+
       - name: Download exact tagged meta-package distribution
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
       contents: read
     outputs:
       target: ${{ steps.identity.outputs.target }}
+      commit_sha: ${{ steps.source.outputs.commit_sha }}
 
     steps:
       - name: Check out the exact requested tag
@@ -31,8 +32,10 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Prove checkout is an existing immutable tag
+        id: source
         shell: bash
         run: |
           set -euo pipefail
@@ -47,6 +50,7 @@ jobs:
             exit 1
           }
           echo "Validated immutable tag ${RELEASE_TAG} at ${head_sha}"
+          echo "commit_sha=${head_sha}" >> "${GITHUB_OUTPUT}"
 
       - name: Resolve package target
         id: identity
@@ -80,8 +84,19 @@ jobs:
         if: steps.identity.outputs.target != 'none'
         run: python scripts/validate_release_tag.py --tag "${RELEASE_TAG}" --target "${{ steps.identity.outputs.target }}"
 
+      - name: Record verified release source
+        if: steps.identity.outputs.target != 'none'
+        run: |
+          {
+            echo "### Verified release source"
+            echo ""
+            echo "- tag: \`${RELEASE_TAG}\`"
+            echo "- commit: \`${{ steps.source.outputs.commit_sha }}\`"
+            echo "- target: \`${{ steps.identity.outputs.target }}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   build-contracts:
-    name: Build and test weaver_contracts from tag
+    name: Build and test weaver_contracts from verified commit
     needs: validate-request
     if: needs.validate-request.outputs.target == 'contracts'
     runs-on: ubuntu-latest
@@ -89,11 +104,15 @@ jobs:
       contents: read
 
     steps:
-      - name: Check out exact contract release tag
+      - name: Check out verified contract release commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ needs.validate-request.outputs.commit_sha }}
           fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify checked-out commit
+        run: test "$(git rev-parse HEAD)" = "${{ needs.validate-request.outputs.commit_sha }}"
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -105,7 +124,7 @@ jobs:
           python -m pip install build twine
           python -m pip install -e "contracts/python[dev]"
 
-      - name: Revalidate tag and package metadata on build checkout
+      - name: Revalidate tag and package metadata on verified source
         run: python scripts/validate_release_tag.py --tag "${RELEASE_TAG}" --target contracts
 
       - name: Test exact tagged contract source
@@ -152,7 +171,7 @@ jobs:
           attestations: true
 
   build-meta:
-    name: Build and validate weaver-stack from tag
+    name: Build and validate weaver-stack from verified commit
     needs: validate-request
     if: needs.validate-request.outputs.target == 'stack'
     runs-on: ubuntu-latest
@@ -160,11 +179,15 @@ jobs:
       contents: read
 
     steps:
-      - name: Check out exact meta-package release tag
+      - name: Check out verified meta-package release commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: ${{ needs.validate-request.outputs.commit_sha }}
           fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify checked-out commit
+        run: test "$(git rev-parse HEAD)" = "${{ needs.validate-request.outputs.commit_sha }}"
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -174,7 +197,7 @@ jobs:
       - name: Install release build tooling
         run: python -m pip install build twine pyyaml
 
-      - name: Revalidate tag and package metadata on build checkout
+      - name: Revalidate tag and package metadata on verified source
         run: python scripts/validate_release_tag.py --tag "${RELEASE_TAG}" --target stack
 
       - name: Validate compatibility-derived meta-package pins

--- a/contracts/python/tests/test_release_tag_validation.py
+++ b/contracts/python/tests/test_release_tag_validation.py
@@ -42,7 +42,16 @@ def test_classify_contract_and_stack_tag_families():
 
 @pytest.mark.parametrize(
     "tag",
-    ["0.8.0", "release-v0.8.0", "weaver-stack-0.7.0", "v0.8", "v0.8.0-rc1"],
+    [
+        "0.8.0",
+        "release-v0.8.0",
+        "weaver-stack-0.7.0",
+        "v0.8",
+        "v0.8.0-rc1",
+        "v0.8.0+build",
+        "v01.2.3",
+        "weaver-stack-v00.7.0",
+    ],
 )
 def test_rejects_unsupported_or_ambiguous_tag_families(tag: str):
     with pytest.raises(ReleaseValidationError, match="unsupported release tag family"):
@@ -69,3 +78,11 @@ def test_wrong_tag_family_cannot_publish_other_target(tmp_path: Path):
         validate_release("v0.8.0", target="stack", repo_root=repo)
     with pytest.raises(ReleaseValidationError, match="belongs to 'stack'"):
         validate_release("weaver-stack-v0.7.0", target="contracts", repo_root=repo)
+
+
+def test_live_contract_metadata_matches_intended_v080_identity():
+    assert validate_release("v0.8.0") == ("contracts", "0.8.0")
+
+
+def test_live_meta_metadata_matches_current_stack_v070_identity():
+    assert validate_release("weaver-stack-v0.7.0") == ("stack", "0.7.0")

--- a/contracts/python/tests/test_release_tag_validation.py
+++ b/contracts/python/tests/test_release_tag_validation.py
@@ -1,0 +1,71 @@
+"""Tests for the immutable release identity helper (#202)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from validate_release_tag import ReleaseValidationError, classify_tag, validate_release  # noqa: E402
+
+
+def _write_pyproject(path: Path, name: str, version: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f'[project]\nname = "{name}"\nversion = "{version}"\n',
+        encoding="utf-8",
+    )
+
+
+def _repo(tmp_path: Path, contracts: str = "0.8.0", stack: str = "0.7.0") -> Path:
+    _write_pyproject(
+        tmp_path / "contracts/python/pyproject.toml",
+        "weaver_contracts",
+        contracts,
+    )
+    _write_pyproject(
+        tmp_path / "packaging/weaver-stack/pyproject.toml",
+        "weaver-stack",
+        stack,
+    )
+    return tmp_path
+
+
+def test_classify_contract_and_stack_tag_families():
+    assert classify_tag("v0.8.0") == ("contracts", "0.8.0")
+    assert classify_tag("weaver-stack-v0.7.0") == ("stack", "0.7.0")
+
+
+@pytest.mark.parametrize(
+    "tag",
+    ["0.8.0", "release-v0.8.0", "weaver-stack-0.7.0", "v0.8", "v0.8.0-rc1"],
+)
+def test_rejects_unsupported_or_ambiguous_tag_families(tag: str):
+    with pytest.raises(ReleaseValidationError, match="unsupported release tag family"):
+        classify_tag(tag)
+
+
+def test_contract_tag_must_match_contract_package_version(tmp_path: Path):
+    repo = _repo(tmp_path, contracts="0.8.0")
+    assert validate_release("v0.8.0", repo_root=repo) == ("contracts", "0.8.0")
+    with pytest.raises(ReleaseValidationError, match="tag/package version mismatch"):
+        validate_release("v0.7.0", repo_root=repo)
+
+
+def test_stack_tag_must_match_meta_package_version(tmp_path: Path):
+    repo = _repo(tmp_path, stack="0.7.0")
+    assert validate_release("weaver-stack-v0.7.0", repo_root=repo) == ("stack", "0.7.0")
+    with pytest.raises(ReleaseValidationError, match="tag/package version mismatch"):
+        validate_release("weaver-stack-v0.8.0", repo_root=repo)
+
+
+def test_wrong_tag_family_cannot_publish_other_target(tmp_path: Path):
+    repo = _repo(tmp_path)
+    with pytest.raises(ReleaseValidationError, match="belongs to 'contracts'"):
+        validate_release("v0.8.0", target="stack", repo_root=repo)
+    with pytest.raises(ReleaseValidationError, match="belongs to 'stack'"):
+        validate_release("weaver-stack-v0.7.0", target="contracts", repo_root=repo)

--- a/scripts/.noop-placeholder
+++ b/scripts/.noop-placeholder
@@ -1,0 +1,1 @@
+placeholder

--- a/scripts/.noop-placeholder
+++ b/scripts/.noop-placeholder
@@ -1,1 +1,0 @@
-placeholder

--- a/scripts/validate_release_tag.py
+++ b/scripts/validate_release_tag.py
@@ -3,7 +3,8 @@
 
 This is build-time, stdlib-only tooling. It deliberately validates source
 metadata only; the publish workflow separately proves that the requested ref is
-an existing Git tag and checks out that exact tag before calling this script.
+an existing Git tag, resolves that tag to an exact commit SHA, and binds all
+build jobs to that verified SHA before calling this script again.
 """
 
 from __future__ import annotations
@@ -22,8 +23,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 CONTRACTS_PYPROJECT = Path("contracts/python/pyproject.toml")
 STACK_PYPROJECT = Path("packaging/weaver-stack/pyproject.toml")
 
-_CONTRACT_TAG = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
-_STACK_TAG = re.compile(r"^weaver-stack-v(?P<version>\d+\.\d+\.\d+)$")
+_SEMVER_CORE = r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+_CONTRACT_TAG = re.compile(rf"^v(?P<version>{_SEMVER_CORE})$")
+_STACK_TAG = re.compile(rf"^weaver-stack-v(?P<version>{_SEMVER_CORE})$")
 
 
 class ReleaseValidationError(ValueError):
@@ -56,7 +58,11 @@ def _project_version(path: Path) -> str:
     return value
 
 
-def validate_release(tag: str, target: str = "auto", repo_root: Path = REPO_ROOT) -> tuple[str, str]:
+def validate_release(
+    tag: str,
+    target: str = "auto",
+    repo_root: Path = REPO_ROOT,
+) -> tuple[str, str]:
     """Validate tag family and package metadata; return resolved target/version."""
     resolved_target, expected_version = classify_tag(tag)
     if target != "auto" and target != resolved_target:

--- a/scripts/validate_release_tag.py
+++ b/scripts/validate_release_tag.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Validate release-tag family and package version before publication.
+
+This is build-time, stdlib-only tooling. It deliberately validates source
+metadata only; the publish workflow separately proves that the requested ref is
+an existing Git tag and checks out that exact tag before calling this script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.11+ in release CI
+    import tomli as tomllib  # type: ignore[no-redef]
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACTS_PYPROJECT = Path("contracts/python/pyproject.toml")
+STACK_PYPROJECT = Path("packaging/weaver-stack/pyproject.toml")
+
+_CONTRACT_TAG = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
+_STACK_TAG = re.compile(r"^weaver-stack-v(?P<version>\d+\.\d+\.\d+)$")
+
+
+class ReleaseValidationError(ValueError):
+    """Raised when a release identity is unsafe or inconsistent."""
+
+
+def classify_tag(tag: str) -> tuple[str, str]:
+    """Return ``(target, version)`` for one supported immutable tag family."""
+    match = _CONTRACT_TAG.fullmatch(tag)
+    if match:
+        return "contracts", match.group("version")
+    match = _STACK_TAG.fullmatch(tag)
+    if match:
+        return "stack", match.group("version")
+    raise ReleaseValidationError(
+        "unsupported release tag family; expected vX.Y.Z for weaver_contracts "
+        "or weaver-stack-vX.Y.Z for the meta-package"
+    )
+
+
+def _project_version(path: Path) -> str:
+    with path.open("rb") as handle:
+        data = tomllib.load(handle)
+    try:
+        value = data["project"]["version"]
+    except (KeyError, TypeError) as exc:
+        raise ReleaseValidationError(f"missing [project].version in {path}") from exc
+    if not isinstance(value, str) or not value:
+        raise ReleaseValidationError(f"invalid [project].version in {path}: {value!r}")
+    return value
+
+
+def validate_release(tag: str, target: str = "auto", repo_root: Path = REPO_ROOT) -> tuple[str, str]:
+    """Validate tag family and package metadata; return resolved target/version."""
+    resolved_target, expected_version = classify_tag(tag)
+    if target != "auto" and target != resolved_target:
+        raise ReleaseValidationError(
+            f"tag {tag!r} belongs to {resolved_target!r}, not requested target {target!r}"
+        )
+
+    pyproject = (
+        repo_root / CONTRACTS_PYPROJECT
+        if resolved_target == "contracts"
+        else repo_root / STACK_PYPROJECT
+    )
+    actual_version = _project_version(pyproject)
+    if actual_version != expected_version:
+        raise ReleaseValidationError(
+            f"tag/package version mismatch for {resolved_target}: "
+            f"tag={expected_version} package={actual_version} ({pyproject})"
+        )
+    return resolved_target, expected_version
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="Existing release tag being validated")
+    parser.add_argument(
+        "--target",
+        choices=("auto", "contracts", "stack"),
+        default="auto",
+        help="Expected package target; auto derives it from the tag family",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        target, version = validate_release(args.tag, args.target)
+    except ReleaseValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"OK: {args.tag} -> target={target} version={version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Fixes the release-identity problems tracked in #202.

### Separate publication identities

- `vX.Y.Z` → `weaver_contracts` only
- `weaver-stack-vX.Y.Z` → `weaver-stack` only
- unrelated GitHub Release tag families run no Python-package build/publish path

### Immutable source binding

A new `validate-request` gate:

- checks out the exact requested tag with full tags available;
- proves `refs/tags/<tag>` exists;
- proves checked-out HEAD is the commit targeted by that tag;
- rejects unsupported manual-dispatch tag families;
- validates tag family + `[project].version` via new stdlib helper `scripts/validate_release_tag.py`.

Manual dispatch is now an **existing-tag recovery path**, not a way to publish `main`.

### Exact tagged-source gates before OIDC publication

For `weaver_contracts` the workflow now:

- re-validates tag ↔ package version on the build checkout;
- installs the tagged package's dev/conformance dependencies;
- runs the package tests and conformance suite;
- builds sdist/wheel;
- runs `twine check`;
- uploads a tag-specific artifact;
- grants PyPI OIDC publication only after those gates succeed.

For `weaver-stack` it similarly validates tag/version, runs the compatibility-derived meta-package validator, builds, runs `twine check`, and publishes only that tag-specific artifact.

### Regression coverage

`test_release_tag_validation.py` covers:

- valid contract/meta tag families;
- wrong/ambiguous tag families;
- tag/package version mismatches;
- cross-family publication attempts.

## Why this matters now

The repository source is already at contract version 0.8.0 while the latest GitHub release is v0.7.0. Current sibling compatibility/conformance work (#169/#170) needs an immutable current spec release before it can make honest current-version declarations.

## Follow-up after merge

1. Let CI prove this workflow/configuration change.
2. Cut the intended `v0.8.0` GitHub release/tag through the reviewed release process.
3. Confirm the release workflow builds/tests/publishes the exact tagged source.
4. Then unblock current sibling conformance publication (#170) and compatibility declarations (#169).

Draft until CI/review confirms the release workflow is safe.