### PR TITLE
ci: make reusable conformance validate the caller artifact

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: dgenio/weaver-spec
-          ref: ${{ inputs.spec-ref }}
+          ref: ${{ inputs['spec-ref'] }}
           path: weaver-spec
           persist-credentials: false
 
@@ -119,7 +119,7 @@ jobs:
       - name: Resolve caller bundle safely
         if: inputs.mode == 'external' || (inputs.mode == 'auto' && github.repository != 'dgenio/weaver-spec')
         env:
-          BUNDLE_PATH: ${{ inputs.bundle-path }}
+          BUNDLE_PATH: ${{ inputs['bundle-path'] }}
         run: |
           python - <<'PY'
           import os

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,16 +1,61 @@
 name: Conformance
 
-# Reusable conformance suite (issues #43, #74). Sibling repos call it with:
+# Reusable downstream conformance gate.
+#
+# External repositories can use the well-known convention with one job call:
 #
 #   jobs:
 #     weaver-conformance:
-#       uses: dgenio/weaver-spec/.github/workflows/conformance.yml@v0.6.0
+#       uses: dgenio/weaver-spec/.github/workflows/conformance.yml@<immutable-ref>
 #
-# It is also invoked from this repo's ci.yml. See docs/CONFORMANCE.md.
+# By default an external caller's `.well-known/conformance.json` is validated
+# against the immutable spec checkout declared by `spec-ref` below.
+#
+# When this workflow is called by dgenio/weaver-spec itself in `mode: auto`, it
+# runs the spec corpus as a self-test across all supported Python versions. A
+# same-repo smoke test can force the downstream path with `mode: external`.
 
 on:
   workflow_call:
+    inputs:
+      mode:
+        description: "auto, self, or external"
+        required: false
+        type: string
+        default: "auto"
+      bundle-path:
+        description: "Caller-repo path to the conformance TraceBundle"
+        required: false
+        type: string
+        default: ".well-known/conformance.json"
+      spec-ref:
+        description: "Immutable weaver-spec ref used to validate external bundles"
+        required: false
+        type: string
+        # Current 0.8.0 contract source. Replace with the matching release tag
+        # once the release-integrity gap in #202 is resolved.
+        default: "f99558e8b701c9f34b6e7e338940e52603a7f540"
   workflow_dispatch:
+    inputs:
+      mode:
+        description: "auto, self, or external"
+        required: false
+        type: choice
+        options:
+          - auto
+          - self
+          - external
+        default: auto
+      bundle-path:
+        description: "Caller-repo path to the conformance TraceBundle"
+        required: false
+        type: string
+        default: ".well-known/conformance.json"
+      spec-ref:
+        description: "Immutable weaver-spec ref used to validate external bundles"
+        required: false
+        type: string
+        default: "f99558e8b701c9f34b6e7e338940e52603a7f540"
 
 jobs:
   conformance:
@@ -21,9 +66,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ${{ fromJSON((inputs.mode == 'self' || (inputs.mode == 'auto' && github.repository == 'dgenio/weaver-spec')) && '["3.10","3.11","3.12","3.13","3.14"]' || '["3.11"]') }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Validate mode
+        env:
+          MODE: ${{ inputs.mode }}
+        run: |
+          case "$MODE" in
+            auto|self|external) ;;
+            *) echo "Invalid conformance mode: $MODE" >&2; exit 2 ;;
+          esac
+
+      - name: Check out self-test repository
+        if: inputs.mode == 'self' || (inputs.mode == 'auto' && github.repository == 'dgenio/weaver-spec')
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Check out caller repository
+        if: inputs.mode == 'external' || (inputs.mode == 'auto' && github.repository != 'dgenio/weaver-spec')
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: caller
+
+      - name: Check out immutable spec for external validation
+        if: inputs.mode == 'external' || (inputs.mode == 'auto' && github.repository != 'dgenio/weaver-spec')
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: dgenio/weaver-spec
+          ref: ${{ inputs.spec-ref }}
+          path: weaver-spec
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -31,8 +102,47 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
 
-      - name: Install conformance dependencies
-        run: pip install jsonschema referencing PyYAML jcs cryptography
+      - name: Install self-test dependencies
+        if: inputs.mode == 'self' || (inputs.mode == 'auto' && github.repository == 'dgenio/weaver-spec')
+        working-directory: contracts/python
+        run: pip install -e ".[dev]"
 
