### PR TITLE
docs: add a CI-tested first-success path

### DIFF
--- a/.github/workflows/first-success.yml
+++ b/.github/workflows/first-success.yml
@@ -1,0 +1,63 @@
+name: First Success Walkthrough
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "docs/GETTING_STARTED.md"
+      - "examples/reference_impl/**"
+      - "conformance/**"
+      - "contracts/**"
+      - ".github/workflows/first-success.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "docs/GETTING_STARTED.md"
+      - "examples/reference_impl/**"
+      - "conformance/**"
+      - "contracts/**"
+      - ".github/workflows/first-success.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  walkthrough:
+    name: Run documented pass/fail loop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+      - name: Install documented dependencies
+        run: pip install -e "contracts/python[dev]"
+      - name: Run reference implementation
+        run: python examples/reference_impl/reference_impl.py
+      - name: Validate signed reference payload
+        run: |
+          python conformance/run.py \
+            --bundle conformance/fixtures/trace_bundle_signed_valid.json
+      - name: Tamper with model-visible result
+        run: |
+          cp conformance/fixtures/trace_bundle_signed_valid.json \
+            /tmp/weaver-first-bundle.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("/tmp/weaver-first-bundle.json")
+          bundle = json.loads(path.read_text())
+          bundle["frames"][0]["summary"] = "Tampered after signing"
+          path.write_text(json.dumps(bundle, indent=2) + "\n")
+          PY
+      - name: Prove tampered payload is rejected
+        run: |
+          if python conformance/run.py --bundle /tmp/weaver-first-bundle.json; then
+            echo "ERROR: tampered payload unexpectedly passed conformance" >&2
+            exit 1
+          fi
+          echo "Expected failure observed: tampered signed payload was rejected."

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -92,5 +92,3 @@ visible instead of relying on prose claims.
 - [Conformance](CONFORMANCE.md) — corpus, invariants, signatures, and downstream
   CI use.
 - [Contract Reference](CONTRACT_REFERENCE.md) — current fields and tiers.
-- [Adoption-stage guardrails](ADOPTION_GUARDRAILS.md) — evidence gates and the
-  pre-1.0 scope reset (available on the adoption-guardrails PR until merged).

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,96 @@
+# First success
+
+This is the shortest supported path from clone to a real Weaver contract check.
+It uses only repository fixtures and the reference conformance runner; no model,
+API key, sibling runtime, or network service is required after dependencies are
+installed.
+
+> [!NOTE]
+> This walkthrough demonstrates the **current reference-stack contracts**. The
+> pre-1.0 adoption reset is revalidating which concepts should remain stable or
+> become optional profiles. Passing this walkthrough is not evidence that the
+> full current contract set will become an industry standard.
+
+## Prerequisites
+
+- Python 3.10 or newer
+- Git
+
+## 1. Clone and install validation dependencies
+
+```bash
+git clone https://github.com/dgenio/weaver-spec.git
+cd weaver-spec
+python -m venv .venv
+. .venv/bin/activate
+pip install -e "contracts/python[dev]"
+```
+
+On Windows PowerShell, activate the virtual environment with:
+
+```powershell
+.venv\Scripts\Activate.ps1
+```
+
+## 2. Run the reference implementation
+
+```bash
+python examples/reference_impl/reference_impl.py
+```
+
+This constructs the current Core artifacts through the reference happy path and
+runs the assertions kept green by CI.
+
+## 3. Validate one real external-style payload
+
+The repository contains a signed `TraceBundle` fixture whose public test key is
+part of the conformance keyring:
+
+```bash
+python conformance/run.py \
+  --bundle conformance/fixtures/trace_bundle_signed_valid.json
+```
+
+Expected result: the command exits successfully after schema, invariant, and
+signature checks pass.
+
+## 4. Tamper with the payload and see the check fail
+
+Copy the signed payload and alter the model-visible result after it was signed:
+
+```bash
+cp conformance/fixtures/trace_bundle_signed_valid.json /tmp/weaver-first-bundle.json
+python - <<'PY'
+import json
+from pathlib import Path
+
+path = Path("/tmp/weaver-first-bundle.json")
+bundle = json.loads(path.read_text())
+bundle["frames"][0]["summary"] = "Tampered after signing"
+path.write_text(json.dumps(bundle, indent=2) + "\n")
+PY
+```
+
+Now validate the modified payload:
+
+```bash
+python conformance/run.py --bundle /tmp/weaver-first-bundle.json
+```
+
+Expected result: the command exits non-zero because the signed artifact no longer
+matches its verified contents.
+
+That pass/fail loop is the essential contract-development workflow: use a
+versioned payload, run machine-checkable validation, and make incompatibility
+visible instead of relying on prose claims.
+
+## Next steps
+
+- [Quickstart](QUICKSTART.md) — Python and JavaScript/TypeScript integration
+  patterns.
+- [Adoption Guide](ADOPTION_GUIDE.md) — current reference-stack adoption modes.
+- [Conformance](CONFORMANCE.md) — corpus, invariants, signatures, and downstream
+  CI use.
+- [Contract Reference](CONTRACT_REFERENCE.md) — current fields and tiers.
+- [Adoption-stage guardrails](ADOPTION_GUARDRAILS.md) — evidence gates and the
+  pre-1.0 scope reset (available on the adoption-guardrails PR until merged).


### PR DESCRIPTION
## Summary

Implements the core of #127 with a short, tested evaluator path rather than another broad guide.

### User path

1. clone + install the existing dev/conformance dependencies;
2. run the existing reference implementation;
3. validate the real signed `TraceBundle` fixture;
4. tamper with the model-visible result;
5. run the same validator and observe the expected non-zero failure.

No API key, model, sibling runtime, or live schema host is required after dependency installation.

### CI guarantee

A dedicated `First Success Walkthrough` workflow executes the documented pass/fail loop. CI fails if:

- the reference implementation breaks;
- the signed fixture stops passing;
- the tampered payload unexpectedly passes.

This keeps the quickest evaluator path aligned with the actual implementation.

## Adoption-reset alignment

The doc explicitly says this demonstrates the **current reference-stack contracts**, not that all current contracts will become a stable industry standard. It therefore improves evaluation friction without pre-judging #205/#210.

## Follow-up link integration

The new doc is independently mergeable. README/other front-door links should be added after the adoption-guardrails README PR #212 is resolved, to avoid creating overlapping README replacements on two branches.

## Related

- #127 first-run experience
- #212 adoption guardrails
- #205 ownership audit
- #210 external demand validation
