### PR TITLE
ci: bind PyPI publishing to exact tagged package identity

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,106 +4,233 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing immutable release tag to retry (vX.Y.Z or weaver-stack-vX.Y.Z)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
 
 jobs:
-  build:
-    name: Build distribution
+  release-plan:
+    name: Verify release identity
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
+    outputs:
+      tag: ${{ steps.target.outputs.tag }}
+      target: ${{ steps.target.outputs.target }}
+      version: ${{ steps.target.outputs.version }}
+      distribution: ${{ steps.target.outputs.distribution }}
+      project_dir: ${{ steps.target.outputs.project_dir }}
+      commit_sha: ${{ steps.identity.outputs.commit_sha }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Resolve requested tag
+        id: release
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          DISPATCH_TAG: ${{ inputs.tag }}
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag="$RELEASE_TAG"
+          else
+            tag="$DISPATCH_TAG"
+          fi
+          if [ -z "$tag" ]; then
+            echo "ERROR: release tag is required" >&2
+            exit 2
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Check out exact release tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ steps.release.outputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
-      - name: Install build
-        run: pip install build
+      - name: Prove HEAD is the requested immutable tag
+        id: identity
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          head_sha="$(git rev-parse HEAD)"
+          tag_sha="$(git rev-list -n 1 "$TAG")"
+          if [ "$head_sha" != "$tag_sha" ]; then
+            echo "ERROR: checkout HEAD $head_sha does not match tag $TAG -> $tag_sha" >&2
+            exit 1
+          fi
+          echo "Validated release source: $TAG -> $head_sha"
+          echo "commit_sha=$head_sha" >> "$GITHUB_OUTPUT"
 
-      - name: Build package
+      - name: Validate tag family and package version
+        id: target
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          python scripts/validate_release_target.py \
+            --tag "$TAG" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Release plan summary
+        env:
+          TAG: ${{ steps.target.outputs.tag }}
+          TARGET: ${{ steps.target.outputs.target }}
+          VERSION: ${{ steps.target.outputs.version }}
+          DIST: ${{ steps.target.outputs.distribution }}
+          SHA: ${{ steps.identity.outputs.commit_sha }}
+        run: |
+          {
+            echo "### Verified release plan"
+            echo ""
+            echo "- tag: \`$TAG\`"
+            echo "- commit: \`$SHA\`"
+            echo "- target: \`$TARGET\`"
+            echo "- distribution: \`$DIST\`"
+            echo "- version: \`$VERSION\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  build-contracts:
+    name: Build and verify weaver_contracts
+    if: needs.release-plan.outputs.target == 'contracts'
+    needs: release-plan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out verified release tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.release-plan.outputs.tag }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Verify checked-out commit
+        env:
+          EXPECTED_SHA: ${{ needs.release-plan.outputs.commit_sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+
+      - name: Install build, metadata, and contract test dependencies
+        run: |
+          pip install build twine
+          pip install -e "./contracts/python[dev]"
+
+      - name: Run package tests on tagged source
+        working-directory: contracts/python
+        run: pytest
+
+      - name: Run conformance suite on tagged source
+        run: python conformance/run.py
+
+      - name: Build distribution
         working-directory: contracts/python
         run: python -m build
 
-      - name: Upload dist artifact
+      - name: Validate distribution metadata
+        run: python -m twine check contracts/python/dist/*
+
+      - name: Upload verified contract distribution
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: dist
+          name: dist-contracts-${{ needs.release-plan.outputs.version }}
           path: contracts/python/dist/
+          if-no-files-found: error
 
-  publish:
-    name: Publish to PyPI
-    needs: build
+  publish-contracts:
+    name: Publish weaver_contracts to PyPI
+    if: needs.release-plan.outputs.target == 'contracts'
+    needs: [release-plan, build-contracts]
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/project/weaver_contracts/
+      url: https://pypi.org/project/weaver-contracts/
     permissions:
       id-token: write
       attestations: write
-
     steps:
-      - name: Download dist artifact
+      - name: Download verified contract distribution
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: dist
+          name: dist-contracts-${{ needs.release-plan.outputs.version }}
           path: dist/
 
-      - name: Publish to PyPI
+      - name: Publish weaver_contracts
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           attestations: true
 
   build-meta:
-    name: Build meta-package distribution
+    name: Build and verify weaver-stack
+    if: needs.release-plan.outputs.target == 'meta'
+    needs: release-plan
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'release' && startsWith(github.event.release.tag_name, 'weaver-stack-v') }}
     permissions:
       contents: read
-
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Check out verified release tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.release-plan.outputs.tag }}
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
-      - name: Install build
-        run: pip install build
+      - name: Verify checked-out commit
+        env:
+          EXPECTED_SHA: ${{ needs.release-plan.outputs.commit_sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
 
-      - name: Build the weaver-stack meta-package
+      - name: Install build and meta-package test dependencies
+        run: pip install build twine pytest PyYAML
+
+      - name: Validate live compatibility manifest against meta-package
+        run: pytest contracts/python/tests/test_meta_package.py
+
+      - name: Build meta-package distribution
         working-directory: packaging/weaver-stack
         run: python -m build
 
-      - name: Upload meta-package dist artifact
+      - name: Validate meta-package distribution metadata
+        run: python -m twine check packaging/weaver-stack/dist/*
+
+      - name: Upload verified meta-package distribution
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: dist-meta
+          name: dist-meta-${{ needs.release-plan.outputs.version }}
           path: packaging/weaver-stack/dist/
+          if-no-files-found: error
 
   publish-meta:
-    name: Publish meta-package to PyPI
-    needs: build-meta
+    name: Publish weaver-stack to PyPI
+    if: needs.release-plan.outputs.target == 'meta'
+    needs: [release-plan, build-meta]
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'release' && startsWith(github.event.release.tag_name, 'weaver-stack-v') }}
     environment:
       name: pypi
       url: https://pypi.org/project/weaver-stack/
     permissions:
       id-token: write
       attestations: write
-
     steps:
-      - name: Download meta-package dist artifact
+      - name: Download verified meta-package distribution
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: dist-meta
+          name: dist-meta-${{ needs.release-plan.outputs.version }}
           path: dist/
 
-      - name: Publish weaver-stack to PyPI
+      - name: Publish weaver-stack
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           attestations: true

--- a/.github/workflows/release-integrity.yml
+++ b/.github/workflows/release-integrity.yml
@@ -1,0 +1,57 @@
+name: Release Integrity
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "contracts/python/pyproject.toml"
+      - "packaging/weaver-stack/pyproject.toml"
+      - "scripts/validate_release_target.py"
+      - "tests/test_release_target.py"
+      - ".github/workflows/publish.yml"
+      - ".github/workflows/release-integrity.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "contracts/python/pyproject.toml"
+      - "packaging/weaver-stack/pyproject.toml"
+      - "scripts/validate_release_target.py"
+      - "tests/test_release_target.py"
+      - ".github/workflows/publish.yml"
+      - ".github/workflows/release-integrity.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate release tag/package identity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+      - name: Run release-target unit tests
+        run: python tests/test_release_target.py
+      - name: Dry-run current contract package identity
+        run: python scripts/validate_release_target.py --tag v0.8.0
+      - name: Dry-run current meta-package identity
+        run: python scripts/validate_release_target.py --tag weaver-stack-v0.7.0
+      - name: Prove wrong tag family/version is rejected
+        run: |
+          if python scripts/validate_release_target.py --tag v0.7.0; then
+            echo "ERROR: mismatched contract tag unexpectedly passed" >&2
+            exit 1
+          fi
+          if python scripts/validate_release_target.py --tag weaver-stack-v0.8.0; then
+            echo "ERROR: mismatched meta-package tag unexpectedly passed" >&2
+            exit 1
+          fi
+          if python scripts/validate_release_target.py --tag release-v0.8.0; then
+            echo "ERROR: unsupported tag family unexpectedly passed" >&2
+            exit 1
+          fi

--- a/scripts/validate_release_target.py
+++ b/scripts/validate_release_target.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Validate release tag family, target package, and version identity.
+
+A release tag selects exactly one publishable artifact:
+
+* ``vX.Y.Z`` -> ``weaver_contracts`` under ``contracts/python``
+* ``weaver-stack-vX.Y.Z`` -> ``weaver-stack`` under ``packaging/weaver-stack``
+
+The tag version MUST exactly match that target package's ``project.version``.
+This script is stdlib-only and is intended to run after checking out the exact
+release tag. It can write stable key/value outputs for GitHub Actions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONTRACTS_PROJECT = REPO_ROOT / "contracts" / "python" / "pyproject.toml"
+META_PROJECT = REPO_ROOT / "packaging" / "weaver-stack" / "pyproject.toml"
+
+_CONTRACT_TAG = re.compile(r"^v(?P<version>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$")
+_META_TAG = re.compile(
+    r"^weaver-stack-v(?P<version>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$"
+)
+
+
+@dataclass(frozen=True)
+class ReleaseTarget:
+    tag: str
+    target: str
+    version: str
+    project_path: Path
+    distribution: str
+
+
+def parse_tag(tag: str) -> ReleaseTarget:
+    """Return the single package selected by *tag* or raise ``ValueError``."""
+    if match := _CONTRACT_TAG.fullmatch(tag):
+        version = ".".join(
+            (match.group("version"), match.group("minor"), match.group("patch"))
+        )
+        return ReleaseTarget(
+            tag=tag,
+            target="contracts",
+            version=version,
+            project_path=CONTRACTS_PROJECT,
+            distribution="weaver_contracts",
+        )
+    if match := _META_TAG.fullmatch(tag):
+        version = ".".join(
+            (match.group("version"), match.group("minor"), match.group("patch"))
+        )
+        return ReleaseTarget(
+            tag=tag,
+            target="meta",
+            version=version,
+            project_path=META_PROJECT,
+            distribution="weaver-stack",
+        )
+    raise ValueError(
+        "unsupported release tag. Expected vX.Y.Z for weaver_contracts or "
+        "weaver-stack-vX.Y.Z for the meta-package"
+    )
+
+
+def project_version(project_path: Path) -> str:
+    """Read ``project.version`` from a package pyproject."""
+    data = tomllib.loads(project_path.read_text(encoding="utf-8"))
+    project = data.get("project")
+    if not isinstance(project, dict):
+        raise ValueError(f"missing [project] table: {project_path}")
+    version = project.get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError(f"missing project.version: {project_path}")
+    return version
+
+
+def validate(tag: str) -> ReleaseTarget:
+    """Resolve *tag* and prove its version matches the selected package."""
+    target = parse_tag(tag)
+    actual = project_version(target.project_path)
+    if actual != target.version:
+        raise ValueError(
+            f"release tag {tag!r} selects {target.distribution} {target.version}, "
+            f"but {target.project_path.relative_to(REPO_ROOT)} declares {actual}"
+        )
+    return target
+
+
+def _write_outputs(path: Path, target: ReleaseTarget) -> None:
+    lines = (
+        f"tag={target.tag}\n",
+        f"target={target.target}\n",
+        f"version={target.version}\n",
+        f"distribution={target.distribution}\n",
+        f"project_dir={target.project_path.parent.relative_to(REPO_ROOT).as_posix()}\n",
+    )
+    with path.open("a", encoding="utf-8", newline="\n") as handle:
+        handle.writelines(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="Existing release tag being built")
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        help="Append target metadata in GitHub Actions output format",
+    )
+    args = parser.parse_args()
+
+    try:
+        target = validate(args.tag)
+        if args.github_output is not None:
+            _write_outputs(args.github_output, target)
+    except (OSError, ValueError, tomllib.TOMLDecodeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"OK: {target.tag} -> {target.distribution} {target.version} "
+        f"({target.project_path.parent.relative_to(REPO_ROOT)})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_release_target.py
+++ b/tests/test_release_target.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Tests for scripts/validate_release_target.py."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import validate_release_target as release_target  # noqa: E402
+
+
+class ReleaseTargetTests(unittest.TestCase):
+    def test_contract_tag_selects_contract_package(self) -> None:
+        target = release_target.parse_tag("v0.8.0")
+        self.assertEqual(target.target, "contracts")
+        self.assertEqual(target.version, "0.8.0")
+        self.assertEqual(target.distribution, "weaver_contracts")
+
+    def test_meta_tag_selects_meta_package(self) -> None:
+        target = release_target.parse_tag("weaver-stack-v0.7.0")
+        self.assertEqual(target.target, "meta")
+        self.assertEqual(target.version, "0.7.0")
+        self.assertEqual(target.distribution, "weaver-stack")
+
+    def test_rejects_unsupported_or_ambiguous_tags(self) -> None:
+        bad_tags = (
+            "0.8.0",
+            "release-v0.8.0",
+            "weaver-v0.8.0",
+            "weaver-stack-0.7.0",
+            "weaver-stack-v0.7",
+            "v0.8",
+            "v01.2.3",
+            "v0.8.0-rc1",
+            "v0.8.0+build",
+        )
+        for tag in bad_tags:
+            with self.subTest(tag=tag):
+                with self.assertRaises(ValueError):
+                    release_target.parse_tag(tag)
+
+    def test_current_contract_metadata_matches_v080(self) -> None:
+        target = release_target.validate("v0.8.0")
+        self.assertEqual(target.version, "0.8.0")
+
+    def test_current_meta_metadata_matches_stack_v070(self) -> None:
+        target = release_target.validate("weaver-stack-v0.7.0")
+        self.assertEqual(target.version, "0.7.0")
+
+    def test_version_mismatch_is_rejected(self) -> None:
+        original = release_target.CONTRACTS_PROJECT
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                project = Path(temp_dir) / "pyproject.toml"
+                project.write_text(
+                    '[project]\nname = "weaver_contracts"\nversion = "9.9.9"\n',
+                    encoding="utf-8",
+                )
+                release_target.CONTRACTS_PROJECT = project
+                with self.assertRaisesRegex(ValueError, "declares 9.9.9"):
+                    release_target.validate("v0.8.0")
+        finally:
+            release_target.CONTRACTS_PROJECT = original
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #202 by making release identity fail-closed and package-specific.

### Release identity

- only two exact tag families are valid:
  - `vX.Y.Z` -> `weaver_contracts`
  - `weaver-stack-vX.Y.Z` -> `weaver-stack`
- tag version must exactly match the selected package's `project.version`;
- manual recovery requires an explicit **existing tag**;
- release planning checks out that exact tag with full tag history and proves `HEAD` equals the tag's commit;
- every downstream build re-checks the verified commit SHA.

### Package isolation

- a `vX.Y.Z` release can only run contract build/publish jobs;
- a `weaver-stack-vX.Y.Z` release can only run meta-package build/publish jobs;
- contract and meta artifacts have distinct artifact names;
- no package is built from implicit default-branch HEAD.

### Tagged-source verification

Contract releases run, on the exact tag:

- package tests;
- the conformance suite;
- package build;
- `twine check`;
- then OIDC Trusted Publishing + attestations.

Meta releases run:

- live compatibility/meta-package consistency tests;
- build;
- `twine check`;
- then the isolated OIDC publish path.

### Continuous dry-run coverage

`Release Integrity` CI verifies:

- current `v0.8.0` contract metadata identity;
- current `weaver-stack-v0.7.0` meta metadata identity;
- wrong package/version combinations fail;
- unsupported tag families fail.

This tests package/tag identity without creating releases or invoking OIDC.

## Existing release gap discovered

The source/package metadata is currently `0.8.0`, while the latest GitHub Release is `v0.7.0`; there is no existing `v0.8.0` tag/release. This PR intentionally **does not manufacture a release**. After this integrity path is merged and the intended release commit is reviewed, a `v0.8.0` release can be created through the hardened path.

That gap is also why #220 currently pins external 0.8.0 conformance to an exact commit SHA instead of a nonexistent tag.

## Non-goals

- Changing package versions.
- Creating the missing v0.8.0 release automatically.
- Replacing Trusted Publishing.
- Combining the contract and meta-package release identities.

## Related

- #202 release integrity
- #169 compatibility evidence
- #220 real downstream conformance