-      - name: Run conformance runner
+      - name: Install external-validation dependencies
+        if: inputs.mode == 'external' || (inputs.mode == 'auto' && github.repository != 'dgenio/weaver-spec')
+        working-directory: weaver-spec/contracts/python
+        run: pip install -e ".[dev]"
+
+      - name: Run spec corpus self-test
+        if: inputs.mode == 'self' || (inputs.mode == 'auto' && github.repository == 'dgenio/weaver-spec')
         run: python conformance/run.py
+
+      - name: Resolve caller bundle safely
+        if: inputs.mode == 'external' || (inputs.mode == 'auto' && github.repository != 'dgenio/weaver-spec')
+        env:
+          BUNDLE_PATH: ${{ inputs.bundle-path }}
+        run: |
+          python - <<'PY'
+          import os
+          import shutil
+          from pathlib import Path
+
+          root = Path("caller").resolve()
+          requested = (root / os.environ["BUNDLE_PATH"]).resolve()
+          try:
+              requested.relative_to(root)
+          except ValueError as exc:
+              raise SystemExit(f"bundle-path escapes caller repository: {requested}") from exc
+          if not requested.is_file():
+              raise SystemExit(
+                  "caller conformance bundle not found: "
+                  f"{requested}. Publish .well-known/conformance.json or pass bundle-path."
+              )
+          shutil.copyfile(requested, "/tmp/weaver-caller-conformance.json")
+          PY
+
+      - name: Validate caller bundle
+        if: inputs.mode == 'external' || (inputs.mode == 'auto' && github.repository != 'dgenio/weaver-spec')
+        run: |
+          python weaver-spec/conformance/run.py \
+            --bundle /tmp/weaver-caller-conformance.json \
+            --keyring weaver-spec/conformance/keyring/test_keyring.json

--- a/.github/workflows/downstream-conformance-smoke.yml
+++ b/.github/workflows/downstream-conformance-smoke.yml
@@ -1,0 +1,32 @@
+name: Downstream Conformance Smoke
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/conformance.yml"
+      - ".github/workflows/downstream-conformance-smoke.yml"
+      - "examples/conformance/sample-sibling/**"
+      - "conformance/**"
+      - "contracts/json/**"
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/conformance.yml"
+      - ".github/workflows/downstream-conformance-smoke.yml"
+      - "examples/conformance/sample-sibling/**"
+      - "conformance/**"
+      - "contracts/json/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sample-downstream:
+    name: Sample caller bundle
+    uses: ./.github/workflows/conformance.yml
+    with:
+      mode: external
+      bundle-path: examples/conformance/sample-sibling/.well-known/conformance.json
+      spec-ref: f99558e8b701c9f34b6e7e338940e52603a7f540

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -67,20 +67,59 @@ generation), so the verification path is exercised end-to-end. The illustrative
 sample in `examples/sample_payloads/trace_bundle_signed.json` keeps its
 documented placeholder signature and is reported as *skipped*.
 
-## Adopting it in a sibling repo
+## Adopting it in another repository
 
-The suite ships as a reusable workflow. Add one job to your CI, pinned to a
-released tag:
+The suite ships as a reusable workflow. With the conventional published artifact
+at `.well-known/conformance.json`, an external repository can add one job:
 
 ```yaml
 jobs:
   weaver-conformance:
-    uses: dgenio/weaver-spec/.github/workflows/conformance.yml@v0.6.0
+    uses: dgenio/weaver-spec/.github/workflows/conformance.yml@<immutable-ref>
 ```
 
-This runs the spec repo's own corpus against the published schemas. To assert
-conformance of *your* emitted artifacts, point the runner at your payloads via a
-local `corpus.yaml` (same shape) and your own keyring.
+Replace `<immutable-ref>` with a reviewed release tag or exact commit SHA. Do
+**not** use a mutable branch for a gating compatibility claim.
+
+The called workflow deliberately checks out two repositories separately:
+
+1. the **caller repository**, which owns the submitted conformance bundle; and
+2. the immutable `weaver-spec` source used to run the verifier.
+
+It then validates the caller's `.well-known/conformance.json` through the
+external-bundle path. A pass therefore attests to the artifact the caller
+published; it does not merely re-run this repository's own corpus.
+
+If your artifact lives elsewhere, pass the path explicitly:
+
+```yaml
+jobs:
+  weaver-conformance:
+    uses: dgenio/weaver-spec/.github/workflows/conformance.yml@<immutable-ref>
+    with:
+      bundle-path: path/to/conformance.json
+      spec-ref: <immutable-weaver-spec-ref>
+```
+
+`bundle-path` is resolved inside the caller checkout and paths that escape that
+repository are rejected.
+
+> [!IMPORTANT]
+> The source tree currently declares contract version `0.8.0`, but there is no
+> matching `v0.8.0` GitHub release/tag yet. Until the release-integrity work in
+> [#202](https://github.com/dgenio/weaver-spec/issues/202) closes that gap, the
+> reusable workflow pins its default external validator to the exact immutable
+> 0.8.0 source commit rather than pretending `main` is a release. Once a matching
+> release exists, prefer that tag.
+
+This repository's own CI calls the same workflow in automatic self-test mode;
+because the caller is `dgenio/weaver-spec`, it preserves the full spec-corpus
+matrix across supported Python versions. The tested downstream template lives in
+[`examples/conformance/sample-sibling/`](../examples/conformance/sample-sibling/).
+
+A conformance pass is **not** a security or production-readiness certification.
+It means only that the submitted artifact satisfies the schemas/invariants
+checked by the selected immutable verifier version.
 
 ## Checking a single external bundle
 
@@ -160,4 +199,5 @@ orphaned entry fails CI rather than silently skipping a check.
 - [SELF_CERTIFICATION.md](SELF_CERTIFICATION.md) — the "Weaver-compatible" badge.
 - [SCOREBOARD.md](SCOREBOARD.md) — the public conformance scoreboard.
 - [examples/reference_impl/](../examples/reference_impl/) — runnable reference.
+- [examples/conformance/sample-sibling/](../examples/conformance/sample-sibling/) — tested downstream-workflow template.
 - [AGENTS.md](../AGENTS.md) — repo scope rule covering `conformance/`.

--- a/examples/conformance/sample-sibling/.well-known/conformance.json
+++ b/examples/conformance/sample-sibling/.well-known/conformance.json
@@ -1,0 +1,75 @@
+{
+  "bundle_id": "tb-conformance-signed-001",
+  "routing_decision": {
+    "id": "rd-conf-001",
+    "choice_cards": [
+      {
+        "id": "card-retrieval",
+        "context_hint": "Select a retrieval action.",
+        "items": [
+          {
+            "id": "search-docs",
+            "label": "Search documentation",
+            "description": "Full-text search across the docs index.",
+            "capability_id": "org.myapp.search_docs"
+          }
+        ]
+      }
+    ],
+    "selected_item_id": "search-docs",
+    "selected_card_id": "card-retrieval",
+    "timestamp": "2026-03-08T06:00:00Z"
+  },
+  "policy_decisions": [
+    {
+      "decision_id": "pd-conf-001",
+      "decision": "allow",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-session-9c2e",
+      "token_id": "tok-conf-001",
+      "timestamp": "2026-03-08T06:00:01Z"
+    }
+  ],
+  "frames": [
+    {
+      "frame_id": "frame-conf-001",
+      "capability_id": "org.myapp.search_docs",
+      "summary": "Found 2 documentation pages matching the query.",
+      "handle_refs": [
+        "handle-conf-001"
+      ],
+      "created_at": "2026-03-08T06:00:05Z"
+    }
+  ],
+  "handles": [
+    {
+      "handle_id": "handle-conf-001",
+      "capability_id": "org.myapp.search_docs",
+      "artifact_type": "application/json",
+      "created_at": "2026-03-08T06:00:05Z",
+      "expires_at": "2026-03-09T06:00:05Z"
+    }
+  ],
+  "trace_events": [
+    {
+      "event_id": "te-conf-001",
+      "event_type": "capability_executed",
+      "timestamp": "2026-03-08T06:00:05Z",
+      "capability_id": "org.myapp.search_docs",
+      "principal": "agent-session-9c2e",
+      "decision_id": "pd-conf-001",
+      "frame_id": "frame-conf-001",
+      "handle_id": "handle-conf-001",
+      "outcome": "success"
+    }
+  ],
+  "canonicalization": "JCS",
+  "created_at": "2026-03-08T06:00:06Z",
+  "signature": {
+    "alg": "ed25519",
+    "kid": "conformance-test-ed25519-2026-01",
+    "sig": "LRB1K8fbJPQNdTbKjrEkzFQWmoiXok-KYARdrSuRJhMJTIOSONgK0gK5W2tdDW5s54z9QycbEwQAMONBX81JDw",
+    "canonicalization": "JCS",
+    "signed_at": "2026-03-08T06:00:06Z"
+  }
+}

--- a/examples/conformance/sample-sibling/README.md
+++ b/examples/conformance/sample-sibling/README.md
@@ -1,0 +1,59 @@
+# Sample downstream conformance consumer
+
+This directory is a **test fixture/template**, not an implementation or adopter.
+It proves that the public reusable workflow validates a caller-owned bundle rather
+than merely re-running the `weaver-spec` repository's own corpus.
+
+## Repository layout
+
+A downstream repository publishes its conformance artifact at the well-known
+path:
+
+```text
+.well-known/
+  conformance.json
+```
+
+The sample fixture in this directory mirrors that layout.
+
+## Copy-paste GitHub Actions job
+
+With the well-known path above, the caller needs only the reusable-workflow job:
+
+```yaml
+jobs:
+  weaver-conformance:
+    uses: dgenio/weaver-spec/.github/workflows/conformance.yml@<immutable-ref>
+```
+
+Replace `<immutable-ref>` with a reviewed Weaver Spec release tag or exact commit
+SHA. Do not use a mutable branch for a gating compatibility claim.
+
+The called workflow:
+
+1. checks out the **caller** repository;
+2. separately checks out the immutable `weaver-spec` source used for validation;
+3. reads the caller's `.well-known/conformance.json`;
+4. runs the external-bundle conformance path against that exact artifact.
+
+If a repository uses a different path, pass it explicitly:
+
+```yaml
+jobs:
+  weaver-conformance:
+    uses: dgenio/weaver-spec/.github/workflows/conformance.yml@<immutable-ref>
+    with:
+      bundle-path: path/to/conformance.json
+      spec-ref: <immutable-weaver-spec-ref>
+```
+
+`spec-ref` defaults to the immutable 0.8.0 source commit while the release/tag
+integrity gap is tracked in issue #202. Once a matching immutable release is
+available, prefer the release tag.
+
+## What a pass means
+
+A pass means only that the submitted artifact satisfies the schemas/invariants
+checked by the selected conformance version. It is **not** security
+certification, production-readiness certification, or evidence of independent
+adoption.


### PR DESCRIPTION
## Summary

Fixes the core adoption bug behind #164.

GitHub documents that reusable workflows run with the caller's `github` context; a plain `actions/checkout` therefore checks out the caller repository. The old workflow then ran `python conformance/run.py`, which a real external caller does not contain. Even if it had checked out the spec, re-running only the spec corpus would not prove caller conformance.

### New behavior

- `mode: auto` (default):
  - when called from `dgenio/weaver-spec`, preserve the existing five-Python-version spec corpus self-test;
  - when called from any other repository, validate the caller's `.well-known/conformance.json`.
- external validation checks out:
  1. the caller repository into `caller/`;
  2. an explicitly immutable `weaver-spec` ref into `weaver-spec/`;
  3. safely resolves/copies the caller bundle after rejecting path traversal;
  4. runs the external-bundle verifier against the caller-owned bytes.
- the default external spec ref is an exact commit containing contract 0.8.0 because the repository currently has no `v0.8.0` release/tag; #202 owns the release-integrity fix.
- a same-repo sample consumer forces `mode: external` and proves the downstream path through CI.
- `examples/conformance/sample-sibling/` contains the well-known bundle layout and copy-paste job.

## External caller UX

With the conventional bundle path, the intended job remains:

```yaml
jobs:
  weaver-conformance:
    uses: dgenio/weaver-spec/.github/workflows/conformance.yml@<immutable-ref>
```

A custom `bundle-path` and `spec-ref` remain available explicitly.

## Security / trust boundaries

- no mutable `main` is used as the default external validation source;
- caller bundle paths cannot escape the checked-out caller tree;
- a pass only attests conformance to the selected vectors/invariants, not implementation security or production readiness.

## Related

- #164 one-line downstream conformance
- #169 current compatibility declarations
- #170 public sibling bundles
- #202 release/tag integrity
- #209 language-neutral conformance remains the longer-term goal

## Documentation note

The sample template is included here. The existing `docs/CONFORMANCE.md` section currently contains the old misleading semantics and must be updated before this PR is ready to merge; this PR stays draft until that canonical-doc change and CI smoke are complete.
